### PR TITLE
Fix 'month' range type issues and sort out magic numbers for margin spacings

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -278,6 +278,189 @@ const icons = [
   }
 ];
 
+const lineChartData = {
+  day: [
+    {
+      timeStamp: moment().subtract(15, 'days').startOf('day').unix(),
+      value: 800
+    },
+    {
+      timeStamp: moment().subtract(14, 'days').startOf('day').unix(),
+      value: 900
+    },
+    {
+      timeStamp: moment().subtract(13, 'days').startOf('day').unix(),
+      value: 1200
+    },
+    {
+      timeStamp: moment().subtract(12, 'days').startOf('day').unix(),
+      value: 850
+    },
+    {
+      timeStamp: moment().subtract(11, 'days').startOf('day').unix(),
+      value: 660
+    },
+    {
+      timeStamp: moment().subtract(10, 'days').startOf('day').unix(),
+      value: 720
+    },
+    {
+      timeStamp: moment().subtract(9, 'days').startOf('day').unix(),
+      value: 900
+    },
+    {
+      timeStamp: moment().subtract(8, 'days').startOf('day').unix(),
+      value: 700
+    },
+    {
+      timeStamp: moment().subtract(7, 'days').startOf('day').unix(),
+      value: 600
+    },
+    {
+      timeStamp: moment().subtract(6, 'days').startOf('day').unix(),
+      value: 1200
+    },
+    {
+      timeStamp: moment().subtract(5, 'days').startOf('day').unix(),
+      value: 900
+    },
+    {
+      timeStamp: moment().subtract(4, 'days').startOf('day').unix(),
+      value: 800
+    },
+    {
+      timeStamp: moment().subtract(3, 'days').startOf('day').unix(),
+      value: 600
+    },
+    {
+      timeStamp: moment().subtract(2, 'days').startOf('day').unix(),
+      value: 1600
+    },
+    {
+      timeStamp: moment().subtract(1, 'days').startOf('day').unix(),
+      value: 1700
+    },
+    {
+      timeStamp: moment().startOf('day').unix(),
+      value: 1400
+    },
+    {
+      timeStamp: moment().add(1, 'days').startOf('day').unix(),
+      value: 1200
+    },
+    {
+      timeStamp: moment().add(2, 'days').startOf('day').unix(),
+      value: 1200
+    },
+    {
+      timeStamp: moment().add(3, 'days').startOf('day').unix(),
+      value: 1700
+    },
+    {
+      timeStamp: moment().add(4, 'days').startOf('day').unix(),
+      value: 1100
+    },
+    {
+      timeStamp: moment().add(5, 'days').startOf('day').unix(),
+      value: 1000
+    },
+    {
+      timeStamp: moment().add(6, 'days').startOf('day').unix(),
+      value: 900
+    },
+    {
+      timeStamp: moment().add(7, 'days').startOf('day').unix(),
+      value: 1000
+    },
+    {
+      timeStamp: moment().add(8, 'days').startOf('day').unix(),
+      value: 850
+    },
+    {
+      timeStamp: moment().add(9, 'days').startOf('day').unix(),
+      value: 1500
+    },
+    {
+      timeStamp: moment().add(10, 'days').startOf('day').unix(),
+      value: 1100
+    },
+    {
+      timeStamp: moment().add(11, 'days').startOf('day').unix(),
+      value: 1000
+    },
+    {
+      timeStamp: moment().add(12, 'days').startOf('day').unix(),
+      value: 800
+    },
+    {
+      timeStamp: moment().add(13, 'days').startOf('day').unix(),
+      value: 1100
+    },
+    {
+      timeStamp: moment().add(14, 'days').startOf('day').unix(),
+      value: 1300
+    },
+    {
+      timeStamp: moment().add(15, 'days').startOf('day').unix(),
+      value: 2200
+    }
+  ],
+  month: [
+    {
+      timeStamp: moment().subtract(6, 'months').startOf('month').unix(),
+      value: 800
+    },
+    {
+      timeStamp: moment().subtract(5, 'months').startOf('month').unix(),
+      value: 600
+    },
+    {
+      timeStamp: moment().subtract(4, 'months').startOf('month').unix(),
+      value: 600
+    },
+    {
+      timeStamp: moment().subtract(3, 'months').startOf('month').unix(),
+      value: 600
+    },
+    {
+      timeStamp: moment().subtract(2, 'months').startOf('month').unix(),
+      value: 1600
+    },
+    {
+      timeStamp: moment().subtract(1, 'months').startOf('month').unix(),
+      value: 1700
+    },
+    {
+      timeStamp: moment().startOf('month').unix(),
+      value: 1400
+    },
+    {
+      timeStamp: moment().add(1, 'months').startOf('month').unix(),
+      value: 1200
+    },
+    {
+      timeStamp: moment().add(2, 'months').startOf('month').unix(),
+      value: 1200
+    },
+    {
+      timeStamp: moment().add(3, 'months').startOf('month').unix(),
+      value: 1700
+    },
+    {
+      timeStamp: moment().add(4, 'months').startOf('month').unix(),
+      value: 1100
+    },
+    {
+      timeStamp: moment().add(5, 'months').startOf('month').unix(),
+      value: 1000
+    },
+    {
+      timeStamp: moment().add(6, 'months').startOf('month').unix(),
+      value: 900
+    }
+  ]
+};
+
 const Demo = React.createClass({
   getInitialState () {
     return {
@@ -316,6 +499,8 @@ const Demo = React.createClass({
   },
 
   render () {
+    const dataType = 'day';
+
     return (
       <div>
         <br/><br/>
@@ -359,138 +544,15 @@ const Demo = React.createClass({
 
         <br/><br/>
         <TimeBasedLineChart
-          breakPointDate={moment().startOf('day').unix()}
-          breakPointLabel='Today'
-          data={[
-            {
-              timeStamp: moment().subtract(15, 'days').unix(),
-              value: 2000
-            },
-            {
-              timeStamp: moment().subtract(14, 'days').unix(),
-              value: 1900
-            },
-            {
-              timeStamp: moment().subtract(13, 'days').unix(),
-              value: 1850
-            },
-            {
-              timeStamp: moment().subtract(12, 'days').unix(),
-              value: 1550
-            },
-            {
-              timeStamp: moment().subtract(11, 'days').unix(),
-              value: 1500
-            },
-            {
-              timeStamp: moment().subtract(10, 'days').unix(),
-              value: 1000
-            },
-            {
-              timeStamp: moment().subtract(9, 'days').unix(),
-              value: 900
-            },
-            {
-              timeStamp: moment().subtract(8, 'days').unix(),
-              value: 900
-            },
-            {
-              timeStamp: moment().subtract(7, 'days').unix(),
-              value: 900
-            },
-            {
-              timeStamp: moment().subtract(6, 'days').unix(),
-              value: 800
-            },
-            {
-              timeStamp: moment().subtract(5, 'days').unix(),
-              value: 600
-            },
-            {
-              timeStamp: moment().subtract(4, 'days').unix(),
-              value: 600
-            },
-            {
-              timeStamp: moment().subtract(3, 'days').unix(),
-              value: 600
-            },
-            {
-              timeStamp: moment().subtract(2, 'days').unix(),
-              value: 1600
-            },
-            {
-              timeStamp: moment().subtract(1, 'days').unix(),
-              value: 1700
-            },
-            {
-              timeStamp: moment().unix(),
-              value: 1400
-            },
-            {
-              timeStamp: moment().add(1, 'days').unix(),
-              value: 1200
-            },
-            {
-              timeStamp: moment().add(2, 'days').unix(),
-              value: 1200
-            },
-            {
-              timeStamp: moment().add(3, 'days').unix(),
-              value: 1700
-            },
-            {
-              timeStamp: moment().add(4, 'days').unix(),
-              value: 1100
-            },
-            {
-              timeStamp: moment().add(5, 'days').unix(),
-              value: 1000
-            },
-            {
-              timeStamp: moment().add(6, 'days').unix(),
-              value: 900
-            },
-            {
-              timeStamp: moment().add(7, 'days').unix(),
-              value: 500
-            },
-            {
-              timeStamp: moment().add(8, 'days').unix(),
-              value: 300
-            },
-            {
-              timeStamp: moment().add(9, 'days').unix(),
-              value: 300
-            },
-            {
-              timeStamp: moment().add(10, 'days').unix(),
-              value: 300
-            },
-            {
-              timeStamp: moment().add(11, 'days').unix(),
-              value: 1700
-            },
-            {
-              timeStamp: moment().add(12, 'days').unix(),
-              value: 1700
-            },
-            {
-              timeStamp: moment().add(13, 'days').unix(),
-              value: 1700
-            },
-            {
-              timeStamp: moment().add(14, 'days').unix(),
-              value: 1300
-            },
-            {
-              timeStamp: moment().add(15, 'days').unix(),
-              value: 900
-            },
-          ]}
+          breakPointDate={moment().startOf(dataType).unix()}
+          breakPointLabel={dataType == 'day' ? 'Today' : 'This Month'}
+          data={lineChartData[dataType]}
           height={400}
           hoverCallBack={this._handleLineChartHover}
-          margin={{ top: 30, right: 50, bottom: 20, left: 50 }}
+          margin={{ top: 30, right: 75, bottom: 30, left: 75 }}
+          rangeType={dataType}
           shadeAreaBelowZero={true}
+          staticXAxis={false}
           width={700}
         >
           <div style={{ backgroundColor: '#999', color: '#fff', padding: '5px' }}>

--- a/demo/app.js
+++ b/demo/app.js
@@ -552,7 +552,6 @@ const Demo = React.createClass({
           margin={{ top: 30, right: 75, bottom: 30, left: 75 }}
           rangeType={dataType}
           shadeAreaBelowZero={true}
-          staticXAxis={false}
           width={700}
         >
           <div style={{ backgroundColor: '#999', color: '#fff', padding: '5px' }}>

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -205,7 +205,6 @@ class TimeBasedLineChart extends React.Component {
 
   _renderChartBase () {
     const margin = this.props.margin;
-    const marginLeftOffSet = Math.floor(this.state.adjustedWidth / this.props.data.length);
     const width = this.props.width;
     const height = this.props.height;
     const chart = d3.select(this.state.chartEl);
@@ -441,9 +440,7 @@ class TimeBasedLineChart extends React.Component {
         })
         .attr('y', -10)
         .attr('height', this.state.adjustedHeight)
-        .attr('width', d => {
-          return this._getSliceWidth();
-        })
+        .attr('width', this._getSliceWidth())
         .style('opacity', '0')
         .style('display', d => {
           const currentDate = moment.unix(d.timeStamp);

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -533,7 +533,7 @@ class TimeBasedLineChart extends React.Component {
     const dash = currentDate.isAfter(breakPointDate) && this.props.dashedFutureLine ? '2, 2' : 'none';
     const isBreakPointDate = currentDate.format('MM DD YYYY') === breakPointDate.format('MM DD YYYY');
     const isDayRangeType = this.props.rangeType === 'day';
-    const dateFormat = isDayRangeType ? 'MM/DD' : 'MMM';
+    const dateFormat = isDayRangeType ? 'MMM D' : 'MMM';
 
     const dots = d3.select(this.state.chartEl).selectAll('.dot-group');
     const slices = d3.select(this.state.chartEl).selectAll('.slice-group');
@@ -553,10 +553,12 @@ class TimeBasedLineChart extends React.Component {
       //Date Text
       slices.append('text')
         .attr('x', () => {
-          return this._getXScaleValue(currentDate.unix()) - this._getSliceMiddle() - 4;
+          const offSet = this.props.rangeType === 'day' ? 17 : 10;
+
+          return this._getXScaleValue(currentDate.unix()) - offSet;
         })
         .attr('y', this.state.adjustedHeight + 5)
-        .style('font-size', '10')
+        .style('font-size', '12')
         .style('opacity', '0.3')
         .text(() => {
           return isBreakPointDate ? null : currentDate.format(dateFormat);

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -82,16 +82,12 @@ class TimeBasedLineChart extends React.Component {
     return line(data);
   }
 
-  _getSliceMiddle (timeStamp) {
-    return Math.floor(this._getSliceWidth(timeStamp) / 2);
+  _getSliceMiddle () {
+    return this._getSliceWidth() / 2;
   }
 
-  _getSliceWidth (timeStamp) {
-    const rangeType = this.props.rangeType;
-    const startOf = timeStamp ? moment.unix(timeStamp).startOf(rangeType).unix() : moment(timeStamp).startOf(rangeType).unix();
-    const endOf = timeStamp ? moment.unix(timeStamp).endOf(rangeType).unix() : moment(timeStamp).endOf(rangeType).unix();
-
-    return Math.floor(this._getXScaleValue(endOf) - this._getXScaleValue(startOf));
+  _getSliceWidth () {
+    return Math.floor(this.state.adjustedWidth / this.props.data.length);
   }
 
   _getSplitData () {
@@ -209,6 +205,7 @@ class TimeBasedLineChart extends React.Component {
 
   _renderChartBase () {
     const margin = this.props.margin;
+    const marginLeftOffSet = Math.floor(this.state.adjustedWidth / this.props.data.length);
     const width = this.props.width;
     const height = this.props.height;
     const chart = d3.select(this.state.chartEl);
@@ -224,15 +221,15 @@ class TimeBasedLineChart extends React.Component {
     if (data.length > 0) {
       chart.append('g')
         .attr('class', 'x-axis')
-        .attr('transform', 'translate(' + margin.left + ',' + (height - margin.bottom) + ')');
+        .attr('transform', 'translate(' + (margin.left - this._getSliceMiddle()) + ',' + (height - margin.bottom) + ')');
 
       chart.append('g')
         .attr('class', 'y-axis')
-        .attr('transform', 'translate(' + (margin.left + 30) + ',' + (margin.top - 10) + ')');
+        .attr('transform', 'translate(' + (margin.left + 20) + ',' + (margin.top - 10) + ')');
 
       chart.append('g')
         .attr('class', 'grid-line')
-        .attr('transform', 'translate(' + (margin.left - 10) + ',' + (margin.top - 10) + ')');
+        .attr('transform', 'translate(' + (margin.left - this._getSliceMiddle()) + ',' + (margin.top - 10) + ')');
     } else {
       chart.append('g')
         .append('text')
@@ -246,6 +243,7 @@ class TimeBasedLineChart extends React.Component {
   _renderLineChart () {
     const chart = d3.select(this.state.chartEl);
     const data = this._getSplitData();
+    const xAxisFormat = this.props.rangeType === 'day' ? 'MMM D' : 'MMM';
     const yTicks = this._getYAxisTicks(this.props.data);
 
     //Draw the xAxis labels
@@ -253,7 +251,7 @@ class TimeBasedLineChart extends React.Component {
       .scale(this._getXScaleFunction())
       .orient('bottom')
       .tickFormat(d => {
-        return moment.unix(d).format('MMM D');
+        return moment.unix(d).format(xAxisFormat);
       })
       .ticks(8);
 
@@ -410,8 +408,8 @@ class TimeBasedLineChart extends React.Component {
         })
         .attr('r', 3)
         .attr('opacity', (d, j) => {
-          const currentDate = moment.unix(d.timeStamp);
-          const isBreakPointDate = currentDate.format('YYYY MM DD') === breakPointDate.format('YYYY MM D');
+          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType);
+          const isBreakPointDate = currentDate.format('YYYY MM DD') === breakPointDate.format('YYYY MM DD');
           const isStartOfSet = j === 0;
           const isEndOfSet = j === (dataSet.length - 1);
 
@@ -444,9 +442,7 @@ class TimeBasedLineChart extends React.Component {
         .attr('y', -10)
         .attr('height', this.state.adjustedHeight)
         .attr('width', d => {
-          const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType).unix();
-
-          return this._getSliceWidth(currentDate);
+          return this._getSliceWidth();
         })
         .style('opacity', '0')
         .style('display', d => {
@@ -486,11 +482,11 @@ class TimeBasedLineChart extends React.Component {
     const breakPointDate = moment.unix(this.props.breakPointDate).startOf(this.props.rangeType);
     const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType);
     const isAfterBreakPoint = currentDate.isAfter(breakPointDate);
-    const sliceWidth = this._getSliceWidth(currentDate.unix());
+    const sliceWidth = this._getSliceMiddle();
     const xScale = this._getXScaleValue(currentDate.unix());
 
-    const left = isAfterBreakPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 3;
-    const right = isAfterBreakPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 3 - xScale : 'auto';
+    const left = isAfterBreakPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 10;
+    const right = isAfterBreakPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 10 - xScale : 'auto';
     const textAlign = isAfterBreakPoint ? 'right' : 'left';
     const top = this.props.children ? this._getYScaleValue(d.value) - 5 + this.props.margin.top : this._getYScaleValue(d.value) - 5;
 
@@ -550,9 +546,7 @@ class TimeBasedLineChart extends React.Component {
       })
       .attr('y', -10)
       .attr('height', this.state.adjustedHeight)
-      .attr('width', () => {
-        return this._getSliceWidth(currentDate.unix());
-      })
+      .attr('width', this._getSliceWidth())
       .style('opacity', '0.025');
 
     if (!this.props.staticXAxis) {


### PR DESCRIPTION
Completes https://github.com/mxenabled/mx-react-components/issues/70

This PR corrects some positioning issues for the y/x axis labels, gridlines, and tool tips pertaining to the `month` range type option for the TimeBasedLineChart component.  It also resolves issue #70 where we wanted to take care of the magic numbers being used to determine the positioning for the above mentioned items.

The x axis labels and the y grid lines now use the getSliceMiddle function for their offset to make sure that they line up correctly with the data points at all times.

The y axis has an offset of 20 and this number is used to position the y axis labels right or left.  Should we want to, we can expose this number as a prop so that the user can position the y axis labels to their liking.  I've left it at 20 for now as it seems to be the sweet spot.  

I've also updated the app.js file to better allow for testing the TimeBasedLineChart with data for both the `day` and `month` range types.

@bsbeeks @jmophoto 

Before this is what the`month` range type looked like.
![screen shot 2015-10-24 at 8 57 51 pm](https://cloud.githubusercontent.com/assets/6463914/10716886/cf9d45d4-7b0c-11e5-979f-d65a64520c53.png)


And here it is after the changes
![screen shot 2015-10-25 at 11 30 58 am](https://cloud.githubusercontent.com/assets/6463914/10716888/e158bb6e-7b0c-11e5-9b8e-b77ba32a340a.png)


And here is proof that we have not caused issues with the `day` range type
![screen shot 2015-10-25 at 11 31 19 am](https://cloud.githubusercontent.com/assets/6463914/10716899/3c947766-7b0d-11e5-9c0b-47c1586e0b80.png)
