### PR TITLE
RangeSelector fixes

### DIFF
--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -20926,7 +20926,7 @@
 	        display: this.state.showPresets ? 'block' : 'none'
 	      },
 	      range: {
-	        padding: '30px 0',
+	        padding: '44px 0 30px',
 	        margin: '0 10px',
 	        visibility: this.state.showPresets ? 'hidden' : 'visible'
 	      },
@@ -20943,6 +20943,7 @@
 	        position: 'absolute',
 	        top: '50%',
 	        left: this.state.lowerPixels,
+	        marginTop: '6px',
 	        transform: 'translate(-50%, -50%)',
 	        WebkitTransform: 'translate(-50%, -50%)',
 	        cursor: 'pointer'
@@ -20956,6 +20957,7 @@
 	        position: 'absolute',
 	        top: '50%',
 	        left: this.state.upperPixels,
+	        marginTop: '6px',
 	        transform: 'translate(-50%, -50%)',
 	        WebkitTransform: 'translate(-50%, -50%)',
 	        cursor: 'pointer',
@@ -20968,6 +20970,7 @@
 	        background: this.props.selectedColor,
 	        height: '3px',
 	        top: '50%',
+	        marginTop: '6px',
 	        transform: 'translateY(-50%)',
 	        WebkitTransform: 'translateY(-50%)'
 	      },
@@ -20978,7 +20981,7 @@
 	        transform: 'translateX(-50%)',
 	        WebkitTransform: 'translateX(-50%)',
 	        textAlign: 'center',
-	        marginTop: '5px',
+	        marginTop: '2px',
 	        display: 'block'
 	      },
 	      upperToggleLabel: {
@@ -20988,7 +20991,7 @@
 	        transform: 'translateX(-50%)',
 	        WebkitTransform: 'translateX(-50%)',
 	        textAlign: 'center',
-	        marginBottom: '5px',
+	        marginBottom: '2px',
 	        display: 'block'
 	      },
 	      preset: {
@@ -23352,6 +23355,7 @@
 
 	  propTypes: {
 	    size: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
+	    style: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object]),
 	    type: React.PropTypes.string
 	  },
 

--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -20939,7 +20939,7 @@
 	        position: 'absolute',
 	        top: '50%',
 	        left: this.state.lowerPixels,
-	        marginTop: '6px',
+	        margin: '6px 0 0 10px',
 	        transform: 'translate(-50%, -50%)',
 	        WebkitTransform: 'translate(-50%, -50%)',
 	        cursor: 'pointer'
@@ -20953,7 +20953,7 @@
 	        position: 'absolute',
 	        top: '50%',
 	        left: this.state.upperPixels,
-	        marginTop: '6px',
+	        margin: '6px 0 0 10px',
 	        transform: 'translate(-50%, -50%)',
 	        WebkitTransform: 'translate(-50%, -50%)',
 	        cursor: 'pointer',
@@ -20978,7 +20978,9 @@
 	        WebkitTransform: 'translateX(-50%)',
 	        textAlign: 'center',
 	        marginTop: '2px',
