### PR TITLE
(fix) TypeAhead empty filter item

### DIFF
--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -86,9 +86,7 @@ const TypeAhead = React.createClass({
     //add to selectedItems
     const selectedItems = this.state.selectedItems;
 
-    if (item) {
-      selectedItems.push(item);
-    }
+    selectedItems.push(item);
 
     this.props.onItemSelect(item, selectedItems);
 
@@ -130,7 +128,11 @@ const TypeAhead = React.createClass({
     if (e.keyCode === 9) {
       e.preventDefault();
 
-      this._handleItemSelect(filteredItems[0]);
+      const item = filteredItems[0];
+
+      if (item) {
+        this._handleItemSelect(item);
+      }
     }
 
     //remove tag on backspace

--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -86,7 +86,9 @@ const TypeAhead = React.createClass({
     //add to selectedItems
     const selectedItems = this.state.selectedItems;
 
-    selectedItems.push(item);
+    if (item) {
+      selectedItems.push(item);
+    }
 
     this.props.onItemSelect(item, selectedItems);
 


### PR DESCRIPTION
the TypeAhead will call the _handleItemSelect function to add
the item to the list, if the item has a value it will get pushed to
the selectedItems array, otherwise it will be ignored

closes #34 