### PR TITLE
A few more bug fixes for the DatePicker component

### DIFF
--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -55,26 +55,17 @@ class DatePicker extends React.Component {
   }
 
   _handleInputBlur (evt) {
-    let inputValue = null;
-    let isValid = true;
-    let selectedDate = null;
+    if (evt.target.value.length === 0) {
+      this.props.onDateSelect(null);
 
-    if (evt.target.value && evt.target.value.length) {
-      const newDate = moment(new Date(evt.target.value));
-
-      inputValue = this._getInputValueByDate(newDate.isValid() ? newDate.unix() : evt.target.value);
-      isValid = newDate.isValid();
-      selectedDate = newDate.isValid() ? newDate.unix() : this.state.selectedDate;
-    }
-
-    this.setState({
-      inputValue,
-      isValid,
-      selectedDate
-    });
-
-    if (isValid) {
-      this.props.onDateSelect(selectedDate);
+      this.setState({
+        inputValue: null,
+        selectedDate: null
+      });
+    } else {
+      this.setState({
+        inputValue: moment.unix(this.state.selectedDate).format(this.props.format)
+      });
     }
   }
 
@@ -184,6 +175,7 @@ class DatePicker extends React.Component {
           <div style={[styles.placeholderText, this.props.placeholderTextStyle]}>
             {this.props.placeholderText || 'Select A Date'}
           </div>
+          {this._renderCaret()}
         </div>
       );
     } else {
@@ -194,6 +186,7 @@ class DatePicker extends React.Component {
           style={styles.selectedDate}
         >
           {this.state.inputValue}
+          {this._renderCaret()}
         </div>
       );
     }
