### PR TITLE
Refactor DatePicker component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -670,7 +670,6 @@ const Demo = React.createClass({
           defaultDate={this.state.selectedDatePickerDate}
           showDayBorders={false}
           onDateSelect={this._handleDateSelect}
-          useScrim={true}
         />
       </div>
     );

--- a/demo/app.js
+++ b/demo/app.js
@@ -476,6 +476,7 @@ const Demo = React.createClass({
         value: 'accounts',
         displayValue: 'Accounts'
       },
+      selectedDatePickerDate: moment().unix(),
       showModal: false,
       showSmallModal: false,
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
@@ -502,8 +503,10 @@ const Demo = React.createClass({
     });
   },
 
-  _handleDateSelect (selectedDate) {
-
+  _handleDateSelect (selectedDatePickerDate) {
+    this.setState({
+      selectedDatePickerDate
+    })
   },
 
   render () {
@@ -664,10 +667,10 @@ const Demo = React.createClass({
         <br/><br/>
         <DatePicker
           closeOnDateSelect={true}
-          defaultDate={moment().unix()}
+          defaultDate={this.state.selectedDatePickerDate}
           showDayBorders={false}
           onDateSelect={this._handleDateSelect}
-          useInputForSelectedDate={false}
+          useScrim={true}
         />
       </div>
     );

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -27,7 +27,7 @@ class DatePicker extends React.Component {
       if (newDate.isValid()) {
         inputValue = newDate.format(this.props.format);
       } else {
-        inputValue = 'Invalid Date';
+        inputValue = date;
       }
     }
 
@@ -47,6 +47,7 @@ class DatePicker extends React.Component {
 
     this.setState({
       inputValue: moment.unix(date).format(this.props.format),
+      isValid: true,
       selectedDate: date
     });
 
@@ -55,21 +56,26 @@ class DatePicker extends React.Component {
 
   _handleInputBlur (evt) {
     let inputValue = null;
+    let isValid = true;
     let selectedDate = null;
 
-    if (evt.target.value.length) {
+    if (evt.target.value && evt.target.value.length) {
       const newDate = moment(new Date(evt.target.value));
 
-      inputValue = this._getInputValueByDate(newDate.unix());
-      selectedDate = newDate.unix();
+      inputValue = this._getInputValueByDate(newDate.isValid() ? newDate.unix() : evt.target.value);
+      isValid = newDate.isValid();
+      selectedDate = newDate.isValid() ? newDate.unix() : this.state.selectedDate;
     }
 
     this.setState({
       inputValue,
+      isValid,
       selectedDate
     });
 
-    this.props.onDateSelect(selectedDate);
+    if (isValid) {
+      this.props.onDateSelect(selectedDate);
+    }
   }
 
   _handleInputChange (evt) {

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -133,7 +133,7 @@ class DatePicker extends React.Component {
       day = (
         <div
           key={startDate.month() + '-' + startDate.date()}
-          onClick={this._handleDateSelect.bind(this, startDate.unix())}
+          onClick={!noSelectDay ? this._handleDateSelect.bind(this, startDate.unix()) : null}
           style={[
             styles.calendarDay,
             (!noSelectDay && isCurrentMonth) && styles.currentMonth

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -159,9 +159,9 @@ class DatePicker extends React.Component {
   }
 
   _renderScrim (styles) {
-    if (this.props.useScrim && this.state.showCalendar) {
+    if (this.state.showCalendar) {
       return (
-        <div onClick={this._handleScrimClick.bind(this)} style={[styles.scrim, this.props.scrimStyle, !this.props.useScrim && styles.hiddenScrim]}/>
+        <div onClick={this._handleScrimClick.bind(this)} style={[styles.scrim, this.props.scrimStyle]}/>
       );
     }
   }
@@ -483,6 +483,7 @@ const styles = {
   },
   placeholderText: {
     color: '#AAAAAA',
+    fontSize: '14px',
     position: 'absolute',
     top: '10px',
     zIndex: 1

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -11,24 +11,75 @@ class DatePicker extends React.Component {
     super(props);
     this.state = {
       currentDate: null,
-      selectedDate: moment.unix(this.props.defaultDate),
+      inputValue: this._getInputValueByDate(this.props.defaultDate),
+      isValid: true,
+      selectedDate: this.props.defaultDate,
       showCalendar: false
     };
   }
 
+  _getInputValueByDate (date) {
+    let inputValue = null;
+
+    if (date) {
+      const newDate = moment.unix(date);
+
+      if (newDate.isValid()) {
+        inputValue = newDate.format(this.props.format);
+      } else {
+        inputValue = 'Invalid Date';
+      }
+    }
+
+    return inputValue;
+  }
+
+  _getSelectedDate () {
+    const selectedDate = this.state.selectedDate;
+
+    return selectedDate && moment.unix(selectedDate).isValid() ? this.state.selectedDate : moment().unix();
+  }
+
   _handleDateSelect (date) {
     if (this.props.closeOnDateSelect) {
-      this._handleBlur();
+      this._handleScrimClick();
     }
+
     this.setState({
-      selectedDate: moment.unix(date)
+      inputValue: moment.unix(date).format(this.props.format),
+      selectedDate: date
     });
 
     this.props.onDateSelect(date);
   }
 
+  _handleInputBlur (evt) {
+    let inputValue = null;
+    let selectedDate = null;
+
+    if (evt.target.value.length) {
+      const newDate = moment(new Date(evt.target.value));
+
+      inputValue = this._getInputValueByDate(newDate.unix());
+      selectedDate = newDate.unix();
+    }
+
+    this.setState({
+      inputValue,
+      selectedDate
+    });
+
+    this.props.onDateSelect(selectedDate);
+  }
+
+  _handleInputChange (evt) {
+    this.setState({
+      inputValue: evt.target.value
+    });
+  }
+
   _handlePreviousClick () {
-    const selectedDate = moment(this.state.selectedDate).locale(this.props.locale);
+    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     currentDate = moment(currentDate.startOf('month').subtract(1, 'm'), this.props.format);
@@ -39,13 +90,25 @@ class DatePicker extends React.Component {
   }
 
   _handleNextClick () {
-    const selectedDate = moment(this.state.selectedDate).locale(this.props.locale);
+    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     currentDate = moment(currentDate.endOf('month').add(1, 'd'), this.props.format);
 
     this.setState({
       currentDate
+    });
+  }
+
+  _handleScrimClick () {
+    this.setState({
+      showCalendar: false
+    });
+  }
+
+  _toggleCalendar () {
+    this.setState({
+      showCalendar: !this.state.showCalendar
     });
   }
 
@@ -64,7 +127,7 @@ class DatePicker extends React.Component {
       day = (
         <div
           key={startDate.month() + '-' + startDate.date()}
-          onClick={!noSelectDay ? this._handleDateSelect.bind(this, startDate.unix()) : null}
+          onClick={this._handleDateSelect.bind(this, startDate.unix())}
           style={[
             styles.calendarDay,
             (!noSelectDay && isCurrentMonth) && styles.currentMonth
@@ -92,28 +155,29 @@ class DatePicker extends React.Component {
   _renderScrim (styles) {
     if (this.props.useScrim && this.state.showCalendar) {
       return (
-        <div style={[styles.scrim, this.props.scrimStyle]}/>
+        <div onClick={this._handleScrimClick.bind(this)} style={[styles.scrim, this.props.scrimStyle, !this.props.useScrim && styles.hiddenScrim]}/>
       );
     }
   }
 
   _renderSelectedDate () {
     if (this.props.useInputForSelectedDate) {
+      const hidePlaceholder = this.state.inputValue && this.state.inputValue.length;
+
       return (
         <div>
           <input
             key='input'
+            onBlur={this._handleInputBlur.bind(this)}
+            onChange={this._handleInputChange.bind(this)}
             onClick={this._toggleCalendar.bind(this)}
-            style={styles.input}
+            style={[styles.input, this.props.inputStyle, hidePlaceholder && { opacity: 1 }]}
             type='text'
-            value={moment(this.state.selectedDate).format(this.props.format)}
+            value={this.state.inputValue}
           />
-          <Icon
-            onClick={this._toggleCalendar.bind(this)}
-            size='28px'
-            style={styles.calendarIcon}
-            type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
-          />
+          <div style={[styles.placeholderText, this.props.placeholderTextStyle]}>
+            {this.props.placeholderText || 'Select A Date'}
+          </div>
         </div>
       );
     } else {
@@ -123,7 +187,7 @@ class DatePicker extends React.Component {
           onClick={this._toggleCalendar.bind(this)}
           style={styles.selectedDate}
         >
-          {moment(this.state.selectedDate).format(this.props.format)}
+          {this.state.inputValue}
         </div>
       );
     }
@@ -137,18 +201,6 @@ class DatePicker extends React.Component {
         </div>
       );
     }
-  }
-
-  _toggleCalendar () {
-    this.setState({
-      showCalendar: !this.state.showCalendar
-    });
-  }
-
-  _handleBlur () {
-    this.setState({
-      showCalendar: false
-    });
   }
 
   _renderCaret () {
@@ -165,12 +217,11 @@ class DatePicker extends React.Component {
   }
 
   render () {
-    const selectedDate = moment(this.state.selectedDate).locale(this.props.locale);
+    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     return (
       <div
-        onBlur={this._handleBlur.bind(this)}
         style={[styles.component, styles.clearFix, this.props.style]}
         tabIndex='0'
       >
@@ -219,31 +270,31 @@ DatePicker.propTypes = {
   closeOnDateSelect: React.PropTypes.bool,
   defaultDate: React.PropTypes.number,
   format: React.PropTypes.string,
+  inputStyle: React.PropTypes.object,
   locale: React.PropTypes.string,
   minimumDate: React.PropTypes.number,
   onDateSelect: React.PropTypes.func,
+  placeholderText: React.PropTypes.string,
+  placeholderTextStyle: React.PropTypes.object,
   scrimStyle: React.PropTypes.object,
   selectedDateWrapperStyle: React.PropTypes.object,
   showCaret: React.PropTypes.bool,
   showDayBorders: React.PropTypes.bool,
   style: React.PropTypes.object,
   title: React.PropTypes.string,
-  useInputForSelectedDate: React.PropTypes.bool,
-  useScrim: React.PropTypes.bool
+  useInputForSelectedDate: React.PropTypes.bool
 };
 
 DatePicker.defaultProps = {
   closeOnDateSelect: false,
-  defaultDate: moment().unix(),
-  format: 'YYYY-MM-DD',
+  format: 'MMM D, YYYY',
   locale: 'en',
   onDateSelect () {},
   scrimStyle: {},
   showCaret: true,
   showDayBorders: false,
   title: null,
-  useInputForSelectedDate: true,
-  useScrim: false
+  useInputForSelectedDate: true
 };
 
 const styles = {
@@ -394,10 +445,14 @@ const styles = {
     backgroundColor: '#FFFFFF',
     border: 'none',
     fontSize: StyleConstants.FontSize,
+    opacity: 0,
     outline: 'none',
     paddingBottom: '10px',
+    position: 'relative',
+    top: '5px',
     WebkitAppearance: 'none',
     width: '80%',
+    zIndex: 2,
 
     ':focus': {
       border: 'none',
@@ -419,6 +474,12 @@ const styles = {
     right: '0',
     top: '50%',
     transform: 'translateY(-50%)'
+  },
+  placeholderText: {
+    color: '#AAAAAA',
+    position: 'absolute',
+    top: '10px',
+    zIndex: 1
   },
   scrim: {
     position: 'fixed',

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -308,7 +308,7 @@ const styles = {
     color: '#CCCCCC',
     cursor: 'pointer',
     position: 'absolute',
-    right: '0',
+    right: '5px',
     top: '50%',
     transform: 'translateY(-50%)'
   },
@@ -454,6 +454,7 @@ const styles = {
     opacity: 0,
     outline: 'none',
     paddingBottom: '10px',
+    paddingLeft: '5px',
     position: 'relative',
     top: '5px',
     WebkitAppearance: 'none',
@@ -484,6 +485,7 @@ const styles = {
   placeholderText: {
     color: '#AAAAAA',
     fontSize: '14px',
+    paddingLeft: '5px',
     position: 'absolute',
     top: '10px'
   },

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -485,8 +485,7 @@ const styles = {
     color: '#AAAAAA',
     fontSize: '14px',
     position: 'absolute',
-    top: '10px',
-    zIndex: 1
+    top: '10px'
   },
   scrim: {
     position: 'fixed',


### PR DESCRIPTION
This PR refactors the DatePicker component for the following reasons.

- Allow and handle nullifying or emptying the selectedDate input so that the component can used for a `not required` fields.
- Adds more props for styling(See new list of props below)
- Handle placeholder text for empty or nullified selectedDate input
- Fix onBlur weirdness by moving to an onClick on scrim
- Fix double caret's being drawn when using input for selectedDate
- Reorder a few functions that were not ordered alphabetically

New Props added

- inputStyle - object - used to custom style the selected date input
- placeholderText - string - used as placeholder for empty selected date input
- placeholderTextStyle - object - used to style the placeholder text

Props removed

- useScrim - boolean - was used to not render the scrim.  

Now that we rely on the scrim for closing the calendar when a user blurs off the component by clicking on the scrim we must always render it.  The user can use the provided scrimStyle prop to style the scrim but it is by default not visible.

Props with modified default values

- defaultDate - unix time stamp - number - The default value was today's date but now that we want to be able to allow null or empty values their is no longer a default value for this prop.

@bsbeeks @jmophoto @tumentumurchudur @malcolmwebdev 

Screen shots:
![screen shot 2015-11-10 at 8 24 34 pm](https://cloud.githubusercontent.com/assets/6463914/11083320/52b0aef8-87eb-11e5-9fc8-50eaf50f7fdd.png)
![screen shot 2015-11-10 at 8 24 44 pm](https://cloud.githubusercontent.com/assets/6463914/11083321/52b10a06-87eb-11e5-8674-c4d347e061aa.png)
![screen shot 2015-11-10 at 8 25 50 pm](https://cloud.githubusercontent.com/assets/6463914/11083319/52b0a69c-87eb-11e5-93f0-33664aedeae4.png)