### PR TITLE
Luke/range selector click functionality

### DIFF
--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -20,7 +20,8 @@ class RangeSelector extends React.Component {
       selectedLabel: this._getSelectedLabel(lowerValue, upperValue),
       showPresets: !!this.props.presets.length && !lowerValue && !upperValue,
       upperPixels: 1,
-      upperValue
+      upperValue,
+      trackClicked: false
     };
   }
 
@@ -92,7 +93,11 @@ class RangeSelector extends React.Component {
     });
   }
 
-  _handleClickStartOnTrack (e) {
+  _handleTrackMouseDown (e) {
+    this.setState({
+      trackClicked: true
+    });
+    
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
 
     const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
@@ -125,35 +130,8 @@ class RangeSelector extends React.Component {
       });
     }
   }
-
-  _handleClickOnTrack (e) {
-    if (this.state.dragging) {
-      const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-      const pixelInterval = this.props.interval * this.state.width / this.state.range;
-      const newState = {
-        selectedLabel: null
-      };
-
-      let newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
-
-      //make sure we snap to our interval
-      newPixels = Math.round(newPixels / pixelInterval) * pixelInterval;
-
-      //convert our pixels to a 0-based scale
-      const newPosition = (newPixels * this.state.range / this.state.width) + this.props.lowerBound;
-
-      //covert our 0-based value to actual value
-      const newValue = Math.round(newPosition / this.props.interval) * this.props.interval;
-
-      newState[this.state.dragging.toLowerCase() + 'Pixels'] = newPixels;
-      newState[this.state.dragging.toLowerCase() + 'Value'] = newValue;
-
-      this.setState(newState);
-
-      e.preventDefault();
-    }
-  }
-
+  
+  //this method now handles both the dragging of the toggle, and moving it when track is clicked
   _handleDragging (e) {
     if (this.state.dragging) {
       const clientX = e.touches ? e.touches[0].clientX : e.clientX;
@@ -198,7 +176,11 @@ class RangeSelector extends React.Component {
     }
   }
 
-  _handleDragEnd () {
+  _handleDragEnd (e) {
+    if (this.state.trackClicked) {
+      this._handleDragging(e);
+    }
+    
     if (this.state.dragging) {
       this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
     }
@@ -358,8 +340,7 @@ class RangeSelector extends React.Component {
           {this.props.presets.length ? <div className='mx-rangeselector-toggle' onClick={this._handleToggleViews.bind(this)} style={styles.showPresets}>Groups</div> : null}
 	<div
           className='mx-rangeselector-track-holder'
-          onMouseDown={this._handleClickStartOnTrack.bind(this)}
-          onMouseUp={this._handleClickOnTrack.bind(this)}
+          onMouseDown={this._handleTrackMouseDown.bind(this)}
           style={styles.trackHolder}
 	>
           <div className='mx-rangeselector-track' style={styles.track}></div>

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -93,66 +93,66 @@ class RangeSelector extends React.Component {
   }
 
   _handleClickStartOnTrack (e) {
-	const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    const clientX = e.touches ? e.touches[0].clientX : e.clientX;
 
-	let newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
+    let newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
 
-	//click point is less than lower selector
-	if (newPixels < this.state.lowerPixels) {
-	  this.setState({
-		dragging: 'Lower'
-	  });
-	}
+    //click point is less than lower selector
+    if (newPixels < this.state.lowerPixels) {
+      this.setState({
+        dragging: 'Lower'
+      });
+    }
 
-	//click point is higher than upper selector
-	if (newPixels > this.state.upperPixels) {
-	  this.setState({
-		dragging: 'Upper'
-	  });
-	}
+    //click point is higher than upper selector
+    if (newPixels > this.state.upperPixels) {
+      this.setState({
+	dragging: 'Upper'
+      });
+    }
 
-	//click point is higher than lower selector && also lower than midway point between selectors
-	if (newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2)) {
-	  this.setState({
-		dragging: 'Lower'
-	  });
-	}
+    //click point is higher than lower selector && also lower than midway point between selectors
+    if (newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2)) {
+      this.setState({
+	dragging: 'Lower'
+      });
+    }
 
-	//click point is lower than upper selector && also greater than midway point between selectors
-	if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels-this.state.lowerPixels) / 2)) {
-	  this.setState({
-	    dragging: 'Upper'
-	  });
-	}
+    //click point is lower than upper selector && also greater than midway point between selectors
+    if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels-this.state.lowerPixels) / 2)) {
+      this.setState({
+        dragging: 'Upper'
+      });
+    }
   }
 
   _handleClickOnTrack (e) {
     if (this.state.dragging) {
+ 
+      const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+      const pixelInterval = this.props.interval * this.state.width / this.state.range;
+      const newState = {
+        selectedLabel: null
+      };
 
-	  const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-	  const pixelInterval = this.props.interval * this.state.width / this.state.range;
-	  const newState = {
-	    selectedLabel: null
-	  };
+      let newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
 
-	  let newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
+      //make sure we snap to our interval
+      newPixels = Math.round(newPixels / pixelInterval) * pixelInterval;
 
-	  //make sure we snap to our interval
-	  newPixels = Math.round(newPixels / pixelInterval) * pixelInterval;
+      //convert our pixels to a 0-based scale
+      const newPosition = (newPixels * this.state.range / this.state.width) + this.props.lowerBound;
 
-	  //convert our pixels to a 0-based scale
-	  const newPosition = (newPixels * this.state.range / this.state.width) + this.props.lowerBound;
+      //covert our 0-based value to actual value
+      const newValue = Math.round(newPosition / this.props.interval) * this.props.interval;
 
-	  //covert our 0-based value to actual value
-	  const newValue = Math.round(newPosition / this.props.interval) * this.props.interval;
+      newState[this.state.dragging.toLowerCase() + 'Pixels'] = newPixels;
+      newState[this.state.dragging.toLowerCase() + 'Value'] = newValue;
 
-	  newState[this.state.dragging.toLowerCase() + 'Pixels'] = newPixels;
-	  newState[this.state.dragging.toLowerCase() + 'Value'] = newValue;
+      this.setState(newState);
 
-	  this.setState(newState);
-
-	  e.preventDefault();
-	}
+      e.preventDefault();
+    }
   }
 
   _handleDragging (e) {
@@ -242,10 +242,10 @@ class RangeSelector extends React.Component {
         height: '1px',
         background: '#ccc'
       },
-	  trackHolder: {
-		padding: '15px 0',
-		cursor: 'pointer'
-	  },
+      trackHolder: {
+        padding: '15px 0',
+        cursor: 'pointer'
+      },
       lowerToggle: {
         width: '20px',
         height: '20px',
@@ -357,18 +357,18 @@ class RangeSelector extends React.Component {
           style={styles.range}
         >
           {this.props.presets.length ? <div className='mx-rangeselector-toggle' onClick={this._handleToggleViews.bind(this)} style={styles.showPresets}>Groups</div> : null}
-		  <div
-		    className='mx-rangeselector-track-holder' style={styles.trackHolder}
-			onMouseDown={this._handleClickStartOnTrack.bind(this)}
-			onMouseUp={this._handleClickOnTrack.bind(this)}
-		  >
-		    <div className='mx-rangeselector-track' style={styles.track}></div>
+	<div
+	  className='mx-rangeselector-track-holder' style={styles.trackHolder}
+	  onMouseDown={this._handleClickStartOnTrack.bind(this)}
+	  onMouseUp={this._handleClickOnTrack.bind(this)}
+	>
+	  <div className='mx-rangeselector-track' style={styles.track}></div>
             <div className='mx-rangeselector-selected' style={styles.selected}>
               <div className='mx-rangeselector-selected-label' style={styles.selectedLabel}>
                 {this.state.selectedLabel}
               </div>
             </div>
-		  </div>
+	</div>
           <div
             className='mx-rangeselector-lower-toggle'
             onMouseDown={this._handleDragStart.bind(this, 'Lower')}

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -94,9 +94,9 @@ class RangeSelector extends React.Component {
   }
 
   _handleTrackMouseDown (e) {
-    this.setState({
+    const updatedState = {
       trackClicked: true
-    });
+    };
 
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
 
@@ -129,6 +129,8 @@ class RangeSelector extends React.Component {
         dragging: 'Upper'
       });
     }
+    
+    this.setState(updatedState);
   }
 
   //this method now handles both the dragging of the toggle, and moving it when track is clicked
@@ -170,8 +172,17 @@ class RangeSelector extends React.Component {
       newState[this.state.dragging.toLowerCase() + 'Pixels'] = newPixels;
       newState[this.state.dragging.toLowerCase() + 'Value'] = newValue;
 
-      this.setState(newState);
-
+      this.setState(newState, () => {
+        this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
+        
+        if (this.state.trackClicked) {
+          this.setState({
+            dragging: false,
+            trackClicked: false
+          });
+        }
+      });
+      
       e.preventDefault();
     }
   }
