### PR TITLE
Keep the context of RangeSelector on window resize, Fixes #48

### DIFF
--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -2,7 +2,6 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const Radium = require('radium');
 const _throttle = require('lodash/function/throttle');
-const _bind = require('lodash/function/bind');
 
 const StyleConstants = require('../constants/Style');
 
@@ -27,11 +26,11 @@ class RangeSelector extends React.Component {
   componentDidMount () {
     this._setDefaultRangeValues();
 
-    window.addEventListener('resize', _throttle(_bind(this._setDefaultRangeValues, this), 300));
+    window.addEventListener('resize', _throttle(this._setDefaultRangeValues.bind(this), 300));
   }
 
   componentWillUnmount () {
-    window.removeEventListener('resize', _throttle(_bind(this._setDefaultRangeValues, this), 300));
+    window.removeEventListener('resize', _throttle(this._setDefaultRangeValues.bind(this), 300));
   }
 
   _getSelectedLabel (lowerValue, upperValue) {

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -2,6 +2,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const Radium = require('radium');
 const _throttle = require('lodash/function/throttle');
+const _bind = require('lodash/function/bind');
 
 const StyleConstants = require('../constants/Style');
 
@@ -26,11 +27,11 @@ class RangeSelector extends React.Component {
   componentDidMount () {
     this._setDefaultRangeValues();
 
-    window.addEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
+    window.addEventListener('resize', _throttle(_bind(this._setDefaultRangeValues, this), 300));
   }
 
   componentWillUnmount () {
-    window.removeEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
+    window.removeEventListener('resize', _throttle(_bind(this._setDefaultRangeValues, this), 300));
   }
 
   _getSelectedLabel (lowerValue, upperValue) {


### PR DESCRIPTION
The callback of `window.addEventListener` changes the context of the function.
The `_bind` sends the component context to the callback, since there is no option to send the context in `_throttle`. ref https://github.com/lodash/lodash/issues/699