### PR TITLE
Update eslint modules, lock down eslint version used in travis, remove rule for multiple react components in same file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -184,7 +184,7 @@
     "react/jsx-uses-vars": 2,
     "react/no-did-mount-set-state": 0,
     "react/no-did-update-set-state": 2,
-    "react/no-multi-comp": 2,
+    "react/no-multi-comp": 0,
     "react/no-unknown-property": 2,
     "react/prop-types": [2, { "ignore": ["style", "children"] }],
     "react/react-in-jsx-scope": 2,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 before_install:
-  - npm install -g eslint
+  - npm install -g eslint@1.10.0
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -36,14 +36,15 @@
     "react-dom": "^0.14.0"
   },
   "devDependencies": {
-    "babel-core": "^5.6.15",
-    "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.3.1",
-    "eslint": "^1.7.2",
-    "eslint-plugin-react": "^3.4.2",
-    "eslint-watch": "^2.1.1",
+    "babel-core": "~5.8.0",
+    "babel-eslint": "~4.1.0",
+    "babel-loader": "~5.4.0",
+    "eslint": "~1.10.0",
+    "eslint-loader": "~1.1.0",
+    "eslint-plugin-react": "~3.10.0",
+    "webpack": "~1.12.9",
     "live-server": "^0.8.1",
     "node-libs-browser": "^0.5.2",
-    "webpack": "^1.10.1"
+    "webpack": "^1.12.9"
   }
 }


### PR DESCRIPTION
The eslint rule that checks to make sure only one React component is defined per file, doesn't like it when jsx is used outside of the ReactComponent class. We are using jsx when defining one of the default props in SelectFullScreen. Removing the rule for now since it's one we rarely (if ever) break. 

Also updated the eslint modules to correspond with our other internal projects at MX.

@mxenabled/frontend-engineers 