@@ -212,12 +205,14 @@ class DatePicker extends React.Component {
   _renderCaret () {
     if (this.props.showCaret) {
       return (
-        <Icon
-          onClick={this._toggleCalendar.bind(this)}
-          size='20px'
-          style={styles.caret}
-          type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
-        />
+        <div style={[styles.caretWrapper, this.props.caretWrapperStyle]}>
+          <Icon
+            onClick={this._toggleCalendar.bind(this)}
+            size='20'
+            style={styles.caret}
+            type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
+          />
+        </div>
       );
     }
   }
@@ -233,11 +228,9 @@ class DatePicker extends React.Component {
       >
         <div key='selectedDateWrapper' style={[
           styles.selectedDateWrapper,
-          this.props.selectedDateWrapperStyle,
-          this.state.showCalendar && styles.selectedDateWrapperOpen
+          this.props.selectedDateWrapperStyle
         ]}>
           {this._renderSelectedDate()}
-          {this._renderCaret()}
         </div>
         <div key='calendarWrapper' style={[
           styles.calendarWrapper,
@@ -273,6 +266,7 @@ class DatePicker extends React.Component {
 
 DatePicker.propTypes = {
   calendarWrapperStyle: React.PropTypes.object,
+  caretWrapperStyle: React.PropTypes.object,
   closeOnDateSelect: React.PropTypes.bool,
   defaultDate: React.PropTypes.number,
   format: React.PropTypes.string,
@@ -311,6 +305,11 @@ const styles = {
     right: '5px',
     top: '50%',
     transform: 'translateY(-50%)'
+  },
+  caretWrapper: {
+    position: 'absolute',
+    top: '50%',
+    right: '5px'
   },
   calendarDay: {
     color: '#DDDDDD',
@@ -416,7 +415,7 @@ const styles = {
     borderBottomRightRadius: '3px',
     borderColor: '#E5E5E5',
     borderStyle: 'solid',
-    borderWidth: '0 1px 1px 1px',
+    borderWidth: '1px',
     boxShadow: StyleConstants.BoxShadow,
     boxSizing: 'border-box',
     display: 'none',
@@ -435,10 +434,6 @@ const styles = {
     borderWidth: '1px 1px 1px 1px',
     position: 'relative',
     padding: '5px 5px 5px 5px'
-  },
-  selectedDateWrapperOpen: {
-    borderBottomWidth: '0',
-    borderRadius: '3px 3px 0 0'
   },
   currentDay: {
     backgroundColor: '#359BCF',

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -22,7 +22,7 @@ class DatePicker extends React.Component {
     let inputValue = null;
 
     if (date) {
-      const newDate = moment.unix(date);
+      const newDate = moment.utc(date * 1000);
 
       if (newDate.isValid()) {
         inputValue = newDate.format(this.props.format);
@@ -37,7 +37,7 @@ class DatePicker extends React.Component {
   _getSelectedDate () {
     const selectedDate = this.state.selectedDate;
 
-    return selectedDate && moment.unix(selectedDate).isValid() ? this.state.selectedDate : moment().unix();
+    return selectedDate && moment.utc(selectedDate * 1000).isValid() ? this.state.selectedDate : moment().unix();
   }
 
   _handleDateSelect (date) {
@@ -46,7 +46,7 @@ class DatePicker extends React.Component {
     }
 
     this.setState({
-      inputValue: moment.unix(date).format(this.props.format),
+      inputValue: moment.utc(date * 1000).format(this.props.format),
       isValid: true,
       selectedDate: date
     });
@@ -64,7 +64,7 @@ class DatePicker extends React.Component {
       });
     } else {
       this.setState({
-        inputValue: moment.unix(this.state.selectedDate).format(this.props.format)
+        inputValue: moment.utc(this.state.selectedDate * 1000).format(this.props.format)
       });
     }
   }
@@ -76,7 +76,7 @@ class DatePicker extends React.Component {
   }
 
   _handlePreviousClick () {
-    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
+    const selectedDate = moment.utc(this._getSelectedDate() * 1000).locale(this.props.locale);
     let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     currentDate = moment(currentDate.startOf('month').subtract(1, 'm'), this.props.format);
@@ -87,7 +87,7 @@ class DatePicker extends React.Component {
   }
 
   _handleNextClick () {
-    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
+    const selectedDate = moment.utc(this._getSelectedDate() * 1000).locale(this.props.locale);
     let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     currentDate = moment(currentDate.endOf('month').add(1, 'd'), this.props.format);
@@ -113,7 +113,7 @@ class DatePicker extends React.Component {
     const days = [];
     const startDate = moment(currentDate, this.props.format).startOf('month').startOf('week');
     const endDate = moment(currentDate, this.props.format).endOf('month').endOf('week');
-    const minimumDate = this.props.minimumDate ? moment.unix(this.props.minimumDate) : null;
+    const minimumDate = this.props.minimumDate ? moment.utc(this.props.minimumDate * 1000) : null;
 
     while (startDate.isBefore(endDate)) {
       const isCurrentMonth = startDate.month() === currentDate.month();
@@ -218,7 +218,7 @@ class DatePicker extends React.Component {
   }
 
   render () {
-    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
+    const selectedDate = moment.utc(this._getSelectedDate() * 1000).locale(this.props.locale);
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     return (


### PR DESCRIPTION
This PR does the following.

- When using an input for the selected date, we no longer remove the bottom border for the input wrapper when the calendar is showing.  This feature was causing weird behavior when a user would style the input wrapper to not have any border.  This also now has the added benefit of mimicking the other components that have a similar open closed state.

- Refactor the `_handleInputBlur` function.  Before we where trying to validate the date via the string value from the input and updating state and calling the `onDateSelect` callback.  This was causing several call backs to happen and also would allow the user to cause unexpected behavior by doing something like typing `Nov` rather than a complete date.  We now check the value of the input to see if it has length.  If it doesn't then we just set things to null and move on.  If it does have length then we restore the current selected date that is in state.  This allows the user to null out the input but forces them to use the calendar to select a date.

- Wraps the caret icon in a div and then allows a prop to style it.  Positioning the caret to match up with other inputs with similar carets was becoming difficult and their was no good way of just effecting the caret icon.  

- Change moment to use utc for dates so that they get formatted using utc rather than with the user time zone offset.

Props Added

- caretWrapperStyle: object - allows for styling the div wrapper around the caret icon

@bsbeeks @jmophoto @tumentumurchudur @malcolmwebdev 