### PR TITLE
Add styling props to DatePicker for more flexibility

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -663,7 +663,6 @@ const Demo = React.createClass({
 
         <br/><br/>
         <DatePicker
-          calendarColumns={7}
           closeOnDateSelect={true}
           defaultDate={moment().unix()}
           showDayBorders={false}

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -175,16 +175,16 @@ class DatePicker extends React.Component {
         tabIndex='0'
       >
         <div key='selectedDateWrapper' style={[
-            (this.props.selectedDateWrapperStyle || styles.selectedDateWrapper),
-            this.state.showCalendar && styles.selectedDateWrapperOpen
-          ]}>
+          (this.props.selectedDateWrapperStyle || styles.selectedDateWrapper),
+          this.state.showCalendar && styles.selectedDateWrapperOpen
+        ]}>
           {this._renderSelectedDate()}
           {this._renderCaret()}
         </div>
         <div key='calendarWrapper' style={[
-            (this.props.calendarWrapperStyle || styles.calendarWrapper),
-            this.state.showCalendar && styles.calendarShow
-          ]}>
+          (this.props.calendarWrapperStyle || styles.calendarWrapper),
+          this.state.showCalendar && styles.calendarShow
+        ]}>
           {this._renderTitle(styles)}
           <div key='calendarHeader' style={[styles.calendarHeader, { borderBottomStyle: this.props.showDayBorders ? 'solid' : 'none' }, styles.clearFix]}>
             <Icon

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -174,11 +174,17 @@ class DatePicker extends React.Component {
         style={[styles.component, styles.clearFix, this.props.style]}
         tabIndex='0'
       >
-        <div key='componentTop' style={[styles.componentTop, this.state.showCalendar && styles.componentTopOpen]}>
+        <div key='selectedDateWrapper' style={[
+            (this.props.selectedDateWrapperStyle || styles.selectedDateWrapper),
+            this.state.showCalendar && styles.selectedDateWrapperOpen
+          ]}>
           {this._renderSelectedDate()}
           {this._renderCaret()}
         </div>
-        <div key='componentBottom' style={[styles.componentBottom, this.state.showCalendar && styles.calendarShow]}>
+        <div key='calendarWrapper' style={[
+            (this.props.calendarWrapperStyle || styles.calendarWrapper),
+            this.state.showCalendar && styles.calendarShow
+          ]}>
           {this._renderTitle(styles)}
           <div key='calendarHeader' style={[styles.calendarHeader, { borderBottomStyle: this.props.showDayBorders ? 'solid' : 'none' }, styles.clearFix]}>
             <Icon
@@ -207,6 +213,7 @@ class DatePicker extends React.Component {
 }
 
 DatePicker.propTypes = {
+  calendarWrapperStyle: React.PropTypes.object,
   closeOnDateSelect: React.PropTypes.bool,
   defaultDate: React.PropTypes.number,
   format: React.PropTypes.string,
@@ -214,8 +221,10 @@ DatePicker.propTypes = {
   minimumDate: React.PropTypes.number,
   onDateSelect: React.PropTypes.func,
   scrimStyle: React.PropTypes.object,
+  selectedDateWrapperStyle: React.PropTypes.object,
   showCaret: React.PropTypes.bool,
   showDayBorders: React.PropTypes.bool,
+  style: React.PropTypes.object,
   title: React.PropTypes.string,
   useInputForSelectedDate: React.PropTypes.bool,
   useScrim: React.PropTypes.bool
@@ -342,7 +351,7 @@ const styles = {
       outline: 'none'
     }
   },
-  componentBottom: {
+  calendarWrapper: {
     backgroundColor: '#FFFFFF',
     borderBottomLeftRadius: '3px',
     borderBottomRightRadius: '3px',
@@ -359,7 +368,7 @@ const styles = {
     width: '100%',
     zIndex: 10
   },
-  componentTop: {
+  selectedDateWrapper: {
     borderBottomWidth: '1px',
     borderColor: '#E5E5E5',
     borderRadius: '3px 3px 3px 3px',
@@ -368,7 +377,7 @@ const styles = {
     position: 'relative',
     padding: '5px 5px 5px 5px'
   },
-  componentTopOpen: {
+  selectedDateWrapperOpen: {
     borderBottomWidth: '0',
     borderRadius: '3px 3px 0 0'
   },

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -175,14 +175,16 @@ class DatePicker extends React.Component {
         tabIndex='0'
       >
         <div key='selectedDateWrapper' style={[
-          (this.props.selectedDateWrapperStyle || styles.selectedDateWrapper),
+          styles.selectedDateWrapper,
+          this.props.selectedDateWrapperStyle,
           this.state.showCalendar && styles.selectedDateWrapperOpen
         ]}>
           {this._renderSelectedDate()}
           {this._renderCaret()}
         </div>
         <div key='calendarWrapper' style={[
-          (this.props.calendarWrapperStyle || styles.calendarWrapper),
+          styles.calendarWrapper,
+          this.props.calendarWrapperStyle,
           this.state.showCalendar && styles.calendarShow
         ]}>
           {this._renderTitle(styles)}


### PR DESCRIPTION
While using the DatePicker in our MX app, I ran into a few issues trying to style the component to match designs.  This change adds a style prop for the selectedDate and calendar wrapper divs so that we can over write the base styling when needed.

I also renamed the style object names for these two divs for clarity as well as removed a prop that is no longer supported from the demo app for the DatePicker.

@bsbeeks @jmophoto

proof that the changes did not cause any harm to standard use of the component in the demo app.
![screen shot 2015-11-09 at 2 42 26 pm](https://cloud.githubusercontent.com/assets/6463914/11047527/33c7aef2-86f0-11e5-87af-eb5213c5de4b.png)