-	        display: 'block'
+	        display: 'block',
+	        cursor: 'pointer',
+	        minWidth: '20px'
 	      },
 	      upperToggleLabel: {
 	        position: 'absolute',
@@ -20988,7 +20990,9 @@
 	        WebkitTransform: 'translateX(-50%)',
 	        textAlign: 'center',
 	        marginBottom: '2px',
-	        display: 'block'
+	        display: 'block',
+	        cursor: 'pointer',
+	        minWidth: '20px'
 	      },
 	      preset: {
 	        display: 'inline-block',
@@ -21002,7 +21006,7 @@
 	      showPresets: {
 	        position: 'absolute',
 	        top: 0,
-	        right: '10px',
+	        right: 0,
 	        cursor: 'pointer',
 	        color: this.props.selectedColor
 	      },

--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -20759,9 +20759,7 @@
 	    defaultUpperValue: React.PropTypes.number,
 	    formatter: React.PropTypes.func,
 	    interval: React.PropTypes.number,
-	    onLowerDrag: React.PropTypes.func,
 	    onLowerDragStop: React.PropTypes.func,
-	    onUpperDrag: React.PropTypes.func,
 	    onUpperDragStop: React.PropTypes.func,
 	    presets: React.PropTypes.array,
 	    range: React.PropTypes.number,
@@ -20776,9 +20774,7 @@
 	      formatter: function formatter(value) {
 	        return value;
 	      },
-	      onLowerDrag: function onLowerDrag() {},
 	      onLowerDragStop: function onLowerDragStop() {},
-	      onUpperDrag: function onUpperDrag() {},
 	      onUpperDragStop: function onUpperDragStop() {},
 	      presets: [],
 	      range: 100,

--- a/dist/components/RangeSelector.js
+++ b/dist/components/RangeSelector.js
@@ -194,7 +194,7 @@ var RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.lowerPixels,
-        marginTop: '6px',
+        margin: '6px 0 0 10px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer'
@@ -208,7 +208,7 @@ var RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.upperPixels,
-        marginTop: '6px',
+        margin: '6px 0 0 10px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer',
@@ -233,7 +233,9 @@ var RangeSelector = React.createClass({
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
         marginTop: '2px',
-        display: 'block'
+        display: 'block',
+        cursor: 'pointer',
+        minWidth: '20px'
       },
       upperToggleLabel: {
         position: 'absolute',
@@ -243,7 +245,9 @@ var RangeSelector = React.createClass({
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
         marginBottom: '2px',
-        display: 'block'
+        display: 'block',
+        cursor: 'pointer',
+        minWidth: '20px'
       },
       preset: {
         display: 'inline-block',
@@ -257,7 +261,7 @@ var RangeSelector = React.createClass({
       showPresets: {
         position: 'absolute',
         top: 0,
-        right: '10px',
+        right: 0,
         cursor: 'pointer',
         color: this.props.selectedColor
       },

--- a/dist/components/RangeSelector.js
+++ b/dist/components/RangeSelector.js
@@ -14,9 +14,7 @@ var RangeSelector = React.createClass({
     defaultUpperValue: React.PropTypes.number,
     formatter: React.PropTypes.func,
     interval: React.PropTypes.number,
-    onLowerDrag: React.PropTypes.func,
     onLowerDragStop: React.PropTypes.func,
-    onUpperDrag: React.PropTypes.func,
     onUpperDragStop: React.PropTypes.func,
     presets: React.PropTypes.array,
     range: React.PropTypes.number,
@@ -31,9 +29,7 @@ var RangeSelector = React.createClass({
       formatter: function formatter(value) {
         return value;
       },
-      onLowerDrag: function onLowerDrag() {},
       onLowerDragStop: function onLowerDragStop() {},
-      onUpperDrag: function onUpperDrag() {},
       onUpperDragStop: function onUpperDragStop() {},
       presets: [],
       range: 100,

--- a/dist/components/RangeSelector.js
+++ b/dist/components/RangeSelector.js
@@ -181,7 +181,7 @@ var RangeSelector = React.createClass({
         display: this.state.showPresets ? 'block' : 'none'
       },
       range: {
-        padding: '30px 0',
+        padding: '44px 0 30px',
         margin: '0 10px',
         visibility: this.state.showPresets ? 'hidden' : 'visible'
       },
@@ -198,6 +198,7 @@ var RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.lowerPixels,
+        marginTop: '6px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer'
@@ -211,6 +212,7 @@ var RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.upperPixels,
+        marginTop: '6px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer',
@@ -223,6 +225,7 @@ var RangeSelector = React.createClass({
         background: this.props.selectedColor,
         height: '3px',
         top: '50%',
+        marginTop: '6px',
         transform: 'translateY(-50%)',
         WebkitTransform: 'translateY(-50%)'
       },
@@ -233,7 +236,7 @@ var RangeSelector = React.createClass({
         transform: 'translateX(-50%)',
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
-        marginTop: '5px',
+        marginTop: '2px',
         display: 'block'
       },
       upperToggleLabel: {
@@ -243,7 +246,7 @@ var RangeSelector = React.createClass({
         transform: 'translateX(-50%)',
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
-        marginBottom: '5px',
+        marginBottom: '2px',
         display: 'block'
       },
       preset: {

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -175,7 +175,7 @@ const RangeSelector = React.createClass({
         display: this.state.showPresets ? 'block' : 'none'
       },
       range: {
-        padding: '30px 0',
+        padding: '44px 0 30px',
         margin: '0 10px',
         visibility: this.state.showPresets ? 'hidden' : 'visible'
       },
@@ -192,6 +192,7 @@ const RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.lowerPixels,
+        marginTop: '6px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer'
@@ -205,6 +206,7 @@ const RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.upperPixels,
+        marginTop: '6px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer',
@@ -217,6 +219,7 @@ const RangeSelector = React.createClass({
         background: this.props.selectedColor,
         height: '3px',
         top: '50%',
+        marginTop: '6px',
         transform: 'translateY(-50%)',
         WebkitTransform: 'translateY(-50%)'
       },
@@ -227,7 +230,7 @@ const RangeSelector = React.createClass({
         transform: 'translateX(-50%)',
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
-        marginTop: '5px',
+        marginTop: '2px',
         display: 'block'
       },
       upperToggleLabel: {
@@ -237,7 +240,7 @@ const RangeSelector = React.createClass({
         transform: 'translateX(-50%)',
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
-        marginBottom: '5px',
+        marginBottom: '2px',
         display: 'block'
       },
       preset: {

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -10,9 +10,7 @@ const RangeSelector = React.createClass({
     defaultUpperValue: React.PropTypes.number,
     formatter: React.PropTypes.func,
     interval: React.PropTypes.number,
-    onLowerDrag: React.PropTypes.func,
     onLowerDragStop: React.PropTypes.func,
-    onUpperDrag: React.PropTypes.func,
     onUpperDragStop: React.PropTypes.func,
     presets: React.PropTypes.array,
     range: React.PropTypes.number,
@@ -27,9 +25,7 @@ const RangeSelector = React.createClass({
       formatter (value) {
         return value;
       },
-      onLowerDrag () {},
       onLowerDragStop () {},
-      onUpperDrag () {},
       onUpperDragStop () {},
       presets: [],
       range: 100,

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -188,7 +188,7 @@ const RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.lowerPixels,
-        marginTop: '6px',
+        margin: '6px 0 0 10px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer'
@@ -202,7 +202,7 @@ const RangeSelector = React.createClass({
         position: 'absolute',
         top: '50%',
         left: this.state.upperPixels,
-        marginTop: '6px',
+        margin: '6px 0 0 10px',
         transform: 'translate(-50%, -50%)',
         WebkitTransform: 'translate(-50%, -50%)',
         cursor: 'pointer',
@@ -227,7 +227,9 @@ const RangeSelector = React.createClass({
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
         marginTop: '2px',
-        display: 'block'
+        display: 'block',
+        cursor: 'pointer',
+        minWidth: '20px'
       },
       upperToggleLabel: {
         position: 'absolute',
@@ -237,7 +239,9 @@ const RangeSelector = React.createClass({
         WebkitTransform: 'translateX(-50%)',
         textAlign: 'center',
         marginBottom: '2px',
-        display: 'block'
+        display: 'block',
+        cursor: 'pointer',
+        minWidth: '20px'
       },
       preset: {
         display: 'inline-block',
@@ -251,7 +255,7 @@ const RangeSelector = React.createClass({
       showPresets: {
         position: 'absolute',
         top: 0,
-        right: '10px',
+        right: 0,
         cursor: 'pointer',
         color: this.props.selectedColor
       },


### PR DESCRIPTION
Fixes #13, Fixes #12, Fixes #7 

- Remove the `onLowerDrag` and `onUpperDrag` props since they are not being used
- Adjust the spacing so the upper toggle label doesn't overlap with the "Groups" link
- The toggle labels were already a part of the draggable area. Add a `pointer` cursor to help users know that they can drag the label
- Adjust the position of the toggles by 10 pixels so they stay in line with where the cursor is

Before:
<img width="499" alt="screenshot 2015-09-30 10 48 41" src="https://cloud.githubusercontent.com/assets/714084/10199957/d509c7a0-6760-11e5-9782-51437a3a5a1d.png">

After:
<img width="508" alt="screenshot 2015-09-30 10 48 25" src="https://cloud.githubusercontent.com/assets/714084/10199956/d5061376-6760-11e5-8c8c-2bef55a5ec78.png">
