### PR TITLE
Fix modal content height issue.

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -163,7 +163,7 @@ const styles = {
   },
   content: {
     position: 'relative',
-    maxHeight: '100%',
+    maxHeight: '100% - 140px',
     overflow: 'auto'
   },
   footer: {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -102,7 +102,7 @@ class Modal extends React.Component {
               type='close-solid'
             />
             {this._renderTitleBar()}
-            <div className='mx-modal-content' style={styles.content}>
+            <div className='mx-modal-content' style={[styles.content, this.props.contentStyle]}>
               {this.props.children}
               {this._renderTooltip()}
             </div>
@@ -163,7 +163,7 @@ const styles = {
   },
   content: {
     position: 'relative',
-    maxHeight: 'calc(100% - 140px)',
+    maxHeight: '100%',
     overflow: 'auto'
   },
   footer: {
@@ -239,6 +239,7 @@ Modal.propTypes = {
     type: React.PropTypes.oneOf(['primary', 'secondary'])
   })),
   color: React.PropTypes.string,
+  contentStyle: React.PropTypes.object,
   isOpen: React.PropTypes.bool,
   isRelative: React.PropTypes.bool,
   onRequestClose: React.PropTypes.func,

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -163,7 +163,7 @@ const styles = {
   },
   content: {
     position: 'relative',
-    maxHeight: '100% - 140px',
+    maxHeight: 'calc(100% - 140px)',
     overflow: 'auto'
   },
   footer: {


### PR DESCRIPTION
This fixes an issue with the max height on the content div of the modal component.  We are using the the css utility `calc` for the default value but it is causing issues in some edge case where the content of the modal would force the bottom of the modal out of it's parent.

To fix this, we now allow a contentStyle prop where users can over ride the default and set their own height/max-height for the content div.

New Prop:

contentStyle (Object) : Style object used to style the content div of the modal 

@mxenabled/frontend-engineers 

Screen shots of the demo app using the 100% max-height default for default and small.
![screen shot 2015-12-07 at 5 17 40 pm](https://cloud.githubusercontent.com/assets/6463914/11644206/651a83e4-9d07-11e5-9248-dad1ac006324.png)
![screen shot 2015-12-07 at 5 17 54 pm](https://cloud.githubusercontent.com/assets/6463914/11644205/6518ac72-9d07-11e5-9765-3eed6dc8f11c.png)
