### PR TITLE
Loader text

### DIFF
--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -6,6 +6,7 @@ const StyleConstants = require('../constants/Style');
 
 class Loader extends React.Component {
   render () {
+	console.log("this is this.props.loaderText", this.props.loaderText);
     if (this.props.isLoading) {
       const styles = {
         component: {
@@ -58,7 +59,7 @@ class Loader extends React.Component {
             {this.props.isSmall ? (
               null
             ) : (
-              <div className='mx-loader-text' style={styles.text} >LOADING...</div>
+              <div className='mx-loader-text' style={styles.text} > {this.props.loaderText} </div>
             )}
           </div>
         </div>
@@ -75,14 +76,16 @@ Loader.propTypes = {
   color: React.PropTypes.string,
   isLoading: React.PropTypes.bool,
   isRelative: React.PropTypes.bool,
-  isSmall: React.PropTypes.bool
+  isSmall: React.PropTypes.bool,
+  loaderText: React.PropTypes.string
 };
 
 Loader.defaultProps = {
   color: StyleConstants.Colors.PRIMARY,
   isLoading: false,
   isRelative: false,
-  isSmall: false
+  isSmall: false,
+  loaderText: "LOADING..."
 };
 
 module.exports = Loader;

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -84,7 +84,7 @@ Loader.defaultProps = {
   isLoading: false,
   isRelative: false,
   isSmall: false,
-  loaderText: "LOADING..."
+  loaderText: 'LOADING...'
 };
 
 module.exports = Loader;

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -58,7 +58,7 @@ class Loader extends React.Component {
             {this.props.isSmall ? (
               null
             ) : (
-              <div className='mx-loader-text' style={styles.text} > {this.props.loaderText} </div>
+              <div className='mx-loader-text' style={styles.text} > {this.props.children} </div>
             )}
           </div>
         </div>
@@ -75,8 +75,7 @@ Loader.propTypes = {
   color: React.PropTypes.string,
   isLoading: React.PropTypes.bool,
   isRelative: React.PropTypes.bool,
-  isSmall: React.PropTypes.bool,
-  loaderText: React.PropTypes.string
+  isSmall: React.PropTypes.bool
 };
 
 Loader.defaultProps = {
@@ -84,7 +83,7 @@ Loader.defaultProps = {
   isLoading: false,
   isRelative: false,
   isSmall: false,
-  loaderText: 'LOADING...'
+  children: 'LOADING...'
 };
 
 module.exports = Loader;

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -6,7 +6,6 @@ const StyleConstants = require('../constants/Style');
 
 class Loader extends React.Component {
   render () {
-	console.log("this is this.props.loaderText", this.props.loaderText);
     if (this.props.isLoading) {
       const styles = {
         component: {


### PR DESCRIPTION
### Added Ability to Pass in Custom Text to Loader
* I might be oversimplifying this or missing something, but:
* I replaced the hard coded 'LOADING...' string with `{this.props.loaderText}` in the `render()` method
* One thing I noticed when I put a console log at the top of the `render()` function is it's logging twice - probably due to the 'live reload enabled', but I don't know why it was reloading?
* Right now the ellipses `...` is not hard coded, but is that something you'll want no matter what the text is?
<img width="1199" alt="screen shot 2016-01-08 at 3 22 29 pm" src="https://cloud.githubusercontent.com/assets/13579578/12211247/e2abeb76-b61c-11e5-9aae-5186942ab766.png">


