### PR TITLE
#30 - Added aria roles and keyboard navigation to Toggle Switch.

### DIFF
--- a/src/constants/KeyCodes.js
+++ b/src/constants/KeyCodes.js
@@ -1,0 +1,15 @@
+module.exports = {
+  backspace: 8,
+  tab: 9,
+  enter: 13,
+  esc: 27,
+  space: 32,
+  pageUp: 33,
+  pageDown: 34,
+  end: 35,
+  home: 36,
+  leftArrow: 37,
+  upArrow: 38,
+  rightArrow: 39,
+  downArrow: 40
+};


### PR DESCRIPTION
This pull request adds aria roles and keyboard navigation to make Toggle Switch component conform to Aria 'switch role.'  See the following links for the description of the role.  Users can use the tab button to give the Toggle Switch focus and the space bar to toggle its position.

[MDN - Aria Switch Role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_switch_role)
[MDN - Aria Checkbox Role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_checkbox_role)

## Example
```html
<p id="email-updates-label">
Would you like you receive updates?
</p>
<ToggleSwitch
  ariaCheckedPosition='right'
  ariaDescribedByElement='email-updates-label'
  leftLabel='No'
  rightLabel='Yes'
>
```

## Props
`ariaCheckedPosition` *string*  **optional**
Default: 'left'
Used to set which direction should be considered "aria-checked=true" for screen readers.  Also used to determine which label should be used to describe the switch to screen readers.

`ariaDescribedByElement` *string* **optional**
This string is the id of an html element (with no hash) that provides additional information to the user about what the switch indicating.  See the above example.

`id` *string* **optional**
An id attribute for the Toggle Switch.  If one is not provided, the component will generate its own unique id so that it does not conflict with other Toggle Switches on the page.  The id is used to associate the Toggle Switch with its labels.