### PR TITLE
Moved props.style to selector

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -109,11 +109,11 @@ const Select = React.createClass({
     const selected = this.state.selected || this.props.selected || { displayValue: this.props.placeholderText, value: '' };
 
     return (
-      <div style={[this.props.style, { position: 'relative' }]}>
+      <div>
         <div
           onBlur={this._handleBlur}
           onClick={this._handleClick}
-          style={styles.component}
+          style={[styles.component, this.props.style]}
           tabIndex='0'
         >
           {this._renderScrim()}


### PR DESCRIPTION
Moved the props.style attribute from the outer most div to the component div. As it was, there was no way to override the select border that was set in styles.component with a passed in prop.

Before:
<img width="241" alt="screen shot 2015-10-06 at 3 55 54 pm" src="https://cloud.githubusercontent.com/assets/488916/10323933/89591062-6c43-11e5-8b6f-1fa4c10d8738.png">

After (passing in border: none on the styles prop)
<img width="252" alt="screen shot 2015-10-06 at 3 55 15 pm" src="https://cloud.githubusercontent.com/assets/488916/10323936/8ed5bf22-6c43-11e5-9e4e-e83ea729b34c.png">

