### PR TITLE
Time based split line chart

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -489,7 +489,7 @@ const Demo = React.createClass({
           width={700}
         >
           <div style={{ backgroundColor: '#999', color: '#fff', padding: '5px' }}>
-            {'$' + this.state.lineChartHoverValue}
+            {this.state.lineChartHoverValue}
           </div>
         </TimeBasedLineChart>
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
+const moment = require('moment');
 
 const {
   DonutChart,
@@ -8,6 +9,7 @@ const {
   Modal,
   RangeSelector,
   Select,
+  TimeBasedLineChart,
   ToggleSwitch,
   TypeAhead
 } = require('../src/Index');
@@ -351,6 +353,147 @@ const Demo = React.createClass({
         />
 
         <br/><br/>
+        <TimeBasedLineChart
+          breakPointDate={moment().startOf('day').unix()}
+          breakPointLabel='Today'
+          data={[
+            {
+              timeStamp: moment().subtract(15, 'days').unix(),
+              value: 2000
+            },
+            {
+              timeStamp: moment().subtract(14, 'days').unix(),
+              value: 1900
+            },
+            {
+              timeStamp: moment().subtract(13, 'days').unix(),
+              value: 1850
+            },
+            {
+              timeStamp: moment().subtract(12, 'days').unix(),
+              value: 1550
+            },
+            {
+              timeStamp: moment().subtract(11, 'days').unix(),
+              value: 1500
+            },
+            {
+              timeStamp: moment().subtract(10, 'days').unix(),
+              value: 1000
+            },
+            {
+              timeStamp: moment().subtract(9, 'days').unix(),
+              value: 900
+            },
+            {
+              timeStamp: moment().subtract(8, 'days').unix(),
+              value: 900
+            },
+            {
+              timeStamp: moment().subtract(7, 'days').unix(),
+              value: 900
+            },
+            {
+              timeStamp: moment().subtract(6, 'days').unix(),
+              value: 800
+            },
+            {
+              timeStamp: moment().subtract(5, 'days').unix(),
+              value: 600
+            },
+            {
+              timeStamp: moment().subtract(4, 'days').unix(),
+              value: 600
+            },
+            {
+              timeStamp: moment().subtract(3, 'days').unix(),
+              value: 600
+            },
+            {
+              timeStamp: moment().subtract(2, 'days').unix(),
+              value: 1600
+            },
+            {
+              timeStamp: moment().subtract(1, 'days').unix(),
+              value: 1700
+            },
+            {
+              timeStamp: moment().unix(),
+              value: 1400
+            },
+            {
+              timeStamp: moment().add(1, 'days').unix(),
+              value: 1200
+            },
+            {
+              timeStamp: moment().add(2, 'days').unix(),
+              value: 1200
+            },
+            {
+              timeStamp: moment().add(3, 'days').unix(),
+              value: 1700
+            },
+            {
+              timeStamp: moment().add(4, 'days').unix(),
+              value: 1100
+            },
+            {
+              timeStamp: moment().add(5, 'days').unix(),
+              value: 1000
+            },
+            {
+              timeStamp: moment().add(6, 'days').unix(),
+              value: 900
+            },
+            {
+              timeStamp: moment().add(7, 'days').unix(),
+              value: 500
+            },
+            {
+              timeStamp: moment().add(8, 'days').unix(),
+              value: 300
+            },
+            {
+              timeStamp: moment().add(9, 'days').unix(),
+              value: 300
+            },
+            {
+              timeStamp: moment().add(10, 'days').unix(),
+              value: 300
+            },
+            {
+              timeStamp: moment().add(11, 'days').unix(),
+              value: 1700
+            },
+            {
+              timeStamp: moment().add(12, 'days').unix(),
+              value: 1700
+            },
+            {
+              timeStamp: moment().add(13, 'days').unix(),
+              value: 1700
+            },
+            {
+              timeStamp: moment().add(14, 'days').unix(),
+              value: 1300
+            },
+            {
+              timeStamp: moment().add(15, 'days').unix(),
+              value: 900
+            },
+          ]}
+          height={400}
+          hoverCallBack={this._handleLineChartHover}
+          margin={{ top: 30, right: 50, bottom: 20, left: 50 }}
+          shadeAreaBelowZero={true}
+          width={700}
+        >
+          <div style={{ backgroundColor: '#999', color: '#fff', padding: '5px' }}>
+            {'$' + this.state.lineChartHoverValue}
+          </div>
+        </TimeBasedLineChart>
+
+        <br/><br/>
         <ToggleSwitch />
 
         <br/><br/>
@@ -445,6 +588,12 @@ const Demo = React.createClass({
         </div>
       </div>
     );
+  },
+
+  _handleLineChartHover (data) {
+    this.setState({
+      lineChartHoverValue: data.value
+    });
   },
 
   _handleSelectChange (option) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "d3": "^3.5.6",
     "lodash": "^3.10.1",
+    "moment": "^2.10.3",
+    "numeral": "^1.5.3",
     "object-assign": "3.x.x",
     "radium": "^0.14.1",
     "react": "^0.14.0",

--- a/src/Index.js
+++ b/src/Index.js
@@ -7,6 +7,7 @@ module.exports = {
   RangeSelector: require('./components/RangeSelector'),
   Select: require('./components/Select'),
   Spin: require('./components/Spin'),
+  TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),
   TypeAhead: require('./components/TypeAhead')
 };

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -46,7 +46,7 @@ class TimeBasedLineChart extends React.Component {
   _getAreaBelowZero (data) {
     const area = d3.svg.area()
       .x(d => {
-        const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
         return this._getXScaleValue(currentDate);
       })
@@ -59,7 +59,7 @@ class TimeBasedLineChart extends React.Component {
   _getFlatLine (data) {
     const flatLine = d3.svg.line()
       .x(d => {
-        const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
         return this._getXScaleValue(currentDate);
       })
@@ -71,7 +71,7 @@ class TimeBasedLineChart extends React.Component {
   _getLine (data) {
     const line = d3.svg.line()
       .x(d => {
-        const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
         return this._getXScaleValue(currentDate);
       })
@@ -87,7 +87,7 @@ class TimeBasedLineChart extends React.Component {
   }
 
   _getSliceWidth (timeStamp) {
-    const rangeType = this.props.rangeType === 'year' ? 'month' : 'day';
+    const rangeType = this.props.rangeType;
     const startOf = timeStamp ? moment.unix(timeStamp).startOf(rangeType).unix() : moment(timeStamp).startOf(rangeType).unix();
     const endOf = timeStamp ? moment.unix(timeStamp).endOf(rangeType).unix() : moment(timeStamp).endOf(rangeType).unix();
 
@@ -99,17 +99,17 @@ class TimeBasedLineChart extends React.Component {
     const past = [];
 
     this.props.data.forEach(item => {
-      const currentDate = moment.unix(item.timeStamp).startOf('day');
+      const currentDate = moment.unix(item.timeStamp).startOf(this.props.rangeType);
 
-      if (currentDate.isBefore(moment.unix(this.props.breakPointDate), 'day')) {
+      if (currentDate.isBefore(moment.unix(this.props.breakPointDate), this.props.rangeType)) {
         past.push(item);
       }
 
-      if (currentDate.isAfter(moment.unix(this.props.breakPointDate), 'day')) {
+      if (currentDate.isAfter(moment.unix(this.props.breakPointDate), this.props.rangeType)) {
         future.push(item);
       }
 
-      if (currentDate.isSame(moment.unix(this.props.breakPointDate), 'day')) {
+      if (currentDate.isSame(moment.unix(this.props.breakPointDate), this.props.rangeType)) {
         past.push(item);
         future.push(item);
       }
@@ -155,8 +155,8 @@ class TimeBasedLineChart extends React.Component {
     let maxDate = this.props.data[this.props.data.length - 1].timeStamp;
     let minDate = this.props.data[0].timeStamp;
 
-    maxDate = moment.unix(maxDate).endOf('day').unix();
-    minDate = moment.unix(minDate).startOf('day').unix();
+    maxDate = moment.unix(maxDate).endOf(this.props.rangeType).unix();
+    minDate = moment.unix(minDate).startOf(this.props.rangeType).unix();
 
     return d3.time.scale()
       .range([0, this.state.adjustedWidth])
@@ -276,7 +276,7 @@ class TimeBasedLineChart extends React.Component {
     data.forEach((dataSet, i) => {
       const color = this.props.lineColor;
       const breakPointDate = moment.unix(this.props.breakPointDate);
-      const isMonthRangeType = this.props.rangeType === 'month';
+      const isDayRangeType = this.props.rangeType === 'day';
       const isPast = i === 0;
 
       const group = chart.append('g')
@@ -324,8 +324,8 @@ class TimeBasedLineChart extends React.Component {
         newBreakPoint.append('text')
           .attr('class', 'mx-time-based-line-chart-break-point-label')
           .attr('x', d => {
-            const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
-            const offSet = isMonthRangeType ? 18 : 25;
+            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+            const offSet = isDayRangeType ? 18 : 25;
 
             return this._getXScaleValue(currentDate) - offSet;
           })
@@ -343,8 +343,8 @@ class TimeBasedLineChart extends React.Component {
           newBreakPoint.append('text')
             .attr('class', 'mx-time-based-line-chart-break-point-date')
             .attr('x', d => {
-              const offSet = isMonthRangeType ? 18 : 22;
-              const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+              const offSet = isDayRangeType ? 18 : 22;
+              const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
               return this._getXScaleValue(currentDate) - offSet;
             })
@@ -356,8 +356,8 @@ class TimeBasedLineChart extends React.Component {
               return isSameDateAsBreakPoint && i === 1 ? '1' : '0';
             })
             .text(d => {
-              const dateFormat = isMonthRangeType ? 'MMM D' : 'MMMM';
-              const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+              const dateFormat = isDayRangeType ? 'MMM D' : 'MMMM';
+              const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
               return moment.unix(currentDate).format(dateFormat);
             });
@@ -367,13 +367,13 @@ class TimeBasedLineChart extends React.Component {
         newBreakPoint.append('line')
           .attr('class', 'mx-time-based-line-chart-break-point-line')
           .attr('x1', d => {
-            const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
             return this._getXScaleValue(currentDate);
           })
           .attr('y1', -10)
           .attr('x2', d => {
-            const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
             return this._getXScaleValue(currentDate);
           })
@@ -401,7 +401,7 @@ class TimeBasedLineChart extends React.Component {
       newDots.append('circle')
         .attr('class', 'mx-time-based-line-chart-dot')
         .attr('cx', d => {
-          const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
           return this._getXScaleValue(currentDate);
         })
@@ -437,14 +437,14 @@ class TimeBasedLineChart extends React.Component {
       newSlices.append('rect')
         .attr('class', 'slice')
         .attr('x', d => {
-          const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
 
           return this._getXScaleValue(currentDate) - this._getSliceMiddle();
         })
         .attr('y', -10)
         .attr('height', this.state.adjustedHeight)
         .attr('width', d => {
-          const currentDate = moment.unix(d.timeStamp).startOf('day').unix();
+          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
           return this._getSliceWidth(currentDate);
         })
@@ -483,10 +483,9 @@ class TimeBasedLineChart extends React.Component {
   }
 
   _showTooltip (d) {
-    const breakPointDate = moment.unix(this.props.breakPointDate);
-    const currentDate = moment.unix(d.timeStamp).startOf('day');
+    const breakPointDate = moment.unix(this.props.breakPointDate).startOf(this.props.rangeType);
+    const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType);
     const isAfterBreakPoint = currentDate.isAfter(breakPointDate);
-    const isMonthRangeType = this.props.rangeType === 'month';
     const sliceWidth = this._getSliceWidth(currentDate.unix());
     const xScale = this._getXScaleValue(currentDate.unix());
 
@@ -537,12 +536,12 @@ class TimeBasedLineChart extends React.Component {
     const hoveredData = this.state.hoveredData;
 
     const breakPointDate = moment.unix(this.props.breakPointDate);
-    const currentDate = moment.unix(hoveredData.timeStamp).startOf('day');
+    const currentDate = moment.unix(hoveredData.timeStamp).startOf(this.props.rangeType);
 
     const dash = currentDate.isAfter(breakPointDate) && this.props.dashedFutureLine ? '2, 2' : 'none';
     const isBreakPointDate = currentDate.format('MM DD YYYY') === breakPointDate.format('MM DD YYYY');
-    const isMonthRangeType = this.props.rangeType === 'month';
-    const dateFormat = isMonthRangeType ? 'MM/DD' : 'MMM';
+    const isDayRangeType = this.props.rangeType === 'day';
+    const dateFormat = isDayRangeType ? 'MM/DD' : 'MMM';
 
     const dots = d3.select(this.state.chartEl).selectAll('.dot-group');
     const slices = d3.select(this.state.chartEl).selectAll('.slice-group');
@@ -740,7 +739,7 @@ TimeBasedLineChart.defaultProps = {
   hoverCallBack: () => {},
   lineColor: StyleConstants.Colors.PRIMARY,
   margin: { top: 20, right: 50, bottom: 20, left: 50 },
-  rangeType: 'month',
+  rangeType: 'day',
   shadeAreaBelowZero: false,
   showBreakPoint: true,
   showTooltips: true,

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -240,7 +240,7 @@ class TimeBasedLineChart extends React.Component {
           .text('No data found.');
     }
 
-    chart.on('mouseleave', this._hideTooltip.bind(this));
+    chart.on('mouseleave', this._handleChartMouseLeave.bind(this));
   }
 
   _renderLineChart () {
@@ -455,7 +455,7 @@ class TimeBasedLineChart extends React.Component {
 
           return isPast && isBreakPointDate ? 'none' : 'block';
         })
-        .on('mouseover', this._showTooltip.bind(this));
+        .on('mouseover', this._handleDataPointMouseOver.bind(this));
     });
 
     //Update the axes
@@ -482,7 +482,7 @@ class TimeBasedLineChart extends React.Component {
     chart.selectAll('.grid-line .tick').style(styles.gridLineTick);
   }
 
-  _showTooltip (d) {
+  _handleDataPointMouseOver (d) {
     const breakPointDate = moment.unix(this.props.breakPointDate).startOf(this.props.rangeType);
     const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType);
     const isAfterBreakPoint = currentDate.isAfter(breakPointDate);
@@ -513,7 +513,7 @@ class TimeBasedLineChart extends React.Component {
     this.props.hoverCallBack(d);
   }
 
-  _hideTooltip () {
+  _handleChartMouseLeave () {
     this.setState({
       hoveredData: false,
       tooltipPosition: false

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -746,7 +746,7 @@ TimeBasedLineChart.defaultProps = {
   staticXAxis: true,
   width: 550,
   yAxisFormatter (d) {
-    return numeral(d).format('$0a');
+    return numeral(d).format('0a');
   }
 };
 

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -46,7 +46,7 @@ class TimeBasedLineChart extends React.Component {
   _getAreaBelowZero (data) {
     const area = d3.svg.area()
       .x(d => {
-        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
         return this._getXScaleValue(currentDate);
       })
@@ -59,7 +59,7 @@ class TimeBasedLineChart extends React.Component {
   _getFlatLine (data) {
     const flatLine = d3.svg.line()
       .x(d => {
-        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
         return this._getXScaleValue(currentDate);
       })
@@ -71,7 +71,7 @@ class TimeBasedLineChart extends React.Component {
   _getLine (data) {
     const line = d3.svg.line()
       .x(d => {
-        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+        const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
         return this._getXScaleValue(currentDate);
       })
@@ -324,7 +324,7 @@ class TimeBasedLineChart extends React.Component {
         newBreakPoint.append('text')
           .attr('class', 'mx-time-based-line-chart-break-point-label')
           .attr('x', d => {
-            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
             const offSet = isDayRangeType ? 18 : 25;
 
             return this._getXScaleValue(currentDate) - offSet;
@@ -344,7 +344,7 @@ class TimeBasedLineChart extends React.Component {
             .attr('class', 'mx-time-based-line-chart-break-point-date')
             .attr('x', d => {
               const offSet = isDayRangeType ? 18 : 22;
-              const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+              const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
               return this._getXScaleValue(currentDate) - offSet;
             })
@@ -357,7 +357,7 @@ class TimeBasedLineChart extends React.Component {
             })
             .text(d => {
               const dateFormat = isDayRangeType ? 'MMM D' : 'MMMM';
-              const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+              const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
               return moment.unix(currentDate).format(dateFormat);
             });
@@ -367,13 +367,13 @@ class TimeBasedLineChart extends React.Component {
         newBreakPoint.append('line')
           .attr('class', 'mx-time-based-line-chart-break-point-line')
           .attr('x1', d => {
-            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
             return this._getXScaleValue(currentDate);
           })
           .attr('y1', -10)
           .attr('x2', d => {
-            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+            const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
             return this._getXScaleValue(currentDate);
           })
@@ -401,7 +401,7 @@ class TimeBasedLineChart extends React.Component {
       newDots.append('circle')
         .attr('class', 'mx-time-based-line-chart-dot')
         .attr('cx', d => {
-          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
           return this._getXScaleValue(currentDate);
         })
@@ -437,7 +437,7 @@ class TimeBasedLineChart extends React.Component {
       newSlices.append('rect')
         .attr('class', 'slice')
         .attr('x', d => {
-          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix()
+          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
 
           return this._getXScaleValue(currentDate) - this._getSliceMiddle();
         })
@@ -492,11 +492,7 @@ class TimeBasedLineChart extends React.Component {
     const left = isAfterBreakPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 3;
     const right = isAfterBreakPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 3 - xScale : 'auto';
     const textAlign = isAfterBreakPoint ? 'right' : 'left';
-    let top = this._getYScaleValue(d.value) - 5;
-
-    if (this.props.children) {
-      top = top + this.props.margin.top;
-    }
+    const top = this.props.children ? this._getYScaleValue(d.value) - 5 + this.props.margin.top : this._getYScaleValue(d.value) - 5;
 
     const position = {
       left,
@@ -658,7 +654,7 @@ class TimeBasedLineChart extends React.Component {
       </div>
     );
   }
-};
+}
 
 const styles = {
   component: {
@@ -708,8 +704,8 @@ const styles = {
 };
 
 TimeBasedLineChart.propTypes = {
-  areaBelowZeroColor: React.PropTypes.string,
   alwaysShowZeroYTick: React.PropTypes.bool,
+  areaBelowZeroColor: React.PropTypes.string,
   breakPointDate: React.PropTypes.number,
   breakPointLabel: React.PropTypes.string,
   children: React.PropTypes.node,
@@ -729,8 +725,8 @@ TimeBasedLineChart.propTypes = {
 };
 
 TimeBasedLineChart.defaultProps = {
-  areaBelowZeroColor: StyleConstants.Colors.RED,
   alwaysShowZeroYTick: false,
+  areaBelowZeroColor: StyleConstants.Colors.RED,
   breakPointDate: moment().startOf('day').unix(),
   breakPointLabel: 'Today',
   dashedFutureLine: true,

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -1,0 +1,754 @@
+const React = require('react');
+const ReactDom = require('react-dom');
+const Radium = require('radium');
+
+const d3 = require('d3');
+const moment = require('moment');
+const numeral = require('numeral');
+
+const StyleConstants = require('../constants/Style');
+
+class TimeBasedLineChart extends React.Component {
+  constructor (props) {
+    super(props);
+
+    const adjustedWidth = this.props.width - this.props.margin.right - this.props.margin.left;
+    const adjustedHeight = this.props.height - this.props.margin.top - this.props.margin.bottom;
+
+    this.state = {
+      adjustedHeight,
+      adjustedWidth
+    };
+  }
+
+  componentDidMount () {
+    this.setState({
+      chartEl: ReactDom.findDOMNode(this.refs.chart)
+    });
+  }
+
+  componentWillReceiveProps (newProps) {
+    if (newProps.height !== null || newProps.width !== null || newProps.margin !== null) {
+      const height = newProps.height || this.props.height;
+      const width = newProps.width || this.props.width;
+      const margin = newProps.margin || this.props.margin;
+
+      const adjustedWidth = width - margin.right - margin.left;
+      const adjustedHeight = height - margin.top - margin.bottom;
+
+      this.setState({
+        adjustedHeight,
+        adjustedWidth
+      });
+    }
+  }
+
+  _getAreaBelowZero (data) {
+    const area = d3.svg.area()
+      .x(d => {
+        const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+        return this._getXScaleValue(currentDate);
+      })
+      .y0(this.state.adjustedHeight - 10)
+      .y1(this._getYScaleValue(0));
+
+    return area(data);
+  }
+
+  _getFlatLine (data) {
+    const flatLine = d3.svg.line()
+      .x(d => {
+        const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+        return this._getXScaleValue(currentDate);
+      })
+      .y(this.state.adjustedHeight);
+
+    return flatLine(data);
+  }
+
+  _getLine (data) {
+    const line = d3.svg.line()
+      .x(d => {
+        const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+        return this._getXScaleValue(currentDate);
+      })
+      .y(d => {
+        return this._getYScaleValue(d.value);
+      });
+
+    return line(data);
+  }
+
+  _getSliceMiddle (timeStamp) {
+    return Math.floor(this._getSliceWidth(timeStamp) / 2);
+  }
+
+  _getSliceWidth (timeStamp) {
+    const rangeType = this.props.rangeType === 'year' ? 'month' : 'day';
+    const startOf = timeStamp ? moment.unix(timeStamp).startOf(rangeType).unix() : moment(timeStamp).startOf(rangeType).unix();
+    const endOf = timeStamp ? moment.unix(timeStamp).endOf(rangeType).unix() : moment(timeStamp).endOf(rangeType).unix();
+
+    return Math.floor(this._getXScaleValue(endOf) - this._getXScaleValue(startOf));
+  }
+
+  _getSplitData () {
+    const future = [];
+    const past = [];
+
+    this.props.data.forEach(item => {
+      const currentDate = moment.unix(item.timeStamp).startOf('day');
+
+      if (currentDate.isBefore(moment.unix(this.props.breakPointDate), 'day')) {
+        past.push(item);
+      }
+
+      if (currentDate.isAfter(moment.unix(this.props.breakPointDate), 'day')) {
+        future.push(item);
+      }
+
+      if (currentDate.isSame(moment.unix(this.props.breakPointDate), 'day')) {
+        past.push(item);
+        future.push(item);
+      }
+    });
+
+    return [past, future];
+  }
+
+  _getYAxisTicks (data, numTicks = 4) {
+    const maxValue = d3.max(this.props.data, d => {
+      const value = d.above ? d.value + d.above : d.value + 1000;
+      const multiplier = value < 0 ? -1000 : 1000;
+
+      return Math.ceil(value / multiplier) * multiplier;
+    });
+
+    let minValue = d3.min(this.props.data, d => {
+      const value = d.below ? d.value + d.below : d.value - 1000;
+      const multiplier = value < 0 ? -1000 : 1000;
+
+      return Math.ceil(value / multiplier) * multiplier;
+    });
+
+    minValue = minValue > 0 ? 0 : minValue;
+
+    const ticks = [maxValue, minValue];
+    const interval = (maxValue - minValue) / numTicks;
+
+    for (let current = minValue; current < maxValue; current += interval) {
+      ticks.push(current);
+    }
+
+    if (this.props.alwaysShowZeroYTick) {
+      if (ticks.indexOf(0) === -1) {
+        ticks.push(0);
+      }
+    }
+
+    return ticks;
+  }
+
+  _getXScaleFunction () {
+    let maxDate = this.props.data[this.props.data.length - 1].timeStamp;
+    let minDate = this.props.data[0].timeStamp;
+
+    maxDate = moment.unix(maxDate).endOf('day').unix();
+    minDate = moment.unix(minDate).startOf('day').unix();
+
+    return d3.time.scale()
+      .range([0, this.state.adjustedWidth])
+      .domain([minDate, maxDate]);
+  }
+
+  _getXScaleValue (value) {
+    const xScale = this._getXScaleFunction();
+
+    return xScale(value);
+  }
+
+  _getYScaleFunction () {
+    const maxValue = d3.max(this.props.data, d => {
+      const value = d.above ? d.value + d.above : d.value + 1000;
+      const multiplier = value < 0 ? -1000 : 1000;
+
+      return Math.ceil(value / multiplier) * multiplier;
+    });
+
+    let minValue = d3.min(this.props.data, d => {
+      const value = d.below ? d.value + d.below : d.value - 1000;
+      const multiplier = value < 0 ? -1000 : 1000;
+
+      return Math.ceil(value / multiplier) * multiplier;
+    });
+
+    minValue = minValue > 0 ? 0 : minValue;
+
+    return d3.scale.linear()
+      .range([this.state.adjustedHeight, 0])
+      .domain([minValue, maxValue]);
+  }
+
+  _getYScaleValue (value) {
+    const yScale = this._getYScaleFunction();
+
+    return yScale(value) - 10;
+  }
+
+  _renderChart () {
+    const data = this.props.data;
+
+    this._renderChartBase();
+
+    if (data.length > 0) {
+      this._renderLineChart();
+    }
+  }
+
+  _renderChartBase () {
+    const margin = this.props.margin;
+    const width = this.props.width;
+    const height = this.props.height;
+    const chart = d3.select(this.state.chartEl);
+    const data = this.props.data;
+
+    chart.style(styles.svg);
+
+    chart.selectAll('g').remove();
+
+    chart.attr('width', width)
+      .attr('height', height);
+
+    if (data.length > 0) {
+      chart.append('g')
+        .attr('class', 'x-axis')
+        .attr('transform', 'translate(' + margin.left + ',' + (height - margin.bottom) + ')');
+
+      chart.append('g')
+        .attr('class', 'y-axis')
+        .attr('transform', 'translate(' + (margin.left + 30) + ',' + (margin.top - 10) + ')');
+
+      chart.append('g')
+        .attr('class', 'grid-line')
+        .attr('transform', 'translate(' + (margin.left - 10) + ',' + (margin.top - 10) + ')');
+    } else {
+      chart.append('g')
+        .append('text')
+          .attr('transform', 'translate(' + ((width / 2) - 37) + ',' + (height / 2.5) + ')')
+          .text('No data found.');
+    }
+
+    chart.on('mouseleave', this._hideTooltip.bind(this));
+  }
+
+  _renderLineChart () {
+    const chart = d3.select(this.state.chartEl);
+    const data = this._getSplitData();
+    const yTicks = this._getYAxisTicks(this.props.data);
+
+    //Draw the xAxis labels
+    const xAxis = d3.svg.axis()
+      .scale(this._getXScaleFunction())
+      .orient('bottom')
+      .tickFormat(d => {
+        return moment.unix(d).format('MMM D');
+      })
+      .ticks(8);
+
+    //Draw the yAxis labels
+    const yAxis = d3.svg.axis()
+      .scale(this._getYScaleFunction())
+      .orient('left')
+      .tickValues(yTicks)
+      .tickFormat(this.props.yAxisFormatter);
+
+    //Draw the horizontal grid lines
+    const yGrid = d3.svg.axis()
+      .scale(this._getYScaleFunction())
+      .orient('left')
+      .tickValues(yTicks)
+      .tickSize(-this.state.adjustedWidth, 0, 0)
+      .tickFormat('');
+
+    //Add the groups
+    data.forEach((dataSet, i) => {
+      const color = this.props.lineColor;
+      const breakPointDate = moment.unix(this.props.breakPointDate);
+      const isMonthRangeType = this.props.rangeType === 'month';
+      const isPast = i === 0;
+
+      const group = chart.append('g')
+        .attr('class', 'group')
+        .attr('transform', 'translate(' + this.props.margin.left + ',' + this.props.margin.top + ')');
+
+      //Lines ================================
+      const dash = !isPast && this.props.dashedFutureLine ? '2, 2' : 'none';
+
+      const lineGroup = group.append('g')
+        .attr('class', 'line-group');
+
+      lineGroup.append('svg:path')
+        .attr('class', 'mx-time-based-line-chart-line')
+        .attr('stroke', color)
+        .attr('stroke-width', '2px')
+        .attr('stroke-dasharray', dash)
+        .attr('fill', 'none')
+        .attr('d', this._getLine(dataSet));
+
+      //Area Below 0 ================
+      if (this.props.shadeAreaBelowZero) {
+        const belowZeroGroup = lineGroup.append('g')
+          .attr('class', 'above-area-group');
+
+        belowZeroGroup.append('svg:path')
+          .attr('class', 'mx-time-based-line-chart-below-zero-area')
+          .attr('stroke-width', '0')
+          .attr('fill', this.props.areaBelowZeroColor)
+          .attr('opacity', '0.1')
+          .attr('d', this._getAreaBelowZero(dataSet));
+      }
+
+      //Break Point date, line, and label ===========
+      if (this.props.showBreakPoint) {
+        const breakPointGroup = lineGroup.append('g')
+          .attr('class', 'break-point-group');
+
+        const breakPoint = breakPointGroup.selectAll('.break-point-group')
+          .data(dataSet);
+
+        const newBreakPoint = breakPoint.enter();
+
+        //Break point label
+        newBreakPoint.append('text')
+          .attr('class', 'mx-time-based-line-chart-break-point-label')
+          .attr('x', d => {
+            const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+            const offSet = isMonthRangeType ? 18 : 25;
+
+            return this._getXScaleValue(currentDate) - offSet;
+          })
+          .attr('y', -18)
+          .attr('opacity', d => {
+            const currentDate = moment.unix(d.timeStamp).format('YYYY MM DD');
+            const isSameDateAsBreakPoint = currentDate === breakPointDate.format('YYYY MM DD');
+
+            return isSameDateAsBreakPoint && i === 1 ? '1' : '0';
+          })
+          .text(this.props.breakPointLabel);
+
+        if (!this.props.staticXAxis) {
+          //Break point date
+          newBreakPoint.append('text')
+            .attr('class', 'mx-time-based-line-chart-break-point-date')
+            .attr('x', d => {
+              const offSet = isMonthRangeType ? 18 : 22;
+              const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+              return this._getXScaleValue(currentDate) - offSet;
+            })
+            .attr('y', this.state.adjustedHeight + 20)
+            .attr('opacity', d => {
+              const currentDate = moment.unix(d.timeStamp).format('YYYY MM DD');
+              const isSameDateAsBreakPoint = currentDate === breakPointDate.format('YYYY MM DD');
+
+              return isSameDateAsBreakPoint && i === 1 ? '1' : '0';
+            })
+            .text(d => {
+              const dateFormat = isMonthRangeType ? 'MMM D' : 'MMMM';
+              const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+              return moment.unix(currentDate).format(dateFormat);
+            });
+        }
+
+        //Break point line
+        newBreakPoint.append('line')
+          .attr('class', 'mx-time-based-line-chart-break-point-line')
+          .attr('x1', d => {
+            const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+            return this._getXScaleValue(currentDate);
+          })
+          .attr('y1', -10)
+          .attr('x2', d => {
+            const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+            return this._getXScaleValue(currentDate);
+          })
+          .attr('y2', this.state.adjustedHeight - 10)
+          .style('stroke-width', 1)
+          .style('stroke', '#555')
+          .style('fill', 'none')
+          .style('opacity', d => {
+            const currentDate = moment.unix(d.timeStamp).format('YYYY MM DD');
+            const isSameDateAsBreakPoint = currentDate === breakPointDate.format('YYYY MM DD');
+
+            return isSameDateAsBreakPoint && !isPast ? '0.2' : '0';
+          });
+      }
+
+      //Dots =================================
+      const dotGroup = lineGroup.append('g')
+        .attr('class', 'dot-group');
+
+      const dots = dotGroup.selectAll('.dot')
+        .data(dataSet);
+
+      const newDots = dots.enter();
+
+      newDots.append('circle')
+        .attr('class', 'mx-time-based-line-chart-dot')
+        .attr('cx', d => {
+          const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+          return this._getXScaleValue(currentDate);
+        })
+        .attr('cy', d => {
+          return this._getYScaleValue(d.value);
+        })
+        .attr('r', 3)
+        .attr('opacity', (d, j) => {
+          const currentDate = moment.unix(d.timeStamp);
+          const isBreakPointDate = currentDate.format('YYYY MM DD') === breakPointDate.format('YYYY MM D');
+          const isStartOfSet = j === 0;
+          const isEndOfSet = j === (dataSet.length - 1);
+
+          if ((isStartOfSet && isPast) || (isBreakPointDate && this.props.showBreakPoint && !isPast) || (isEndOfSet && !isPast)) {
+            return '1';
+          }
+
+          return '0';
+        })
+        .style('fill', '#fff')
+        .style('stroke', color)
+        .style('stroke-width', '2px');
+
+      //Slice ================================
+      const sliceGroup = lineGroup.append('g')
+        .attr('class', 'slice-group');
+
+      const slices = sliceGroup.selectAll('.slice-group')
+        .data(dataSet);
+
+      const newSlices = slices.enter();
+
+      newSlices.append('rect')
+        .attr('class', 'slice')
+        .attr('x', d => {
+          const currentDate = moment.unix(d.timeStamp).startOf('day').unix()
+
+          return this._getXScaleValue(currentDate) - this._getSliceMiddle();
+        })
+        .attr('y', -10)
+        .attr('height', this.state.adjustedHeight)
+        .attr('width', d => {
+          const currentDate = moment.unix(d.timeStamp).startOf('day').unix();
+
+          return this._getSliceWidth(currentDate);
+        })
+        .style('opacity', '0')
+        .style('display', d => {
+          const currentDate = moment.unix(d.timeStamp);
+          const isBreakPointDate = currentDate.format('YYYY MM DD') === breakPointDate.format('YYYY MM D');
+
+          return isPast && isBreakPointDate ? 'none' : 'block';
+        })
+        .on('mouseover', this._showTooltip.bind(this));
+    });
+
+    //Update the axes
+    chart.selectAll('g.grid-line').call(yGrid);
+    chart.select('g.y-axis').call(yAxis);
+
+    if (this.props.staticXAxis) {
+      chart.select('g.x-axis').call(xAxis);
+    }
+
+    //Style xAxis labels
+    chart.select('g.x-axis').selectAll('text')
+      .style('text-anchor', () => {
+        return 'middle';
+      });
+
+    chart.select('g.y-axis').selectAll('text')
+      .style('text-anchor', 'start')
+      .attr('transform', 'translate(-60, 0)');
+
+    //Style rest of chart elements
+    chart.selectAll('text').style(styles.text);
+    chart.selectAll('.domain').style(styles.domain);
+    chart.selectAll('.grid-line .tick').style(styles.gridLineTick);
+  }
+
+  _showTooltip (d) {
+    const breakPointDate = moment.unix(this.props.breakPointDate);
+    const currentDate = moment.unix(d.timeStamp).startOf('day');
+    const isAfterBreakPoint = currentDate.isAfter(breakPointDate);
+    const isMonthRangeType = this.props.rangeType === 'month';
+    const sliceWidth = this._getSliceWidth(currentDate.unix());
+    const xScale = this._getXScaleValue(currentDate.unix());
+
+    const left = isAfterBreakPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 3;
+    const right = isAfterBreakPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 3 - xScale : 'auto';
+    const textAlign = isAfterBreakPoint ? 'right' : 'left';
+    let top = this._getYScaleValue(d.value) - 5;
+
+    if (this.props.children) {
+      top = top + this.props.margin.top;
+    }
+
+    const position = {
+      left,
+      right,
+      textAlign,
+      top
+    };
+
+    this.setState({
+      hoveredData: d,
+      tooltipPosition: position
+    });
+
+    this.props.hoverCallBack(d);
+  }
+
+  _hideTooltip () {
+    this.setState({
+      hoveredData: false,
+      tooltipPosition: false
+    });
+
+    this._removeSvgTooltipComponents();
+  }
+
+  _removeSvgTooltipComponents () {
+    const dots = d3.select(this.state.chartEl).selectAll('.dot-group');
+    const slices = d3.select(this.state.chartEl).selectAll('.slice-group');
+
+    slices.selectAll('.mx-time-based-line-chart-hover-rectangle').remove();
+    dots.selectAll('.mx-time-based-line-chart-hover-above').remove();
+    dots.selectAll('.mx-time-based-line-chart-hover-below').remove();
+    dots.selectAll('.mx-time-based-line-chart-hover-dot').remove();
+  }
+
+  _renderSvgTooltipComponents () {
+    const hoveredData = this.state.hoveredData;
+
+    const breakPointDate = moment.unix(this.props.breakPointDate);
+    const currentDate = moment.unix(hoveredData.timeStamp).startOf('day');
+
+    const dash = currentDate.isAfter(breakPointDate) && this.props.dashedFutureLine ? '2, 2' : 'none';
+    const isBreakPointDate = currentDate.format('MM DD YYYY') === breakPointDate.format('MM DD YYYY');
+    const isMonthRangeType = this.props.rangeType === 'month';
+    const dateFormat = isMonthRangeType ? 'MM/DD' : 'MMM';
+
+    const dots = d3.select(this.state.chartEl).selectAll('.dot-group');
+    const slices = d3.select(this.state.chartEl).selectAll('.slice-group');
+
+    //Gray rectangle highlighting hovered section
+    slices.append('rect')
+      .attr('class', 'mx-time-based-line-chart-hover-rectangle')
+      .attr('x', () => {
+        return this._getXScaleValue(currentDate.unix()) - this._getSliceMiddle();
+      })
+      .attr('y', -10)
+      .attr('height', this.state.adjustedHeight)
+      .attr('width', () => {
+        return this._getSliceWidth(currentDate.unix());
+      })
+      .style('opacity', '0.025');
+
+    if (!this.props.staticXAxis) {
+      //Date Text
+      slices.append('text')
+        .attr('x', () => {
+          return this._getXScaleValue(currentDate.unix()) - this._getSliceMiddle() - 4;
+        })
+        .attr('y', this.state.adjustedHeight + 5)
+        .style('font-size', '10')
+        .style('opacity', '0.3')
+        .text(() => {
+          return isBreakPointDate ? null : currentDate.format(dateFormat);
+        });
+    }
+
+    //Credit balance line
+    if (hoveredData.above) {
+      dots.append('line')
+        .attr('class', 'mx-time-based-line-chart-hover-above')
+        .attr('x1', this._getXScaleValue(currentDate.unix()))
+        .attr('y1', this._getYScaleValue(hoveredData.value + hoveredData.above))
+        .attr('x2', this._getXScaleValue(currentDate.unix()))
+        .attr('y2', this._getYScaleValue(hoveredData.value))
+        .style('stroke-dasharray', dash)
+        .style('stroke-width', 3)
+        .style('stroke', '#30B53C')
+        .style('fill', 'none');
+    }
+
+    //Debit balance line
+    if (hoveredData.below) {
+      const below = hoveredData.value + hoveredData.below;
+      const belowValue = below < -4000 ? below + 500 : below;
+
+      dots.append('line')
+        .attr('class', 'mx-time-based-line-chart-hover-below')
+        .attr('x1', this._getXScaleValue(currentDate.unix()))
+        .attr('y1', this._getYScaleValue(hoveredData.value))
+        .attr('x2', this._getXScaleValue(currentDate.unix()))
+        .attr('y2', this._getYScaleValue(belowValue))
+        .style('stroke-dasharray', dash)
+        .style('stroke-width', 3)
+        .style('stroke', '#C93030')
+        .style('fill', 'none');
+    }
+
+    //Circle on line
+    dots.append('circle')
+      .attr('class', 'mx-time-based-line-chart-hover-dot')
+      .attr('cx', this._getXScaleValue(currentDate.unix()))
+      .attr('cy', this._getYScaleValue(hoveredData.value))
+      .attr('r', 3)
+      .style('fill', '#fff')
+      .style('stroke', this.props.lineColor)
+      .style('stroke-width', '2px');
+  }
+
+  _renderTooltip () {
+    if (this.props.showTooltips && this.state.tooltipPosition) {
+      const hoveredData = this.state.hoveredData;
+      const position = this.state.tooltipPosition;
+
+      this._renderSvgTooltipComponents();
+
+      if (this.props.children) {
+        return (
+          <div className='mx-time-based-line-chart-tool-tip-wrapper' style={[styles.tooltipWrapper, position]}>
+            {this.props.children}
+          </div>
+        );
+      }
+
+      return (
+        <div style={[styles.tooltipWrapper, position]}>
+          <div style={[styles.tooltip, styles.credit]}>
+            {numeral(hoveredData.above).format('$0,0')} Income
+          </div>
+          <br/>
+          <div style={[styles.tooltip, { backgroundColor: this.props.lineColor }]}>
+            {numeral(hoveredData.value).format('$0,0')} Cash Balance
+          </div>
+          <br/>
+          <div style={[styles.tooltip, styles.debit]}>
+            {numeral(hoveredData.below).format('$0,0')} Expenses
+          </div>
+        </div>
+      );
+    }
+  }
+
+  render () {
+    this._renderChart();
+
+    return (
+      <div className='mx-time-based-line-chart' style={[styles.component, { height: this.props.height + 'px', width: this.props.width + 'px' }]}>
+        {this._renderTooltip()}
+        <svg className='mx-time-based-line-chart-svg' ref='chart' />
+      </div>
+    );
+  }
+};
+
+const styles = {
+  component: {
+    fontFamily: StyleConstants.FontFamily,
+    padding: '10px',
+    position: 'relative'
+  },
+  credit: {
+    backgroundColor: '#30B53C'
+  },
+  debit: {
+    backgroundColor: '#C93030'
+  },
+  domain: {
+    opacity: 0
+  },
+  gridLineTick: {
+    'stroke': '#ccc',
+    'opacity': 1,
+    'stroke-width': '0.5px'
+  },
+  svg: {
+    'display': 'block',
+    'height': '100%',
+    'position': 'relative',
+    'width': '100%'
+  },
+  text: {
+    'fill': '#999',
+    'font-size': '12px',
+    'font-weight': 'normal'
+  },
+  tooltip: {
+    color: '#FFF',
+    display: 'inline-block',
+    fontSize: '11px',
+    marginBottom: '3px',
+    marginTop: '3px',
+    minWidth: '50px',
+    padding: '5px'
+  },
+  tooltipWrapper: {
+    display: 'inline-block',
+    position: 'absolute',
+    zIndex: '1'
+  }
+};
+
+TimeBasedLineChart.propTypes = {
+  areaBelowZeroColor: React.PropTypes.string,
+  alwaysShowZeroYTick: React.PropTypes.bool,
+  breakPointDate: React.PropTypes.number,
+  breakPointLabel: React.PropTypes.string,
+  children: React.PropTypes.node,
+  dashedFutureLine: React.PropTypes.bool,
+  data: React.PropTypes.array,
+  height: React.PropTypes.number,
+  hoverCallBack: React.PropTypes.func,
+  lineColor: React.PropTypes.string,
+  margin: React.PropTypes.object,
+  rangeType: React.PropTypes.string,
+  shadeAreaBelowZero: React.PropTypes.bool,
+  showBreakPoint: React.PropTypes.bool,
+  showTooltips: React.PropTypes.bool,
+  staticXAxis: React.PropTypes.bool,
+  width: React.PropTypes.number,
+  yAxisFormatter: React.PropTypes.func
+};
+
+TimeBasedLineChart.defaultProps = {
+  areaBelowZeroColor: StyleConstants.Colors.RED,
+  alwaysShowZeroYTick: false,
+  breakPointDate: moment().startOf('day').unix(),
+  breakPointLabel: 'Today',
+  dashedFutureLine: true,
+  data: [],
+  height: 400,
+  hoverCallBack: () => {},
+  lineColor: StyleConstants.Colors.PRIMARY,
+  margin: { top: 20, right: 50, bottom: 20, left: 50 },
+  rangeType: 'month',
+  shadeAreaBelowZero: false,
+  showBreakPoint: true,
+  showTooltips: true,
+  staticXAxis: true,
+  width: 550,
+  yAxisFormatter (d) {
+    return numeral(d).format('$0a');
+  }
+};
+
+module.exports = Radium(TimeBasedLineChart);


### PR DESCRIPTION
@bsbeeks @jmophoto

Adds new TimeBasedLineChart component.

To use:
```javascript
const  { TimeBasedLineChart } = require('mx-react-components');
```

```html
<TimeBasedLineChart 
  data={myData}
  hoverCallBack={myHoverCallBackFunction}
>
  <div>
    {Hover data from call back}
  </div>
</TimeBasedLineChart>
```

There are no required props for this component to work but the prop `data` will need to be passed if you want the graph to draw.

The data prop should be formatted as follows:

```javascript
data = [
  {
    timeStamp: 14093498, //unix time stamp for data point REQUIRED
    value: 100 //value to be displayed at the corresponding time stamp REQUIRED
  }
];
```

Props Descriptions:

-  areaBelowZeroColor (string, #EE4235): A hex color used to shade the area below zero on the line chart. 

-  alwaysShowZeroYTick (boolean, false): Zero is not always shown as a tick on the y axis.  This forces it to be drawn if it does not exist.

-  breakPointDate (unix time stamp, today's date): The location on the chart to draw the break point line and associated label

-  breakPointLabel (string, Today): The label to be drawn above the break point line on the chart.

-  children (node, null): Any child DOM elements added to the component at time of use.

-  dashedFutureLine (boolean, true): Will draw the part of the line on the graph that is in the future as a dashed line.

-  data (array, []): An array of data point objects used to draw the graph.

-  height (number, 400): The height of the graph.

-  hoverCallBack (function, () => {}): The function that is used as a means of returning the hover state to the user of the component.

-  lineColor (string, #359BCF): The color used to draw the line.

-  margin (object, { top: 20, right: 50, bottom: 20, left: 50 }): The margins used for the graph.

-  rangeType (string, day): The chart is set to render data points as days by default but you can have it render data points as months if you switch rangeType to month.

-  shadeAreaBelowZero (boolean, false): Shade the area below zero on the graph.

-  showBreakPoint (boolean, true): Hide or show the break point and it's label on the graph.

-  showTooltips (boolean, true): Hide or show tool tips on hover over data points in the graph.

-  staticXAxis (boolean, true): Makes the x axis ticks on the graph be created and drawn as static.  If set to false then the labels for the x axis are hidden until you hover over a data point on the graph.

-  width (number, 550): The width of the graph.

-  yAxisFormatter (function, (value) => {return numeral(value).format('0a')}): A function used to format y axis ticks on the graph.

Built in classes for styling:
mx-time-based-line-chart-below-zero-area: The shaded area below zero on chart
mx-time-based-line-chart-break-point-date: The break point date
mx-time-based-line-chart-break-point-label: The break point label
mx-time-based-line-chart-break-point-line: The break point line
mx-time-based-line-chart-dot: Static dots on the line
mx-time-based-line-chart-hover-dot: The dot drawn above a data point on hover
mx-time-based-line-chart-hover-rectangle: The grey rectangle shown for a data point on hover
mx-time-based-line-chart-line: Chart line
mx-time-based-line-chart-svg: Chart svg
mx-time-based-line-chart-tool-tip-wrapper: Tooltip div wrapper
mx-time-based-line-chart: Chart div wrapper

![screen shot 2015-10-22 at 12 14 49 pm](https://cloud.githubusercontent.com/assets/6463914/10674109/8adbc3c4-78b6-11e5-914f-9869945c2b53.png)

