### PR TITLE
TimeBasedLineChart: set box-sizing: content-box

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -646,7 +646,8 @@ const styles = {
   component: {
     fontFamily: StyleConstants.FontFamily,
     padding: '10px',
-    position: 'relative'
+    position: 'relative',
+    boxSizing: 'content-box'
   },
   credit: {
     backgroundColor: '#30B53C'


### PR DESCRIPTION
After investigating a little further. It made more sense to just explicitly set `boxSizing: content-box` on the wrapping element to Fix #82.

@cerinman @jmophoto 