### PR TITLE
Added aria attributes and keyboard navigation to RangeSelector.

### DIFF
--- a/src/constants/KeyCodes.js
+++ b/src/constants/KeyCodes.js
@@ -1,0 +1,15 @@
+module.exports = {
+  backspace: 8,
+  tab: 9,
+  enter: 13,
+  esc: 27,
+  space: 32,
+  pageUp: 33,
+  pageDown: 34,
+  end: 35,
+  home: 36,
+  leftArrow: 37,
+  upArrow: 38,
+  rightArrow: 39,
+  downArrow: 40
+};


### PR DESCRIPTION
This PR makes the RangeSelector accessible by allowing for keyboard navigation and adding labels and aria attributes.

The range selector conforms to the [slider widget](http://www.w3.org/TR/wai-aria-practices/#slider) documentation.  The range selector presets conform to the [menu button](http://www.w3.org/TR/wai-aria-practices/#menubutton) and [menu](http://www.w3.org/TR/wai-aria-practices/#menu) documentation.

## Props
`descriptionElementId` *string* **optional**
The element that provides additional descriptive information about what the range selector selects.

`id` *string* **optional**
A unique id, used to establish aria relationships between elements in the component.  If no id is provided, the component will create its own unique id.

`pageUpDownInterval` *number* **optional**
A number that sets the interval that the Range Selector toggles should change when the user presses 'Page Up' or 'Page Down' buttons.  The w3 accessible slider widget document recommends that the 'Page Up' and 'Page Down' buttons change the slider values faster than the arrow keys.  Defaults to 10.  