@@ -179,15 +190,12 @@ class RangeSelector extends React.Component {
   _handleDragEnd (e) {
     if (this.state.trackClicked) {
       this._handleDragging(e);
+    } else {
+      this.setState({
+        dragging: false,
+        trackClicked: false
+      });
     }
-
-    if (this.state.dragging) {
-      this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
-    }
-
-    this.setState({
-      dragging: false
-    });
   }
 
   _handleToggleViews () {

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -173,13 +173,13 @@ class RangeSelector extends React.Component {
       newState[this.state.dragging.toLowerCase() + 'Value'] = newValue;
 
       if (this.state.trackClicked) {
-      	newState.dragging = false;
-      	newState.trackClicked = false;
+        newState.dragging = false;
+        newState.trackClicked = false;
       }
       this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
-      
+
       this.setState(newState);
-      
+
       e.preventDefault();
     }
   }

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -129,7 +129,7 @@ class RangeSelector extends React.Component {
         dragging: 'Upper'
       });
     }
-    
+
     this.setState(updatedState);
   }
 
@@ -174,7 +174,7 @@ class RangeSelector extends React.Component {
 
       this.setState(newState, () => {
         this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
-        
+
         if (this.state.trackClicked) {
           this.setState({
             dragging: false,
@@ -182,7 +182,7 @@ class RangeSelector extends React.Component {
           });
         }
       });
-      
+
       e.preventDefault();
     }
   }

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -172,17 +172,14 @@ class RangeSelector extends React.Component {
       newState[this.state.dragging.toLowerCase() + 'Pixels'] = newPixels;
       newState[this.state.dragging.toLowerCase() + 'Value'] = newValue;
 
-      this.setState(newState, () => {
-        this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
-
-        if (this.state.trackClicked) {
-          this.setState({
-            dragging: false,
-            trackClicked: false
-          });
-        }
-      });
-
+      if (this.state.trackClicked) {
+      	newState.dragging = false;
+      	newState.trackClicked = false;
+      }
+      this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
+      
+      this.setState(newState);
+      
       e.preventDefault();
     }
   }

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -234,10 +234,9 @@ class RangeSelector extends React.Component {
         display: this.state.showPresets ? 'block' : 'none'
       },
       range: {
-    	padding: '45px 0',
+    	padding: '30px 0',
         margin: '0 10px',
-        visibility: this.state.showPresets ? 'hidden' : 'visible',
-		border: '1px solid red'
+        visibility: this.state.showPresets ? 'hidden' : 'visible'
       },
       track: {
         height: '1px',
@@ -245,8 +244,7 @@ class RangeSelector extends React.Component {
       },
 	  trackHolder: {
 		padding: '15px 0',
-		cursor: 'pointer',
-		border: '1px solid blue'
+		cursor: 'pointer'
 	  },
       lowerToggle: {
         width: '20px',

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -94,44 +94,26 @@ class RangeSelector extends React.Component {
   }
 
   _handleTrackMouseDown (e) {
-    const updatedState = {
-      trackClicked: true
-    };
+  const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+  const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
+  const updatedState = {
+    trackClicked: true
+  };
+  const clickBelowLower = newPixels < this.state.lowerPixels;
+  const clickAboveUpper = newPixels > this.state.upperPixels;
+  const clickCloserToLower = newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2);
+  const clickCloserToUpper = newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2);
 
-    const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-
-    const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
-
-    //click point is less than lower selector
-    if (newPixels < this.state.lowerPixels) {
-      this.setState({
-        dragging: 'Lower'
-      });
-    }
-
-    //click point is higher than upper selector
-    if (newPixels > this.state.upperPixels) {
-      this.setState({
-        dragging: 'Upper'
-      });
-    }
-
-    //click point is higher than lower selector && also lower than midway point between selectors
-    if (newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2)) {
-      this.setState({
-        dragging: 'Lower'
-      });
-    }
-
-    //click point is lower than upper selector && also greater than midway point between selectors
-    if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2)) {
-      this.setState({
-        dragging: 'Upper'
-      });
-    }
-
-    this.setState(updatedState);
+  if (clickBelowLower || clickCloserToLower) {
+    updatedState.dragging = 'Lower';
   }
