### PR TITLE
Add bool to PropTypes for selected in Select.js

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -14,7 +14,7 @@ const Select = React.createClass({
     optionStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     placeholderText: React.PropTypes.string,
     scrimStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
-    selected: React.PropTypes.object,
+    selected: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.bool]),
     selectedStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     valid: React.PropTypes.bool
   },


### PR DESCRIPTION
Allows for style props to be passed as a single object or an array of objects.