### PR TITLE
Add new FormField component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -12,7 +12,8 @@ const {
   TimeBasedLineChart,
   ToggleSwitch,
   TypeAhead,
-  DatePicker
+  DatePicker,
+  FormField
 } = require('../src/Index');
 
 const styles = {
@@ -48,6 +49,29 @@ const styles = {
     cursor: 'pointer',
     fontSize: '14px',
     WebkitFontSmoothing: 'antialiased'
+  },
+  input: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    color: '#56595A',
+    fontSize: '16px',
+    height: '100%',
+    paddingTop: '20px',
+    position: 'relative',
+    width: '100%',
+    zindex: 2,
+
+    ':focus': {
+      backgroundColor: '#F7F8F8',
+      border: 'none',
+      outline: 'none'
+    },
+
+    ':hover': {
+      backgroundColor: '#F7F8F8',
+      border: 'none',
+      outline: 'none'
+    }
   }
 };
 
@@ -479,7 +503,9 @@ const Demo = React.createClass({
       selectedDatePickerDate: moment().unix(),
       showModal: false,
       showSmallModal: false,
-      windowWidth: document.documentElement.clientWidth || document.body.clientWidth
+      windowWidth: document.documentElement.clientWidth || document.body.clientWidth,
+      nameInputValue: 'John Doe',
+      emailInputValue: 'john.doe@missingidentity.com'
     }
   },
 
@@ -507,6 +533,18 @@ const Demo = React.createClass({
     this.setState({
       selectedDatePickerDate
     })
+  },
+
+  _handleNameInputChange (evt) {
+    this.setState({
+      nameInputValue: evt.target.value
+    });
+  },
+
+  _handleEmailInputChange (evt) {
+    this.setState({
+      emailInputValue: evt.target.value
+    });
   },
 
   render () {
@@ -671,6 +709,32 @@ const Demo = React.createClass({
           showDayBorders={false}
           onDateSelect={this._handleDateSelect}
         />
+
+        <br/><br/>
+        <FormField
+          isRequired={this.state.nameInputValue.length === 0}
+          label='Name'
+          placeholder='Enter Your Name'
+        >
+          <input
+            onChange={this._handleNameInputChange}
+            style={[styles.input, this.state.nameInputValue.length > 0 && { backgroundColor: '#FFFFFF' }]}
+            value={this.state.nameInputValue}
+          />
+        </FormField>
+        <FormField
+          isRequired={this.state.emailInputValue.length === 0}
+          label='Email'
+          placeholder='Enter Your Email'
+        >
+          <input
+            onChange={this._handleEmailInputChange}
+            style={[styles.input, this.state.emailInputValue.length > 0 && { backgroundColor: '#FFFFFF' }]}
+            value={this.state.emailInputValue}
+          />
+        </FormField>
+
+        <br/><br/>
       </div>
     );
   },

--- a/src/Index.js
+++ b/src/Index.js
@@ -10,5 +10,6 @@ module.exports = {
   TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),
   TypeAhead: require('./components/TypeAhead'),
-  DatePicker: require('./components/DatePicker')
+  DatePicker: require('./components/DatePicker'),
+  FormField: require('./components/FormField')
 };

--- a/src/components/FormField.js
+++ b/src/components/FormField.js
@@ -1,23 +1,9 @@
 const React = require('react');
 const Radium = require('radium');
-const moment = require('moment');
 
 const StyleConstants = require('../constants/Style');
 
 class FormField extends React.Component {
-  constructor (props) {
-    super(props);
-    this.state = {
-      focused: false
-    };
-  }
-
-  _toggleFieldFocus () {
-    this.setState({
-      focused: !this.state.focused
-    });
-  }
-
   render () {
     return (
       <div
@@ -74,10 +60,14 @@ class FormField extends React.Component {
 }
 
 FormField.propTypes = {
+  fieldWrapperStyle: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object]),
   height: React.PropTypes.number,
   isRequired: React.PropTypes.bool,
   label: React.PropTypes.string,
+  labelStyle: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object]),
   placeholder: React.PropTypes.string,
+  placeholderStyle: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object]),
+  requiredStyle: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object]),
   width: React.PropTypes.number
 };
 

