### PR TITLE
TimeBasedLineChart: Dont render zero axis if to close to another tick.

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -140,7 +140,17 @@ class TimeBasedLineChart extends React.Component {
 
     if (this.props.alwaysShowZeroYTick) {
       if (ticks.indexOf(0) === -1) {
-        ticks.push(0);
+        let shouldAddZeroToTicks = true;
+
+        ticks.forEach(tick => {
+          if ((tick <= 1000 && tick > 0) || (tick >= -1000 && tick < 0)) {
+            shouldAddZeroToTicks = false;
+          }
+        });
+
+        if (shouldAddZeroToTicks) {
+          ticks.push(0);
+        }
       }
     }
 


### PR DESCRIPTION
This prevents the addition of the zero y axis tick if zero is to close to an existing tick.  This stops the behavior where the zero y axis would some times overlap another y axis tick.  The shading of the area below zero will still happen.

@bsbeeks @jmophoto @malcolmwebdev @tumentumurchudur 

Before:
![screen shot 2015-11-30 at 1 37 53 pm](https://cloud.githubusercontent.com/assets/6463914/11484152/c3a6b7d2-9769-11e5-8a38-65f63e13999e.png)
 
After:
![screen shot 2015-11-30 at 1 49 42 pm](https://cloud.githubusercontent.com/assets/6463914/11484154/cc412882-9769-11e5-976e-017c7a2e4d43.png)
