### PR TITLE
Cleanup Full Screen Datepicker

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -478,7 +478,7 @@ const Demo = React.createClass({
         value: 'accounts',
         displayValue: 'Accounts'
       },
-      selectedDatePickerDate: moment().unix(),
+      selectedDatePickerDate: null,
       showModal: false,
       showSmallModal: false,
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
@@ -742,7 +742,6 @@ const Demo = React.createClass({
           <DatePickerFullScreen
             closeOnDateSelect={true}
             defaultDate={this.state.selectedDatePickerDate}
-            showDayBorders={false}
             title='Select A Date'
             onDateSelect={this._handleDateSelect}
           />

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -10,7 +10,7 @@ class DatePickerFullScreen extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
-      currentDate: null,
+      currentDate: moment().unix(),
       selectedDate: this.props.defaultDate,
       showCalendar: false
     };
@@ -24,21 +24,15 @@ class DatePickerFullScreen extends React.Component {
     };
   }
 
-  _getSelectedDate () {
-    const selectedDate = this.state.selectedDate;
-
-    return selectedDate && moment.unix(selectedDate).isValid() ? this.state.selectedDate : moment().unix();
-  }
-
   _handleCloseClick () {
     this.setState({
       showCalendar: false
     });
   }
 
-  _handleDateSelect (date) {
+  _handleDateSelect (selectedDate) {
     const updatedState = {
-      selectedDate: date
+      selectedDate
     };
 
     if (this.props.closeOnDateSelect) {
@@ -47,28 +41,18 @@ class DatePickerFullScreen extends React.Component {
 
     this.setState(updatedState);
 
-    this.props.onDateSelect(date);
+    this.props.onDateSelect(selectedDate);
   }
 
   _handlePreviousClick () {
-    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
-    let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
-
-    currentDate = moment(currentDate.startOf('month').subtract(1, 'm'), this.props.format);
-
     this.setState({
-      currentDate
+      currentDate: moment.unix(this.state.currentDate).locale(this.props.locale).startOf('month').subtract(1, 'm').unix()
     });
   }
 
   _handleNextClick () {
-    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
-    let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
-
-    currentDate = moment(currentDate.endOf('month').add(1, 'd'), this.props.format);
-
     this.setState({
-      currentDate
+      currentDate: moment.unix(this.state.currentDate).locale(this.props.locale).endOf('month').add(1, 'd').unix()
     });
   }
 
@@ -78,14 +62,14 @@ class DatePickerFullScreen extends React.Component {
     });
   }
 
-  _renderMonthTable (currentDate, selectedDate) {
+  _renderMonthTable () {
     const days = [];
-    const startDate = moment(currentDate, this.props.format).startOf('month').startOf('week');
-    const endDate = moment(currentDate, this.props.format).endOf('month').endOf('week');
+    const startDate = moment(this.state.currentDate).startOf('month').startOf('week');
+    const endDate = moment(this.state.currentDate).endOf('month').endOf('week');
 
     while (startDate.isBefore(endDate)) {
-      const isCurrentMonth = startDate.month() === currentDate.month();
-      const isCurrentDay = startDate.format(this.props.format) === selectedDate.format(this.props.format);
+      const isCurrentMonth = startDate.month() === moment(this.state.currentDate).month();
+      const isCurrentDay = startDate.format(this.props.format) === moment(this.state.selectedDate).format(this.props.format);
       const active = this.props.minimumDate ? startDate.isAfter(moment.unix(this.props.minimumDate)) : true;
 
       days.push((
@@ -110,13 +94,10 @@ class DatePickerFullScreen extends React.Component {
   }
 
   render () {
-    const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
-    const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
-
     return (
       <div className='mx-date-picker-full-screen' style={[styles.component, this.props.style]}>
         <div key='selectedDate' onClick={this._toggleCalendar.bind(this)} style={[styles.placeholder, this.state.selectedDate && styles.selectedDate]}>
-          {selectedDate ? selectedDate.format(this.props.format) : 'Select A Date'}
+          {this.state.selectedDate ? moment.unix(this.state.selectedDate).locale(this.props.locale).format(this.props.format) : 'Select A Date'}
         </div>
         {this.state.showCalendar ? (
           <div className='mx-date-picker-full-screen-calendar-scrim' key='modal' style={[styles.modal, this.props.isFixed && { position: 'fixed' }]}>
@@ -137,7 +118,7 @@ class DatePickerFullScreen extends React.Component {
                   style={styles.navIcon}
                   type='caret-left'
                 />
-                {currentDate.format('MMMM YYYY')}
+                {moment.unix(this.state.currentDate).format('MMMM YYYY')}
                 <Icon
                   onClick={this._handleNextClick.bind(this)}
                   size='32px'
@@ -146,8 +127,9 @@ class DatePickerFullScreen extends React.Component {
                 />
               </div>
               <div style={styles.calendar}>
-                {this._renderMonthTable(currentDate, selectedDate)}
+                {this._renderMonthTable()}
               </div>
+              <div onClick={this._handleDateSelect.bind(this, null)} style={styles.clearButton}>Clear Date</div>
             </div>
           </div>
         ) : null }
@@ -299,6 +281,16 @@ const styles = {
   },
   currentMonth: {
     color: StyleConstants.Colors.CHARCOAL
+  },
+  clearButton: {
+    fontSize: StyleConstants.FontSizes.LARGE,
+    backgroundColor: StyleConstants.Colors.FOG,
+    color: StyleConstants.Colors.CHARCOAL,
+    fontWeight: 500,
+    padding: '7px 14px',
+    borderRadius: 2,
+    textAlign: 'center',
+    cursor: 'pointer'
   }
 };
 

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -11,8 +11,6 @@ class DatePickerFullScreen extends React.Component {
     super(props);
     this.state = {
       currentDate: null,
-      inputValue: this._getInputValueByDate(this.props.defaultDate),
-      isValid: true,
       selectedDate: this.props.defaultDate,
       showCalendar: false
     };
@@ -24,22 +22,6 @@ class DatePickerFullScreen extends React.Component {
         this._handleCloseClick();
       }
     };
-  }
-
-  _getInputValueByDate (date) {
-    let inputValue = null;
-
-    if (date) {
-      const newDate = moment.unix(date);
-
-      if (newDate.isValid()) {
-        inputValue = newDate.format(this.props.format);
-      } else {
-        inputValue = date;
-      }
-    }
-
-    return inputValue;
   }
 
   _getSelectedDate () {
@@ -55,38 +37,17 @@ class DatePickerFullScreen extends React.Component {
   }
 
   _handleDateSelect (date) {
+    const updatedState = {
+      selectedDate: date
+    };
+
     if (this.props.closeOnDateSelect) {
-      this._handleScrimClick();
+      updatedState.showCalendar = false;
     }
 
-    this.setState({
-      inputValue: moment.unix(date).format(this.props.format),
-      isValid: true,
-      selectedDate: date
-    });
+    this.setState(updatedState);
 
     this.props.onDateSelect(date);
-  }
-
-  _handleInputBlur (evt) {
-    if (evt.target.value.length === 0) {
-      this.props.onDateSelect(null);
-
-      this.setState({
-        inputValue: null,
-        selectedDate: null
-      });
-    } else {
-      this.setState({
-        inputValue: moment.unix(this.state.selectedDate).format(this.props.format)
-      });
-    }
-  }
-
-  _handleInputChange (evt) {
-    this.setState({
-      inputValue: evt.target.value
-    });
   }
 
   _handlePreviousClick () {
@@ -111,12 +72,6 @@ class DatePickerFullScreen extends React.Component {
     });
   }
 
-  _handleScrimClick () {
-    this.setState({
-      showCalendar: false
-    });
-  }
-
   _toggleCalendar () {
     this.setState({
       showCalendar: !this.state.showCalendar
@@ -127,83 +82,31 @@ class DatePickerFullScreen extends React.Component {
     const days = [];
     const startDate = moment(currentDate, this.props.format).startOf('month').startOf('week');
     const endDate = moment(currentDate, this.props.format).endOf('month').endOf('week');
-    const minimumDate = this.props.minimumDate ? moment.unix(this.props.minimumDate) : null;
 
     while (startDate.isBefore(endDate)) {
       const isCurrentMonth = startDate.month() === currentDate.month();
       const isCurrentDay = startDate.format(this.props.format) === selectedDate.format(this.props.format);
-      let day;
-      const noSelectDay = startDate.isBefore(minimumDate);
+      const active = this.props.minimumDate ? startDate.isAfter(moment.unix(this.props.minimumDate)) : true;
 
-      day = (
+      days.push((
         <div
-          key={startDate.month() + '-' + startDate.date()}
-          onClick={!noSelectDay ? this._handleDateSelect.bind(this, startDate.unix()) : null}
+          key={startDate.format('DDDD')}
+          onClick={active ? this._handleDateSelect.bind(this, startDate.unix()) : null}
           style={[
-            styles.calendarDay,
-            (!noSelectDay && isCurrentMonth) && styles.currentMonth
+            styles.dayContent,
+            isCurrentMonth && styles.currentMonth,
+            isCurrentDay && styles.currentDay,
+            active && styles.dayActive
           ]}
         >
-          <div
-            key={startDate.format('DDDD')}
-            style={[styles.calendarDayContent, noSelectDay ? styles.calendarDayDisabled : isCurrentDay && styles.currentDay]}
-          >
-            <div style={styles.calendarDayText}>{startDate.date()}</div>
-          </div>
-        </div>);
+          {startDate.date()}
+        </div>
+      ));
 
-      if (this.props.showDayBorders) {
-        day.props.style.push([styles.borderRight, styles.borderBottom]);
-      }
-
-      days.push(day);
       startDate.add(1, 'd');
     }
 
     return days;
-  }
-
-  _renderSelectedDate () {
-    if (this.props.useInputForSelectedDate) {
-      const hidePlaceholder = this.state.inputValue && this.state.inputValue.length;
-
-      return (
-        <div>
-          <input
-            key='input'
-            onBlur={this._handleInputBlur.bind(this)}
-            onChange={this._handleInputChange.bind(this)}
-            onClick={this._toggleCalendar.bind(this)}
-            style={[styles.input, this.props.inputStyle, hidePlaceholder && { backgroundColor: StyleConstants.Colors.INVERSE_PRIMARY }]}
-            type='text'
-            value={this.state.inputValue}
-          />
-          <div style={[styles.placeholderText, this.props.placeholderTextStyle]}>
-            {this.props.placeholderText || 'Select A Date'}
-          </div>
-        </div>
-      );
-    } else {
-      return (
-        <div
-          key='selectedDate'
-          onClick={this._toggleCalendar.bind(this)}
-          style={styles.selectedDate}
-        >
-          {this.state.inputValue}
-        </div>
-      );
-    }
-  }
-
-  _renderTitle (styles) {
-    if (this.props.title) {
-      return (
-        <div key='title' style={styles.title}>
-          {this.props.title}
-        </div>
-      );
-    }
   }
 
   render () {
@@ -211,53 +114,43 @@ class DatePickerFullScreen extends React.Component {
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
     return (
-      <div
-        className='mx-date-picker-full-screen'
-        style={[styles.component, styles.clearFix, this.props.style]}
-        tabIndex='0'
-      >
-        <div className='mx-date-picker-full-screen-selected-date' key='selectedDateWrapper' style={[
-          styles.selectedDateWrapper,
-          this.props.selectedDateWrapperStyle
-        ]}>
-          {this._renderSelectedDate()}
+      <div className='mx-date-picker-full-screen' style={[styles.component, this.props.style]}>
+        <div key='selectedDate' onClick={this._toggleCalendar.bind(this)} style={[styles.placeholder, this.state.selectedDate && styles.selectedDate]}>
+          {selectedDate ? selectedDate.format(this.props.format) : 'Select A Date'}
         </div>
-        <div className='mx-date-picker-full-screen-calendar-scrim' key='calendarModal' style={[
-          styles.calendarModal,
-          this.state.showCalendar && styles.calendarShow,
-          this.props.isFixed && { position: 'fixed' }
-        ]}>
-          <div onClick={this._handleCloseClick.bind(this)} style={styles.close}>
-            <Icon
-              size={20}
-              style={styles.closeIcon}
-              type={this.props.closeIcon}
-            />
-            <div style={styles.closeText}>ESC</div>
-          </div>
-          <div className='mx-date-picker-full-screen-calendar-wrapper' style={styles.calendarWrapper}>
-            {this._renderTitle(styles)}
-            <div className='mx-date-picker-full-screen-calendar-header' key='calendarHeader' style={[styles.calendarHeader, { borderBottomStyle: this.props.showDayBorders ? 'solid' : 'none' }, styles.clearFix]}>
-              <Icon
-                onClick={this._handlePreviousClick.bind(this)}
-                size='32px'
-                style={[styles.navIcon, styles.navLeft, this.props.showDayBorders && styles.borderRight]}
-                type='caret-left'
-              />
-              {currentDate.format('MMMM YYYY')}
-              <Icon
-                onClick={this._handleNextClick.bind(this)}
-                size='32px'
-                style={[styles.navIcon, styles.navRight, this.props.showDayBorders && styles.borderLeft]}
-                type='caret-right'
-              />
+        {this.state.showCalendar ? (
+          <div className='mx-date-picker-full-screen-calendar-scrim' key='modal' style={[styles.modal, this.props.isFixed && { position: 'fixed' }]}>
+            <div onClick={this._handleCloseClick.bind(this)} style={styles.close}>
+              <Icon size={20} style={styles.closeIcon} type={this.props.closeIcon} />
+              <div style={styles.closeText}>ESC</div>
             </div>
-            <div style={styles.calendarContainer}>
-              {this._renderMonthTable(currentDate, selectedDate)}
+            <div className='mx-date-picker-full-screen-calendar-wrapper' style={styles.calendarWrapper}>
+              {this.props.title ? (
+                <div key='title' style={styles.title}>
+                  {this.props.title}
+                </div>
+              ) : null }
+              <div className='mx-date-picker-full-screen-calendar-header' key='header' style={styles.header}>
+                <Icon
+                  onClick={this._handlePreviousClick.bind(this)}
+                  size='32px'
+                  style={styles.navIcon}
+                  type='caret-left'
+                />
+                {currentDate.format('MMMM YYYY')}
+                <Icon
+                  onClick={this._handleNextClick.bind(this)}
+                  size='32px'
+                  style={[styles.navIcon, styles.navRight]}
+                  type='caret-right'
+                />
+              </div>
+              <div style={styles.calendar}>
+                {this._renderMonthTable(currentDate, selectedDate)}
+              </div>
             </div>
-            <div style={styles.clearFix}></div>
           </div>
-        </div>
+        ) : null }
       </div>
     );
   }
@@ -268,18 +161,14 @@ DatePickerFullScreen.propTypes = {
   closeOnDateSelect: React.PropTypes.bool,
   defaultDate: React.PropTypes.number,
   format: React.PropTypes.string,
-  inputStyle: React.PropTypes.object,
   isFixed: React.PropTypes.bool,
   locale: React.PropTypes.string,
   minimumDate: React.PropTypes.number,
   onDateSelect: React.PropTypes.func,
   placeholderText: React.PropTypes.string,
   placeholderTextStyle: React.PropTypes.object,
-  selectedDateWrapperStyle: React.PropTypes.object,
-  showDayBorders: React.PropTypes.bool,
   style: React.PropTypes.object,
-  title: React.PropTypes.string,
-  useInputForSelectedDate: React.PropTypes.bool
+  title: React.PropTypes.string
 };
 
 DatePickerFullScreen.defaultProps = {
@@ -289,88 +178,47 @@ DatePickerFullScreen.defaultProps = {
   isFixed: false,
   locale: 'en',
   onDateSelect () {},
-  showDayBorders: false,
-  title: 'Select A Date',
-  useInputForSelectedDate: true
+  placeholderText: 'Select A Date',
+  title: 'Select A Date'
 };
 
 const styles = {
-  calendarDay: {
-    color: StyleConstants.Colors.ASH,
-    float: 'left',
-    paddingBottom: '11%',
-    position: 'relative',
-    width: '13.5%'
-  },
-  borderBottom: {
-    borderBottom: StyleConstants.Colors.FOG,
-    borderBottomStyle: 'solid',
-    borderBottomWidth: 1
-  },
-  borderRight: {
-    borderRight: StyleConstants.Colors.FOG,
-    borderRightStyle: 'solid',
-    borderRightWidth: 1
-  },
-  borderLeft: {
-    borderLeft: StyleConstants.Colors.FOG,
-    borderLeftStyle: 'solid',
-    borderLeftWidth: 1
-  },
-  calendarContainer: {
+  component: {
+    backgroundColor: '#fff',
+    fontFamily: StyleConstants.FontFamily,
+    fontSize: StyleConstants.FontSizes.LARGE,
     width: '100%',
-    padding: '0px 2px 10px 6px'
+
+    ':focus': {
+      boxShadow: 'none',
+      outline: 'none'
+    }
   },
-  calendarDayContent: {
-    borderRadius: '50%',
-    height: 32,
-    left: '50%',
-    position: 'absolute',
-    top: '50%',
-    transform: 'translateY(-50%) translateX(-50%)',
-    width: 32,
+  placeholder: {
+    color: StyleConstants.Colors.ASH,
+    fontSize: StyleConstants.FontSizes.LARGE
+  },
+  selectedDate: {
+    color: StyleConstants.Colors.CHARCOAL,
+    cursor: 'pointer',
+    fontSize: StyleConstants.FontSizes.LARGE,
+    verticalAlign: 'middle',
+    width: '100%',
 
     ':hover': {
-      backgroundColor: StyleConstants.Colors.BLUE,
-      color: StyleConstants.Colors.INVERSE_PRIMARY,
-      cursor: 'pointer'
+      color: StyleConstants.Colors.BLUE
     }
   },
-  calendarDayText: {
-    borderRadius: '100%',
-    fontSize: StyleConstants.FontSizes.MEDIUM,
-    fontWeight: 'normal',
-    left: '50%',
+  modal: {
+    backgroundColor: '#fff',
+    bottom: 0,
+    left: 0,
+    margin: 0,
+    padding: 0,
     position: 'absolute',
-    top: '50%',
-    transform: 'translateY(-50%) translateX(-50%)'
-  },
-  calendarDayDisabled: {
-    ':hover': {
-      background: 'none',
-      color: StyleConstants.Colors.PORCELAIN
-    }
-  },
-  calendarHeader: {
-    color: StyleConstants.Colors.CHARCOAL,
-    borderBottom: StyleConstants.Colors.FOG,
-    borderBottomWidth: 1,
-    fontSize: StyleConstants.FontSizes.XLARGE,
-    fontWeight: 'normal',
-    padding: '5px 0px 7px 0px',
-    position: 'relative',
-    textAlign: 'center',
-    textTransform: 'none'
-  },
-  calendarIcon: {
-    color: StyleConstants.Colors.PORCELAIN,
-    position: 'absolute',
-    right: 12.8,
-    top: '50%',
-    transform: 'translateY(-50%)'
-  },
-  calendarShow: {
-    display: 'block'
+    right: 0,
+    top: 0,
+    zIndex: 999
   },
   close: {
     position: 'absolute',
@@ -386,44 +234,64 @@ const styles = {
   closeText: {
     fontSize: StyleConstants.FontSizes.TINY
   },
-  clearFix: {
-    clear: 'both',
-    marginBottom: 15
-  },
-  component: {
-    backgroundColor: '#fff',
-    fontFamily: StyleConstants.FontFamily,
-    fontSize: StyleConstants.FontSizes.LARGE,
-    width: '100%',
-
-    ':focus': {
-      boxShadow: 'none',
-      outline: 'none'
-    }
-  },
-  calendarModal: {
-    backgroundColor: '#fff',
-    bottom: 0,
-    display: 'none',
-    left: 0,
-    margin: 0,
-    padding: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    zIndex: 999
+  title: {
+    boxSizing: 'border-box',
+    color: StyleConstants.Colors.CHARCOAL,
+    fontSize: StyleConstants.FontSizes.XXLARGE,
+    fontWeight: 600,
+    padding: '0 10px 20px'
   },
   calendarWrapper: {
-    height: 300,
+    maxHeight: 300,
     left: '50%',
     position: 'absolute',
     top: '50%',
     transform: 'translate(-50%, -50%)',
     width: 300
   },
-  selectedDateWrapper: {
+  header: {
+    color: StyleConstants.Colors.CHARCOAL,
+    fontSize: StyleConstants.FontSizes.XLARGE,
+    fontWeight: 'normal',
+    padding: '5px 0px 7px 0px',
     position: 'relative',
+    textAlign: 'center',
+    textTransform: 'none'
+  },
+  navIcon: {
+    position: 'absolute',
+    left: '0',
+    top: '50%',
+    transform: 'translateY(-50%)',
     cursor: 'pointer'
+  },
+  navRight: {
+    right: '0',
+    left: 'auto'
+  },
+  calendar: {
+    width: '100%',
+    padding: '0px 2px 10px 6px',
+    display: 'flex',
+    flexWrap: 'wrap'
+  },
+  dayContent: {
+    color: StyleConstants.Colors.ASH,
+    borderRadius: '100%',
+    height: 32,
+    lineHeight: '32px',
+    width: 32,
+    marginTop: 10,
+    textAlign: 'center',
+    fontSize: StyleConstants.FontSizes.MEDIUM
+  },
+  dayActive: {
+    cursor: 'pointer',
+
+    ':hover': {
+      backgroundColor: StyleConstants.Colors.BLUE,
+      color: StyleConstants.Colors.INVERSE_PRIMARY
+    }
   },
   currentDay: {
     backgroundColor: StyleConstants.Colors.BLUE,
@@ -431,66 +299,6 @@ const styles = {
   },
   currentMonth: {
     color: StyleConstants.Colors.CHARCOAL
-  },
-  input: {
-    backgroundColor: 'transparent',
-    border: 'none',
-    fontSize: StyleConstants.FontSizes.MEDIUM,
-    outline: 'none',
-    paddingBottom: 10,
-    paddingLeft: 5,
-    position: 'relative',
-    top: 5,
-    WebkitAppearance: 'none',
-    width: '80%',
-    zIndex: 2,
-
-    ':focus': {
-      border: 'none',
-      boxShadow: 'none',
-      outline: 'none'
-    }
-  },
-  navIcon: {
-    cursor: 'pointer'
-  },
-  navLeft: {
-    position: 'absolute',
-    left: '0',
-    top: '50%',
-    transform: 'translateY(-50%)'
-  },
-  navRight: {
-    position: 'absolute',
-    right: '0',
-    top: '50%',
-    transform: 'translateY(-50%)'
-  },
-  placeholderText: {
-    color: StyleConstants.Colors.CHARCOAL,
-    fontSize: StyleConstants.FontSizes.MEDIUM,
-    paddingLeft: 5,
-    position: 'absolute',
-    top: 10
-  },
-  selectedDate: {
-    color: StyleConstants.Colors.CHARCOAL,
-    cursor: 'pointer',
-    fontSize: StyleConstants.FontSizes.MEDIUM,
-    padding: '5px 0 5px 5px',
-    verticalAlign: 'middle',
-    width: '100%',
-
-    ':hover': {
-      color: StyleConstants.Colors.BLUE
-    }
-  },
-  title: {
-    boxSizing: 'border-box',
-    color: StyleConstants.Colors.CHARCOAL,
-    fontSize: StyleConstants.FontSizes.XXLARGE,
-    fontWeight: 'bold',
-    padding: '0px 0px 20px 10px'
   }
 };
 

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -33,6 +33,7 @@ module.exports = {
     JUMBO: '30px',
     XXLARGE: '21px',
     XLARGE: '17px',
+    LARGE: '15px',
     MEDIUM: '13px',
     SMALL: '11px',
     TINY: '10px'


### PR DESCRIPTION
WIP

This cleans up the full screen datepicker for more global use. Namely:
- Remove all layout styling (padding, margin, etc) from selected date and placeholder element
- Remove the input option. The purpose of this component is to simply select a date, not type one in
- Remove unneeded html elements
- Clean up the CSS (using flexbox instead of floats)