### PR TITLE
Flip tooltip on middle date rather than break point date

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -476,15 +476,16 @@ class TimeBasedLineChart extends React.Component {
   }
 
   _handleDataPointMouseOver (d) {
-    const breakPointDate = moment.unix(this.props.breakPointDate).startOf(this.props.rangeType);
+    const graphMiddleTimeStamp = this.props.data[Math.floor(this.props.data.length / 2)].timeStamp;
+    const graphMiddleDate = moment.unix(graphMiddleTimeStamp).startOf(this.props.rangeType);
     const currentDate = moment.unix(d.timeStamp).startOf(this.props.rangeType);
-    const isAfterBreakPoint = currentDate.isAfter(breakPointDate);
+    const isAfterMidPoint = currentDate.isAfter(graphMiddleDate);
     const sliceWidth = this._getSliceMiddle();
     const xScale = this._getXScaleValue(currentDate.unix());
 
-    const left = isAfterBreakPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 10;
-    const right = isAfterBreakPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 10 - xScale : 'auto';
-    const textAlign = isAfterBreakPoint ? 'right' : 'left';
+    const left = isAfterMidPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 10;
+    const right = isAfterMidPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 10 - xScale : 'auto';
+    const textAlign = isAfterMidPoint ? 'right' : 'left';
     const top = this.props.children ? this._getYScaleValue(d.value) - 5 + this.props.margin.top : this._getYScaleValue(d.value) - 5;
 
     const position = {


### PR DESCRIPTION
Fixes https://github.com/mxenabled/mx-react-components/issues/75

TimeBasedLineChart component

We were flipping the tool tip direction based upon the break point date.  This was working fine but failed to take into account that the graph might not always have the break point date in the range of data points supplied.  In these cases the tool tips did not get flipped and would extend off the edge of the graph.

We no take the middle data point of the set and use it's date to determine when to flip the tooltip label.

@bsbeeks @jmophoto 

Pics of range missing break point date.  See how the tool tip flips from right to left after middle point.
![screen shot 2015-10-27 at 11 50 46 am](https://cloud.githubusercontent.com/assets/6463914/10767386/83693e70-7ca1-11e5-9845-6732f32df5f6.png)
![screen shot 2015-10-27 at 11 50 54 am](https://cloud.githubusercontent.com/assets/6463914/10767387/836958ba-7ca1-11e5-9a50-ecced54a43c5.png)