### PR TITLE
Fix TimeBasedLineChart when receiving new data props

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -296,188 +296,132 @@ const icons = [
   }
 ];
 
-const lineChartData = {
-  day: [
-    {
-      timeStamp: moment().subtract(15, 'days').startOf('day').unix(),
-      value: 800
-    },
-    {
-      timeStamp: moment().subtract(14, 'days').startOf('day').unix(),
-      value: 900
-    },
-    {
-      timeStamp: moment().subtract(13, 'days').startOf('day').unix(),
-      value: 1200
-    },
-    {
-      timeStamp: moment().subtract(12, 'days').startOf('day').unix(),
-      value: 850
-    },
-    {
-      timeStamp: moment().subtract(11, 'days').startOf('day').unix(),
-      value: 660
-    },
-    {
-      timeStamp: moment().subtract(10, 'days').startOf('day').unix(),
-      value: 720
-    },
-    {
-      timeStamp: moment().subtract(9, 'days').startOf('day').unix(),
-      value: 900
-    },
-    {
-      timeStamp: moment().subtract(8, 'days').startOf('day').unix(),
-      value: 700
-    },
-    {
-      timeStamp: moment().subtract(7, 'days').startOf('day').unix(),
-      value: 600
-    },
-    {
-      timeStamp: moment().subtract(6, 'days').startOf('day').unix(),
-      value: 1200
-    },
-    {
-      timeStamp: moment().subtract(5, 'days').startOf('day').unix(),
-      value: 900
-    },
-    {
-      timeStamp: moment().subtract(4, 'days').startOf('day').unix(),
-      value: 800
-    },
-    {
-      timeStamp: moment().subtract(3, 'days').startOf('day').unix(),
-      value: 600
-    },
-    {
-      timeStamp: moment().subtract(2, 'days').startOf('day').unix(),
-      value: 1600
-    },
-    {
-      timeStamp: moment().subtract(1, 'days').startOf('day').unix(),
-      value: 1700
-    },
-    {
-      timeStamp: moment().startOf('day').unix(),
-      value: 1400
-    },
-    {
-      timeStamp: moment().add(1, 'days').startOf('day').unix(),
-      value: 1200
-    },
-    {
-      timeStamp: moment().add(2, 'days').startOf('day').unix(),
-      value: 1200
-    },
-    {
-      timeStamp: moment().add(3, 'days').startOf('day').unix(),
-      value: 1700
-    },
-    {
-      timeStamp: moment().add(4, 'days').startOf('day').unix(),
-      value: 1100
-    },
-    {
-      timeStamp: moment().add(5, 'days').startOf('day').unix(),
-      value: 1000
-    },
-    {
-      timeStamp: moment().add(6, 'days').startOf('day').unix(),
-      value: 900
-    },
-    {
-      timeStamp: moment().add(7, 'days').startOf('day').unix(),
-      value: 1000
-    },
-    {
-      timeStamp: moment().add(8, 'days').startOf('day').unix(),
-      value: 850
-    },
-    {
-      timeStamp: moment().add(9, 'days').startOf('day').unix(),
-      value: 1500
-    },
-    {
-      timeStamp: moment().add(10, 'days').startOf('day').unix(),
-      value: 1100
-    },
-    {
-      timeStamp: moment().add(11, 'days').startOf('day').unix(),
-      value: 1000
-    },
-    {
-      timeStamp: moment().add(12, 'days').startOf('day').unix(),
-      value: 800
-    },
-    {
-      timeStamp: moment().add(13, 'days').startOf('day').unix(),
-      value: 1100
-    },
-    {
-      timeStamp: moment().add(14, 'days').startOf('day').unix(),
-      value: 1300
-    },
-    {
-      timeStamp: moment().add(15, 'days').startOf('day').unix(),
-      value: 2200
-    }
-  ],
-  month: [
-    {
-      timeStamp: moment().subtract(6, 'months').startOf('month').unix(),
-      value: 800
-    },
-    {
-      timeStamp: moment().subtract(5, 'months').startOf('month').unix(),
-      value: 600
-    },
-    {
-      timeStamp: moment().subtract(4, 'months').startOf('month').unix(),
-      value: 600
-    },
-    {
-      timeStamp: moment().subtract(3, 'months').startOf('month').unix(),
-      value: 600
-    },
-    {
-      timeStamp: moment().subtract(2, 'months').startOf('month').unix(),
-      value: 1600
-    },
-    {
-      timeStamp: moment().subtract(1, 'months').startOf('month').unix(),
-      value: 1700
-    },
-    {
-      timeStamp: moment().startOf('month').unix(),
-      value: 1400
-    },
-    {
-      timeStamp: moment().add(1, 'months').startOf('month').unix(),
-      value: 1200
-    },
-    {
-      timeStamp: moment().add(2, 'months').startOf('month').unix(),
-      value: 1200
-    },
-    {
-      timeStamp: moment().add(3, 'months').startOf('month').unix(),
-      value: 1700
-    },
-    {
-      timeStamp: moment().add(4, 'months').startOf('month').unix(),
-      value: 1100
-    },
-    {
-      timeStamp: moment().add(5, 'months').startOf('month').unix(),
-      value: 1000
-    },
-    {
-      timeStamp: moment().add(6, 'months').startOf('month').unix(),
-      value: 900
-    }
-  ]
-};
+const lineChartData = [
+  {
+    timeStamp: moment().subtract(15, 'days').startOf('day').unix(),
+    value: 800
+  },
+  {
+    timeStamp: moment().subtract(14, 'days').startOf('day').unix(),
+    value: 900
+  },
+  {
+    timeStamp: moment().subtract(13, 'days').startOf('day').unix(),
+    value: 1200
+  },
+  {
+    timeStamp: moment().subtract(12, 'days').startOf('day').unix(),
+    value: 850
+  },
+  {
+    timeStamp: moment().subtract(11, 'days').startOf('day').unix(),
+    value: 660
+  },
+  {
+    timeStamp: moment().subtract(10, 'days').startOf('day').unix(),
+    value: 720
+  },
+  {
+    timeStamp: moment().subtract(9, 'days').startOf('day').unix(),
+    value: 900
+  },
+  {
+    timeStamp: moment().subtract(8, 'days').startOf('day').unix(),
+    value: 700
+  },
+  {
+    timeStamp: moment().subtract(7, 'days').startOf('day').unix(),
+    value: 600
+  },
+  {
+    timeStamp: moment().subtract(6, 'days').startOf('day').unix(),
+    value: 1200
+  },
+  {
+    timeStamp: moment().subtract(5, 'days').startOf('day').unix(),
+    value: 900
+  },
+  {
+    timeStamp: moment().subtract(4, 'days').startOf('day').unix(),
+    value: 800
+  },
+  {
+    timeStamp: moment().subtract(3, 'days').startOf('day').unix(),
+    value: 600
+  },
+  {
+    timeStamp: moment().subtract(2, 'days').startOf('day').unix(),
+    value: 1600
+  },
+  {
+    timeStamp: moment().subtract(1, 'days').startOf('day').unix(),
+    value: 1700
+  },
+  {
+    timeStamp: moment().startOf('day').unix(),
+    value: 1400
+  },
+  {
+    timeStamp: moment().add(1, 'days').startOf('day').unix(),
+    value: 1200
+  },
+  {
+    timeStamp: moment().add(2, 'days').startOf('day').unix(),
+    value: 1200
+  },
+  {
+    timeStamp: moment().add(3, 'days').startOf('day').unix(),
+    value: 1700
+  },
+  {
+    timeStamp: moment().add(4, 'days').startOf('day').unix(),
+    value: 1100
+  },
+  {
+    timeStamp: moment().add(5, 'days').startOf('day').unix(),
+    value: 1000
+  },
+  {
+    timeStamp: moment().add(6, 'days').startOf('day').unix(),
+    value: 900
+  },
+  {
+    timeStamp: moment().add(7, 'days').startOf('day').unix(),
+    value: 1000
+  },
+  {
+    timeStamp: moment().add(8, 'days').startOf('day').unix(),
+    value: 850
+  },
+  {
+    timeStamp: moment().add(9, 'days').startOf('day').unix(),
+    value: 1500
+  },
+  {
+    timeStamp: moment().add(10, 'days').startOf('day').unix(),
+    value: 1100
+  },
+  {
+    timeStamp: moment().add(11, 'days').startOf('day').unix(),
+    value: 1000
+  },
+  {
+    timeStamp: moment().add(12, 'days').startOf('day').unix(),
+    value: 800
+  },
+  {
+    timeStamp: moment().add(13, 'days').startOf('day').unix(),
+    value: 1100
+  },
+  {
+    timeStamp: moment().add(14, 'days').startOf('day').unix(),
+    value: 1300
+  },
+  {
+    timeStamp: moment().add(15, 'days').startOf('day').unix(),
+    value: 2200
+  }
+];
 
 const Demo = React.createClass({
   getInitialState () {
@@ -486,6 +430,7 @@ const Demo = React.createClass({
         value: 'accounts',
         displayValue: 'Accounts'
       },
+      lineChartData: [],
       selectedDatePickerDate: moment().unix(),
       showModal: false,
       showSmallModal: false,
@@ -495,6 +440,12 @@ const Demo = React.createClass({
 
   componentDidMount () {
     window.addEventListener('resize', this._handleWindowResize);
+
+    setTimeout(() => {
+      this.setState({
+        lineChartData
+      });
+    }, 3000);
   },
 
   componentWillUnmount () {
@@ -520,8 +471,6 @@ const Demo = React.createClass({
   },
 
   render () {
-    const dataType = 'day';
-
     return (
       <div>
         <br/><br/>
@@ -585,12 +534,12 @@ const Demo = React.createClass({
         <br/><br/>
         <div style={{ textAlign: 'center' }}>
           <TimeBasedLineChart
-            breakPointDate={moment().startOf(dataType).unix()}
-            breakPointLabel={dataType == 'day' ? 'Today' : 'This Month'}
-            data={lineChartData[dataType]}
+            breakPointDate={moment().startOf('day').unix()}
+            breakPointLabel={'Today'}
+            data={this.state.lineChartData}
             height={400}
             hoverCallBack={this._handleLineChartHover}
-            rangeType={dataType}
+            rangeType={'day'}
             shadeAreaBelowZero={true}
             width={700}
           />

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^3.10.1",
     "moment": "^2.10.3",
     "numeral": "^1.5.3",
-    "object-assign": "3.x.x",
+    "object-assign": "^4.0.1",
     "radium": "^0.14.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -204,13 +204,8 @@ class TimeBasedLineChart extends React.Component {
   }
 
   _renderChart () {
-    const data = this.props.data;
-
     this._renderChartBase();
-
-    if (data.length > 0) {
-      this._renderLineChart();
-    }
+    this._renderLineChart();
   }
 
   _renderChartBase () {
@@ -240,8 +235,6 @@ class TimeBasedLineChart extends React.Component {
         .attr('class', 'grid-line')
         .attr('transform', 'translate(' + (margin.left - this._getSliceMiddle()) + ',' + (margin.top - 10) + ')');
     }
-
-    chart.on('mouseleave', this._handleChartMouseLeave.bind(this));
   }
 
   _renderLineChart () {
@@ -636,18 +629,15 @@ class TimeBasedLineChart extends React.Component {
   }
 
   render () {
-    this._renderChart();
-
     return (
       <div className='mx-time-based-line-chart' style={[styles.component, { height: this.props.height + 'px', width: this.props.width + 'px' }]}>
         {this.props.data.length ? (
           <div>
             {this._renderTooltip()}
-            <svg className='mx-time-based-line-chart-svg' ref='chart' />
+            {this._renderChart()}
           </div>
-        ) : (
-          <div>{this.props.zeroState}</div>
-        )}
+        ) : this.props.zeroState}
+        <svg className='mx-time-based-line-chart-svg' onMouseLeave={this._handleChartMouseLeave.bind(this)} ref='chart' />
       </div>
     );
   }
@@ -704,6 +694,12 @@ const styles = {
     display: 'inline-block',
     position: 'absolute',
     zIndex: '1'
+  },
+  zeroState: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)'
   }
 };
 
@@ -749,7 +745,7 @@ TimeBasedLineChart.defaultProps = {
   yAxisFormatter (d) {
     return numeral(d).format('0a');
   },
-  zeroState: 'No Data Found'
+  zeroState: <div style={styles.zeroState}>No Data Found</div>
 };
 
 module.exports = Radium(TimeBasedLineChart);


### PR DESCRIPTION
My last changes worked if the data is passed into the initial props. If data was passed into the prop anytime after initial mount, then the chart wouldn't display. This was due to the fact that we were not initially rendering out the svg element that D3 uses. So, after the initial load, the reference to the svg didn't exist.

This also does the following:
- Updates the demo to mimic the behavior of the data coming in after initial mount
- Moves the mouseLeave event handler onto the svg element
- Updates object-assign module (was getting some dependency conflicts, all npm commands still work)

@mxenabled/frontend-engineers 