--- a/src/components/FormField.js
+++ b/src/components/FormField.js
@@ -1,0 +1,131 @@
+const React = require('react');
+const Radium = require('radium');
+const moment = require('moment');
+
+const StyleConstants = require('../constants/Style');
+
+class FormField extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      focused: false
+    };
+  }
+
+  _toggleFieldFocus () {
+    this.setState({
+      focused: !this.state.focused
+    });
+  }
+
+  render () {
+    return (
+      <div
+        className='mx-form-field-component'
+        style={[
+          styles.component, this.props.style,
+          { height: this.props.height + 'px', width: this.props.width + 'px' }
+        ]}
+      >
+        <div
+          className='mx-form-field-label'
+          style={[
+            styles.label, this.props.labelStyle,
+            { marginTop: this.props.height - 16 }
+          ]}
+        >
+          {this.props.label}
+        </div>
+        <div
+          className='mx-form-field-wrapper'
+          style={[
+            styles.fieldWrapper,
+            this.props.fieldWrapperStyle
+          ]}
+        >
+          {this.props.isRequired ? (
+            <div
+              className='mx-form-field-required'
+              style={[
+                styles.required,
+                this.props.requiredStyle
+              ]}
+            >
+              * Required
+            </div>
+          ) : null}
+          {this.props.children}
+          {this.props.placeholder ? (
+            <div
+              className='mx-form-field-placeholder'
+              style={[
+                styles.placeholder,
+                this.props.placeholderStyle,
+                { paddingTop: this.props.height / 2 }
+              ]}
+            >
+              {this.props.placeholder}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+}
+
+FormField.propTypes = {
+  height: React.PropTypes.number,
+  isRequired: React.PropTypes.bool,
+  label: React.PropTypes.string,
+  placeholder: React.PropTypes.string,
+  width: React.PropTypes.number
+};
+
+FormField.defaultProps = {
+  height: 40,
+  isRequired: false,
+  width: 350
+};
+
+const styles = {
+  component: {
+    borderBottom: '1px solid ' + StyleConstants.Colors.FOG,
+    boxSizing: 'border-box'
+  },
+  fieldWrapper: {
+    boxSizing: 'border-box',
+    float: 'left',
+    position: 'relative',
+    width: '70%'
+  },
+  label: {
+    color: StyleConstants.Colors.ASH,
+    boxSizing: 'border-box',
+    float: 'left',
+    fontSize: '12px',
+    padding: '0px 5px 0px 0px',
+    position: 'relative',
+    width: '30%'
+  },
+  placeholder: {
+    boxSizing: 'border-box',
+    color: StyleConstants.Colors.ASH,
+    fontSize: StyleConstants.FontSizeMedium,
+    height: '100%',
+    position: 'absolute',
+    right: '0px',
+    top: '0px',
+    width: '100%',
+    zIndex: -1
+  },
+  required: {
+    boxSizing: 'border-box',
+    color: StyleConstants.Colors.STRAWBERRY,
+    fontSize: StyleConstants.FontSize,
+    position: 'absolute',
+    right: '5px',
+    top: '5px'
+  }
+};
+
+module.exports = Radium(FormField);

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -15,10 +15,20 @@ module.exports = {
     YELLOW: '#f6a01e',
     GREEN: '#00a89c',
     BLUE: '#359BCF',
-    RED: '#EE4235'
+    RED: '#EE4235',
+    BANANA: '#FBB600',
+    LIME: '#2EBE51',
+    STRAWBERRY: '#E22727',
+
+    //Grays
+    ASH: '#ACB0B3',
+    CHARCOAL: '#56595A',
+    FOG: '#E3E6E7',
+    PORCELAIN: '#F7F8F8'
   },
 
   FontSize: '13px',
+  FontSizeMedium: '16px',
   FontFamily: 'Helvetica, Arial, sans-serif',
   BoxShadow: '0 30px 30px 10px rgba(0,0,0,0.1)'
 };


### PR DESCRIPTION
This PR adds a new component FormField.  This component is a wrapper for form fields that provides a nice clean layout of the forms label, is required error message, and placeholder text.

![screen shot 2015-11-18 at 11 03 54 am](https://cloud.githubusercontent.com/assets/6463914/11249509/86093b0e-8de4-11e5-9efd-cd10a3b37de5.png)
![screen shot 2015-11-18 at 11 04 13 am](https://cloud.githubusercontent.com/assets/6463914/11249510/8609d88e-8de4-11e5-8fc8-f6baed8b63e5.png)


It can wrap just about anything that requires a label and some basic validation.

Props

- fieldWrapperStyle: (array | object) - Style object or Radium array of style objects used to style the field wrapper.
- height: number(default 40) - Height of component.
- isRequired: boolean(default false) - Used to show or hide the `* Required` message in top right corner if field.
- label: string - The label to rendered next to the field.
- labelStyle: (array | object) - Style object or Radium array of style objects used to style the label.
- placeholder: string - The placeholder text to be drawn below the field.
- placeholderStyle: (array | object) - Style object or Radium array of style objects used to style the placeholder.
- requiredStyle: (array | object) - Style object or Radium array of style objects used to style the required error message.
- width: number(default 350) - The width of the component

Classes available for styling the component

- mx-form-field-component : used to style component as a whole.
- mx-form-field-label: used to style label.
- mx-form-field-wrapper: used to style the field wrapper.
- mx-form-field-required: used to style the required error message.
- mx-form-field-placeholder: used to style the placeholder.

@bsbeeks @jmophoto @tumentumurchudur @malcolmwebdev