### PR TITLE
Allow users to set a specific lower bound (positive or negative) for the RangeSelector component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -435,7 +435,8 @@ const Demo = React.createClass({
               label: 'Silent'
             }
           ]}
-          range={100}
+          lowerBound={-25}
+          upperBound={100}
           selectedColor='#359BCF'
         />
 


### PR DESCRIPTION
This will introduce a breaking change into the RangeSelector component.

- rename `range` to `upperBound`. Functionality is the same (breaking change)
- add new `lowerBound` prop. This will determine the lowest value possible on the track. It can be positive or negative
- added some comments to help other follow the logic

@jmophoto @cerinman 