### PR TITLE
Add array to style propTypes in Icon.

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -4,6 +4,7 @@ const Radium = require('radium');
 const Icon = React.createClass({
   propTypes: {
     size: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
+    style: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object]),
     type: React.PropTypes.string
   },
 


### PR DESCRIPTION
Allows for style props to be passed as a single object or an array of objects.