### PR TITLE
Change bind from prop to local method

### DIFF
--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -26,6 +26,10 @@ class DonutChart extends React.Component {
     }
   }
 
+  _handleClick (index) {
+    this.props.onClick(index);
+  }
+
   _handleMouseEnter (index) {
     if (this.props.animateOnHover) {
       this.setState({

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -71,7 +71,7 @@ class DonutChart extends React.Component {
           return (
             <g
               key={i}
-              onClick={this.props.onClick.bind(this, i)}
+              onClick={this._handleClick.bind(this, i)}
               onMouseEnter={this._handleMouseEnter.bind(this, i)}
               onMouseLeave={this._handleMouseLeave.bind(this)}
             >
@@ -133,7 +133,7 @@ class DonutChart extends React.Component {
     if (this.props.showDataLabel) {
       if (this.props.children) {
         return (
-          <div onClick={this.props.onClick.bind(this)} style={styles.center}>
+          <div onClick={this._handleClick.bind(this)} style={styles.center}>
             {this.props.children}
           </div>
         );
@@ -144,7 +144,7 @@ class DonutChart extends React.Component {
         const value = this.state.activeIndex === -1 ? this.props.formatter(this.props.defaultLabelValue) : this.props.formatter(activeDataSet.value);
 
         return (
-          <div onClick={this.props.onClick.bind(this)} style={styles.center}>
+          <div onClick={this._handleClick.bind(this)} style={styles.center}>
             <div style={[styles.value, { color }]}>
               {value}
             </div>


### PR DESCRIPTION
There is warning thrown when binding to a function passed as a prop. From what I can tell, you can't bind 'this' between props. This adds a method to the local component which then calls the prop.

Would be interested on your thoughts on this @bsbeeks @cerinman 

http://stackoverflow.com/questions/30477042/react-js-how-to-bind-passed-in-event-handlers-this-to-child-component