+
+  if (clickAboveUpper || clickCloserToUpper) {
+    updatedState.dragging = 'Upper';
+  }
+
+  this.setState(updatedState);
+}
 
   //this method now handles both the dragging of the toggle, and moving it when track is clicked
   _handleDragging (e) {

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -357,12 +357,12 @@ class RangeSelector extends React.Component {
         >
           {this.props.presets.length ? <div className='mx-rangeselector-toggle' onClick={this._handleToggleViews.bind(this)} style={styles.showPresets}>Groups</div> : null}
 	<div
-	  className='mx-rangeselector-track-holder' 
-	  onMouseDown={this._handleClickStartOnTrack.bind(this)}
-	  onMouseUp={this._handleClickOnTrack.bind(this)}
-	  style={styles.trackHolder}
+          className='mx-rangeselector-track-holder'
+          onMouseDown={this._handleClickStartOnTrack.bind(this)}
+          onMouseUp={this._handleClickOnTrack.bind(this)}
+          style={styles.trackHolder}
 	>
-	  <div className='mx-rangeselector-track' style={styles.track}></div>
+          <div className='mx-rangeselector-track' style={styles.track}></div>
             <div className='mx-rangeselector-selected' style={styles.selected}>
               <div className='mx-rangeselector-selected-label' style={styles.selectedLabel}>
                 {this.state.selectedLabel}

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -122,7 +122,7 @@ class RangeSelector extends React.Component {
         dragging: 'Lower'
       });
     }
