### PR TITLE
Fix nuances with TimeBasedLineChart spacing

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -579,18 +579,18 @@ const Demo = React.createClass({
         />
 
         <br/><br/>
-        <TimeBasedLineChart
-          breakPointDate={moment().startOf(dataType).unix()}
-          breakPointLabel={dataType == 'day' ? 'Today' : 'This Month'}
-          data={lineChartData[dataType]}
-          height={400}
-          hoverCallBack={this._handleLineChartHover}
-          margin={{ top: 30, right: 75, bottom: 30, left: 75 }}
-          rangeType={dataType}
-          shadeAreaBelowZero={true}
-          style={{ margin: '0 auto'}}
-          width={700}
-        />
+        <div style={{ textAlign: 'center' }}>
+          <TimeBasedLineChart
+            breakPointDate={moment().startOf(dataType).unix()}
+            breakPointLabel={dataType == 'day' ? 'Today' : 'This Month'}
+            data={lineChartData[dataType]}
+            height={400}
+            hoverCallBack={this._handleLineChartHover}
+            rangeType={dataType}
+            shadeAreaBelowZero={true}
+            width={700}
+          />
+        </div>
 
         <br/><br/>
         <div style={{ textAlign: 'center' }}>

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -726,7 +726,7 @@ TimeBasedLineChart.propTypes = {
   staticXAxis: React.PropTypes.bool,
   width: React.PropTypes.number,
   yAxisFormatter: React.PropTypes.func,
-  zeroState: React.PropTypes.node,
+  zeroState: React.PropTypes.node
 };
 
 TimeBasedLineChart.defaultProps = {

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -239,11 +239,6 @@ class TimeBasedLineChart extends React.Component {
       chart.append('g')
         .attr('class', 'grid-line')
         .attr('transform', 'translate(' + (margin.left - this._getSliceMiddle()) + ',' + (margin.top - 10) + ')');
-    } else {
-      chart.append('g')
-        .append('text')
-          .attr('transform', 'translate(' + ((width / 2) - 37) + ',' + (height / 2.5) + ')')
-          .text('No data found.');
     }
 
     chart.on('mouseleave', this._handleChartMouseLeave.bind(this));
@@ -644,9 +639,15 @@ class TimeBasedLineChart extends React.Component {
     this._renderChart();
 
     return (
-      <div className='mx-time-based-line-chart' style={[styles.component, { height: this.props.height + 'px', width: this.props.width + 'px' }, this.props.style]}>
-        {this._renderTooltip()}
-        <svg className='mx-time-based-line-chart-svg' ref='chart' />
+      <div className='mx-time-based-line-chart' style={[styles.component, { height: this.props.height + 'px', width: this.props.width + 'px' }]}>
+        {this.props.data.length ? (
+          <div>
+            {this._renderTooltip()}
+            <svg className='mx-time-based-line-chart-svg' ref='chart' />
+          </div>
+        ) : (
+          <div>{this.props.zeroState}</div>
+        )}
       </div>
     );
   }
@@ -655,9 +656,9 @@ class TimeBasedLineChart extends React.Component {
 const styles = {
   component: {
     fontFamily: StyleConstants.FontFamily,
-    padding: '10px',
     position: 'relative',
-    boxSizing: 'content-box'
+    boxSizing: 'content-box',
+    display: 'inline-block'
   },
   credit: {
     backgroundColor: '#30B53C'
@@ -724,7 +725,8 @@ TimeBasedLineChart.propTypes = {
   showTooltips: React.PropTypes.bool,
   staticXAxis: React.PropTypes.bool,
   width: React.PropTypes.number,
-  yAxisFormatter: React.PropTypes.func
+  yAxisFormatter: React.PropTypes.func,
+  zeroState: React.PropTypes.node,
 };
 
 TimeBasedLineChart.defaultProps = {
@@ -736,7 +738,7 @@ TimeBasedLineChart.defaultProps = {
   data: [],
   height: 400,
   lineColor: StyleConstants.Colors.PRIMARY,
-  margin: { top: 30, right: 50, bottom: 20, left: 50 },
+  margin: { top: 30, right: 0, bottom: 20, left: 50 },
   onDataPointHover: () => {},
   rangeType: 'day',
   shadeAreaBelowZero: false,
@@ -746,7 +748,8 @@ TimeBasedLineChart.defaultProps = {
   width: 550,
   yAxisFormatter (d) {
     return numeral(d).format('0a');
-  }
+  },
+  zeroState: 'No Data Found'
 };
 
 module.exports = Radium(TimeBasedLineChart);


### PR DESCRIPTION
- Allowing a user to set the styles, specifically `padding` and `box-sizing` was breaking the chart width and spacing. This removes the ability to set the styles on the wrapping `div`. Users should still be able to accomplish the same results by wrapping this component with a div that hold their custom styles.
- Now that the spacing is cleaned up, the best default right margin is `0`.
- This also moves the zeroState out of D3 and exposes a `zeroState` prop that allows users to set the chart zero state using anything that is renderable (string, number, jsx, etc).

@mxenabled/frontend-engineers 