### PR TITLE
Change default styling on donut chart

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -324,10 +324,7 @@ const Demo = React.createClass({
 
         <br/><br/>
         <DonutChart
-          activeIndex={1}
-          activeOffset={10}
-          arcWidth={40}
-          baseArcColor='#f5f5f5'
+          animateOnHover={true}
           chartTotal={300}
           data={[
             {
@@ -339,17 +336,14 @@ const Demo = React.createClass({
               value: 80
             }
           ]}
-          dataPointRadius={16}
           dataPoints={[
             {
               name: 'Data Dot 1',
               value: 200
             }
           ]}
-          dataPointColors={[ '#555' ]}
-          showBaseArc={true}
-          style={{ margin: '0 auto' }}
-          width={this.state.windowWidth - 40}
+          defaultLabelText='Total Users'
+          defaultLabelValue={300}
         />
 
         <br/><br/>

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -19,6 +19,7 @@ const DonutChart = React.createClass({
     dataPointRadius: React.PropTypes.number,
     dataPoints: React.PropTypes.array,
     defaultLabelText: React.PropTypes.string,
+    defaultLabelValue: React.PropTypes.string,
     formatter: React.PropTypes.func,
     height: React.PropTypes.number,
     onClick: React.PropTypes.func,
@@ -34,14 +35,14 @@ const DonutChart = React.createClass({
   getDefaultProps () {
     return {
       activeIndex: -1,
-      activeOffset: 3,
-      animateOnHover: true,
-      arcWidth: 80,
-      baseArcColor: '#E5E5E5',
+      activeOffset: 0,
+      animateOnHover: false,
+      arcWidth: 10,
+      baseArcColor: '#F5F5F5',
       colors: d3.scale.category20().range(),
       data: [],
       dataPointColors: d3.scale.category20b().range(),
-      dataPointRadius: 40,
+      dataPointRadius: 5,
       dataPoints: [],
       defaultLabelText: 'Roll over an item for details',
       formatter (value) {
@@ -53,7 +54,7 @@ const DonutChart = React.createClass({
       onMouseLeave () {},
       opacity: 1,
       padAngle: 0.01,
-      showBaseArc: false,
+      showBaseArc: true,
       showDataLabel: true,
       width: 360
     };
@@ -80,19 +81,23 @@ const DonutChart = React.createClass({
   },
 
   _handleMouseEnter (index) {
-    this.setState({
-      activeIndex: index
-    });
+    if (this.props.animateOnHover) {
+      this.setState({
+        activeIndex: index
+      });
 
-    this.props.onMouseEnter(index);
+      this.props.onMouseEnter(index);
+    }
   },
 
   _handleMouseLeave () {
-    this.setState({
-      activeIndex: -1
-    });
+    if (this.props.animateOnHover) {
+      this.setState({
+        activeIndex: -1
+      });
 
-    this.props.onMouseLeave();
+      this.props.onMouseLeave();
+    }
   },
 
   _renderArcs () {
@@ -184,26 +189,19 @@ const DonutChart = React.createClass({
             {this.props.children}
           </div>
         );
-      } else if (this.state.activeIndex >= 0) {
+      } else {
         const activeDataSet = this.props.data[this.state.activeIndex] || {};
-        const color = this.props.colors[this.state.activeIndex];
-        const value = this.props.formatter(activeDataSet.value);
+        const color = this.state.activeIndex === -1 ? this.props.colors[0] : this.props.colors[this.state.activeIndex];
+        const text = this.state.activeIndex === -1 ? this.props.defaultLabelText : activeDataSet.name;
+        const value = this.state.activeIndex === -1 ? this.props.formatter(this.props.defaultLabelValue) : this.props.formatter(activeDataSet.value);
 
         return (
           <div onClick={this.props.onClick} style={styles.center}>
-              <div style={styles.label}>
-                {activeDataSet.name}
-              </div>
-              <div style={[styles.value, { color }]}>
-                {value}
-              </div>
-          </div>
-        );
-      } else {
-        return (
-          <div onClick={this.props.onClick} style={styles.center}>
+            <div style={[styles.value, { color }]}>
+              {value}
+            </div>
             <div style={styles.label}>
-              {this.props.defaultLabelText}
+              {text}
             </div>
           </div>
         );
@@ -213,12 +211,13 @@ const DonutChart = React.createClass({
 
   render () {
     const position = 'translate(' + this.props.width / 2 + ',' + this.props.height / 2 + ')';
+    const fontSize = Math.min(this.props.width, this.props.height) * 0.2 + 'px';
 
     return (
-      <div style={[styles.component, this.props.style, { height: this.props.height, width: this.props.width }]}>
+      <div style={[styles.component, this.props.style, { fontSize, height: this.props.height, width: this.props.width }]}>
         {this._renderDataLabel()}
         <svg height={this.props.height} width={this.props.width}>
-          <g style={styles.pointer} transform={position}>
+          <g style={{ cursor: this.props.animateOnHover ? 'pointer' : 'auto' }} transform={position}>
             {this._renderBaseArc()}
             {this._renderArcs()}
             {this._renderDataPoints()}
@@ -242,16 +241,12 @@ const styles = {
     transform: 'translate(-50%, -50%)'
   },
   label: {
-    color: '#333',
-    fontSize: '14px',
-    fontWeight: '800'
-  },
-  pointer: {
-    cursor: 'pointer'
+    color: '#999',
+    fontSize: '0.4em',
+    marginTop: '5px'
   },
   value: {
-    fontSize: '24px',
-    fontWeight: '400'
+    fontWeight: 300
   }
 };
 

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -39,9 +39,9 @@ const DonutChart = React.createClass({
       animateOnHover: false,
       arcWidth: 10,
       baseArcColor: StyleConstants.Colors.BASE_ARC,
-      colors: [StyleConstants.Colors.DEFAULT_ARC].concat(d3.scale.category20().range()),
+      colors: [StyleConstants.Colors.PRIMARY].concat(d3.scale.category20().range()),
       data: [],
-      dataPointColors: [StyleConstants.Colors.DEFAULT_DOT].concat(d3.scale.category20b().range()),
+      dataPointColors: [StyleConstants.Colors.SECONDARY].concat(d3.scale.category20b().range()),
       dataPointRadius: 5,
       dataPoints: [],
       formatter (value) {
@@ -211,8 +211,6 @@ const DonutChart = React.createClass({
   render () {
     const position = 'translate(' + this.props.width / 2 + ',' + this.props.height / 2 + ')';
     const fontSize = Math.min(this.props.width, this.props.height) * 0.2 + 'px';
-
-    console.log('on click', this.props.onClick());
 
     return (
       <div style={[styles.component, this.props.style, { fontSize, height: this.props.height, width: this.props.width }]}>

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -39,9 +39,9 @@ const DonutChart = React.createClass({
       animateOnHover: false,
       arcWidth: 10,
       baseArcColor: StyleConstants.Colors.BASE_ARC,
-      colors: d3.scale.category20().range(),
+      colors: [StyleConstants.Colors.DEFAULT_ARC].concat(d3.scale.category20().range()),
       data: [],
-      dataPointColors: d3.scale.category20b().range(),
+      dataPointColors: [StyleConstants.Colors.DEFAULT_DOT].concat(d3.scale.category20b().range()),
       dataPointRadius: 5,
       dataPoints: [],
       formatter (value) {

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -38,17 +38,16 @@ const DonutChart = React.createClass({
       activeOffset: 0,
       animateOnHover: false,
       arcWidth: 10,
-      baseArcColor: '#F5F5F5',
+      baseArcColor: StyleConstants.Colors.BASE_ARC,
       colors: d3.scale.category20().range(),
       data: [],
       dataPointColors: d3.scale.category20b().range(),
       dataPointRadius: 5,
       dataPoints: [],
-      defaultLabelText: 'Roll over an item for details',
       formatter (value) {
         return value;
       },
-      height: 360,
+      height: 150,
       onClick () {},
       onMouseEnter () {},
       onMouseLeave () {},
@@ -56,7 +55,7 @@ const DonutChart = React.createClass({
       padAngle: 0.01,
       showBaseArc: true,
       showDataLabel: true,
-      width: 360
+      width: 150
     };
   },
 
@@ -85,9 +84,9 @@ const DonutChart = React.createClass({
       this.setState({
         activeIndex: index
       });
-
-      this.props.onMouseEnter(index);
     }
+
+    this.props.onMouseEnter(index);
   },
 
   _handleMouseLeave () {
@@ -95,9 +94,9 @@ const DonutChart = React.createClass({
       this.setState({
         activeIndex: -1
       });
-
-      this.props.onMouseLeave();
     }
+
+    this.props.onMouseLeave();
   },
 
   _renderArcs () {
@@ -241,7 +240,7 @@ const styles = {
     transform: 'translate(-50%, -50%)'
   },
   label: {
-    color: '#999',
+    color: StyleConstants.Colors.LIGHT_FONT,
     fontSize: '0.4em',
     marginTop: '5px'
   },

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -212,11 +212,13 @@ const DonutChart = React.createClass({
     const position = 'translate(' + this.props.width / 2 + ',' + this.props.height / 2 + ')';
     const fontSize = Math.min(this.props.width, this.props.height) * 0.2 + 'px';
 
+    console.log('on click', this.props.onClick());
+
     return (
       <div style={[styles.component, this.props.style, { fontSize, height: this.props.height, width: this.props.width }]}>
         {this._renderDataLabel()}
         <svg height={this.props.height} width={this.props.width}>
-          <g style={{ cursor: this.props.animateOnHover ? 'pointer' : 'auto' }} transform={position}>
+          <g transform={position}>
             {this._renderBaseArc()}
             {this._renderArcs()}
             {this._renderDataPoints()}

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -11,9 +11,6 @@ module.exports = {
     LIGHT_FONT: '#999999',
 
     BASE_ARC: '#F5F5F5',
-    DEFAULT_ARC: '#359BCF',
-    DEFAULT_DOT: '#F7B148',
-
     ORANGE: '#ca3a31',
     YELLOW: '#f6a01e',
     GREEN: '#00a89c',

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -11,6 +11,8 @@ module.exports = {
     LIGHT_FONT: '#999999',
 
     BASE_ARC: '#F5F5F5',
+    DEFAULT_ARC: '#359BCF',
+    DEFAULT_DOT: '#F7B148',
 
     ORANGE: '#ca3a31',
     YELLOW: '#f6a01e',

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -10,6 +10,8 @@ module.exports = {
     FONT: '#2E323F',
     LIGHT_FONT: '#999999',
 
+    BASE_ARC: '#F5F5F5',
+
     ORANGE: '#ca3a31',
     YELLOW: '#f6a01e',
     GREEN: '#00a89c',


### PR DESCRIPTION
New default values
- activeOffset: 0
- animateOnHover: false
- arcWidth: 10
- baseArcColor: #F5F5F5
- dataPointRadius: 5
- showBaseArc: true

Other changes
- Wrapped mouse events in conditional to only fire when animateOnHover is set to true
- Swapped position of value and text in label
- Set fontSize for label based on chart dimensions
- Set cursor to pointer only if animateOnHover is true