-
+    
     //click point is lower than upper selector && also greater than midway point between selectors
     if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2)) {
       this.setState({

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -95,7 +95,7 @@ class RangeSelector extends React.Component {
   _handleClickStartOnTrack (e) {
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
 
-    let newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
+    const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
 
     //click point is less than lower selector
     if (newPixels < this.state.lowerPixels) {
@@ -107,19 +107,19 @@ class RangeSelector extends React.Component {
     //click point is higher than upper selector
     if (newPixels > this.state.upperPixels) {
       this.setState({
-	dragging: 'Upper'
+        dragging: 'Upper'
       });
     }
 
     //click point is higher than lower selector && also lower than midway point between selectors
     if (newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2)) {
       this.setState({
-	dragging: 'Lower'
+        dragging: 'Lower'
       });
     }
 
     //click point is lower than upper selector && also greater than midway point between selectors
-    if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels-this.state.lowerPixels) / 2)) {
+    if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2)) {
       this.setState({
         dragging: 'Upper'
       });
@@ -128,7 +128,6 @@ class RangeSelector extends React.Component {
 
   _handleClickOnTrack (e) {
     if (this.state.dragging) {
- 
       const clientX = e.touches ? e.touches[0].clientX : e.clientX;
       const pixelInterval = this.props.interval * this.state.width / this.state.range;
       const newState = {
@@ -234,7 +233,7 @@ class RangeSelector extends React.Component {
         display: this.state.showPresets ? 'block' : 'none'
       },
       range: {
-    	padding: '30px 0',
+        padding: '30px 0',
         margin: '0 10px',
         visibility: this.state.showPresets ? 'hidden' : 'visible'
       },
@@ -358,9 +357,10 @@ class RangeSelector extends React.Component {
         >
           {this.props.presets.length ? <div className='mx-rangeselector-toggle' onClick={this._handleToggleViews.bind(this)} style={styles.showPresets}>Groups</div> : null}
 	<div
-	  className='mx-rangeselector-track-holder' style={styles.trackHolder}
+	  className='mx-rangeselector-track-holder' 
 	  onMouseDown={this._handleClickStartOnTrack.bind(this)}
 	  onMouseUp={this._handleClickOnTrack.bind(this)}
+	  style={styles.trackHolder}
 	>
 	  <div className='mx-rangeselector-track' style={styles.track}></div>
             <div className='mx-rangeselector-selected' style={styles.selected}>

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -94,26 +94,26 @@ class RangeSelector extends React.Component {
   }
 
   _handleTrackMouseDown (e) {
-  const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-  const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
-  const updatedState = {
-    trackClicked: true
-  };
-  const clickBelowLower = newPixels < this.state.lowerPixels;
-  const clickAboveUpper = newPixels > this.state.upperPixels;
-  const clickCloserToLower = newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2);
-  const clickCloserToUpper = newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2);
+    const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
+    const updatedState = {
+      trackClicked: true
+    };
+    const clickBelowLower = newPixels < this.state.lowerPixels;
+    const clickAboveUpper = newPixels > this.state.upperPixels;
+    const clickCloserToLower = newPixels > this.state.lowerPixels && newPixels < (this.state.lowerPixels + (this.state.upperPixels - this.state.lowerPixels) / 2);
+    const clickCloserToUpper = newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2);
 
-  if (clickBelowLower || clickCloserToLower) {
-    updatedState.dragging = 'Lower';
+    if (clickBelowLower || clickCloserToLower) {
+      updatedState.dragging = 'Lower';
+    }
+
+    if (clickAboveUpper || clickCloserToUpper) {
+      updatedState.dragging = 'Upper';
+    }
+
+    this.setState(updatedState);
   }
-
-  if (clickAboveUpper || clickCloserToUpper) {
-    updatedState.dragging = 'Upper';
-  }
-
-  this.setState(updatedState);
-}
 
   //this method now handles both the dragging of the toggle, and moving it when track is clicked
   _handleDragging (e) {

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -97,7 +97,7 @@ class RangeSelector extends React.Component {
     this.setState({
       trackClicked: true
     });
-    
+
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
 
     const newPixels = clientX - ReactDOM.findDOMNode(this.refs.rangeSelector).getBoundingClientRect().left;
@@ -122,7 +122,7 @@ class RangeSelector extends React.Component {
         dragging: 'Lower'
       });
     }
-    
+
     //click point is lower than upper selector && also greater than midway point between selectors
     if (newPixels < this.state.upperPixels && newPixels > (this.state.upperPixels - (this.state.upperPixels - this.state.lowerPixels) / 2)) {
       this.setState({
@@ -130,7 +130,7 @@ class RangeSelector extends React.Component {
       });
     }
   }
-  
+
   //this method now handles both the dragging of the toggle, and moving it when track is clicked
   _handleDragging (e) {
     if (this.state.dragging) {
@@ -180,7 +180,7 @@ class RangeSelector extends React.Component {
     if (this.state.trackClicked) {
       this._handleDragging(e);
     }
-    
+
     if (this.state.dragging) {
       this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
     }


### PR DESCRIPTION
# Summary of Features Added
* Click above the upper selector on/near the track and the upper toggle will move
* Click below the lower selector on/near the track and the lower toggle will move
* Click between the two toggles, and the closest one will move

### Added a ` <div className='track-holder'> ` Element
* This element was added because the `range` element already was handling mouse up events, and the track is too thin to reliably handle clicks
* The element now contains the track, and extends several pixels beyond the track so the user clicking doesn't have to be so exact

### Used Two Functions to Accomplish result: 

#####  `_handleClickStartOnTrack()` function 
* Function determines which toggle should move by setting `this.state.dragging` example:
``` 	
//click point is less than lower selector
	if (newPixels < this.state.lowerPixels) {
	  this.setState({
		dragging: 'Lower'
	  });
	}
```

#####  `_handleClickOnTrack() ` function
* Moves the proper toggle

### Misc:
* Padding on `range` div was adjusted to compensate for the new `track-holder` containing element that I added
* I really enjoyed working on this - let me know if you see any edits/issues
* I'm not sure why the formatting looks weird in the changes shown on github - I matched the spacing and indents and everything in Atom and it looked fine there...