### PR TITLE
Style caret icon on select component

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -101,7 +101,7 @@ class Select extends React.Component {
             {selected.displayValue}
             <Icon
               size='20'
-              style={[styles.downArrow, this.props.selectedStyle && { color: this.props.selectedStyle.color }]}
+              style={styles.caret}
               type={this.state.isOpen ? 'caret-up' : 'caret-down'}
             />
           </div>
@@ -121,6 +121,14 @@ class Select extends React.Component {
 }
 
 const styles = {
+  caret: {
+    color: '#CCCCCC',
+    cursor: 'pointer',
+    position: 'absolute',
+    right: '-10px',
+    top: '50%',
+    transform: 'translateY(-50%)'
+  },
   component: {
     backgroundColor: '#FFFFFF',
     borderRadius: '3px',
@@ -147,13 +155,6 @@ const styles = {
   },
   selected: {
     position: 'relative'
-  },
-  downArrow: {
-    color: StyleConstants.Colors.FONT,
-    position: 'absolute',
-    right: '-5px',
-    top: '50%',
-    marginTop: '-10px'
   },
   invalid: {
     borderColor: StyleConstants.Colors.RED

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -125,7 +125,7 @@ const styles = {
     color: '#CCCCCC',
     cursor: 'pointer',
     position: 'absolute',
-    right: '-10px',
+    right: '-5px',
     top: '50%',
     transform: 'translateY(-50%)'
   },


### PR DESCRIPTION
The caret up/down icon on the select component used to show the user if the component is open or closed did not have a style that matched the same icons in other components.  This PR changes the styles to bring it inline for consistency.  


@bsbeeks @jmophoto @tumentumurchudur @malcolmwebdev 

Select Component after change
![screen shot 2015-11-10 at 9 12 28 pm](https://cloud.githubusercontent.com/assets/6463914/11083754/61dd2924-87f0-11e5-9830-8d4f9dca244e.png)

DatePicker Component for reference to what we needed to match
![screen shot 2015-11-10 at 9 12 38 pm](https://cloud.githubusercontent.com/assets/6463914/11083762/7102896c-87f0-11e5-91af-7daf2c24fbfb.png)
