### PR TITLE
Fix TimeBasedLineChart Tooltip position, Hover State, and style issues

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -280,14 +280,14 @@ class TimeBasedLineChart extends React.Component {
       const isPast = i === 0;
 
       const group = chart.append('g')
-        .attr('class', 'group-' + i)
+        .attr('class', 'group')
         .attr('transform', 'translate(' + this.props.margin.left + ',' + this.props.margin.top + ')');
 
       //Lines ================================
       const dash = !isPast && this.props.dashedFutureLine ? '2, 2' : 'none';
 
       const lineGroup = group.append('g')
-        .attr('class', 'line-group-' + i);
+        .attr('class', 'line-group');
 
       lineGroup.append('svg:path')
         .attr('class', 'mx-time-based-line-chart-line')

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -3,6 +3,7 @@ const ReactDom = require('react-dom');
 const Radium = require('radium');
 
 const d3 = require('d3');
+const { isEqual } = require('lodash');
 const moment = require('moment');
 const numeral = require('numeral');
 
@@ -41,6 +42,10 @@ class TimeBasedLineChart extends React.Component {
         adjustedWidth
       });
     }
+  }
+
+  shouldComponentUpdate (newProps, newState) {
+    return !isEqual(newProps.data, this.props.data) || !isEqual(newState.hoveredData, this.state.hoveredData);
   }
 
   _getAreaBelowZero (data) {
@@ -275,14 +280,14 @@ class TimeBasedLineChart extends React.Component {
       const isPast = i === 0;
 
       const group = chart.append('g')
-        .attr('class', 'group')
+        .attr('class', 'group-' + i)
         .attr('transform', 'translate(' + this.props.margin.left + ',' + this.props.margin.top + ')');
 
       //Lines ================================
       const dash = !isPast && this.props.dashedFutureLine ? '2, 2' : 'none';
 
       const lineGroup = group.append('g')
-        .attr('class', 'line-group');
+        .attr('class', 'line-group-' + i);
 
       lineGroup.append('svg:path')
         .attr('class', 'mx-time-based-line-chart-line')
@@ -481,8 +486,8 @@ class TimeBasedLineChart extends React.Component {
     const sliceWidth = this._getSliceMiddle();
     const xScale = this._getXScaleValue(currentDate.unix());
 
-    const left = isAfterMidPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth + 10;
-    const right = isAfterMidPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth + 10 - xScale : 'auto';
+    const left = isAfterMidPoint ? 'auto' : xScale + this.props.margin.left + sliceWidth;
+    const right = isAfterMidPoint ? this.state.adjustedWidth + this.props.margin.right + sliceWidth - xScale : 'auto';
     const textAlign = isAfterMidPoint ? 'right' : 'left';
     const top = this.props.children ? this._getYScaleValue(d.value) - 5 + this.props.margin.top : this._getYScaleValue(d.value) - 5;
 
@@ -498,6 +503,7 @@ class TimeBasedLineChart extends React.Component {
       tooltipPosition: position
     });
 
+    this._renderSvgTooltipComponents();
     this.props.onDataPointHover(d);
   }
 
@@ -608,8 +614,6 @@ class TimeBasedLineChart extends React.Component {
       const hoveredData = this.state.hoveredData;
       const position = this.state.tooltipPosition;
 
-      this._renderSvgTooltipComponents();
-
       if (this.props.children) {
         return (
           <div className='mx-time-based-line-chart-tool-tip-wrapper' style={[styles.tooltipWrapper, position]}>
@@ -651,14 +655,14 @@ const styles = {
     display: 'inline-block'
   },
   credit: {
-    backgroundColor: '#30B53C'
+    backgroundColor: StyleConstants.Colors.LIME
   },
   debit: {
-    backgroundColor: '#C93030'
+    backgroundColor: StyleConstants.Colors.STRAWBERRY
   },
   defaultToolTip: {
     backgroundColor: StyleConstants.Colors.PRIMARY,
-    color: '#FFFFFF',
+    color: StyleConstants.Colors.WHITE,
     padding: '3px 5px 3px 5px',
     transform: 'translateY(32px)'
   },
@@ -666,9 +670,8 @@ const styles = {
     opacity: 0
   },
   gridLineTick: {
-    'stroke': '#ccc',
-    'opacity': 1,
-    'stroke-width': '0.5px'
+    'stroke': StyleConstants.Colors.ASH,
+    'stroke-width': 0.5
   },
   svg: {
     'display': 'block',
@@ -677,23 +680,23 @@ const styles = {
     'width': '100%'
   },
   text: {
-    'fill': '#999',
-    'font-size': '12px',
+    'color': StyleConstants.Colors.CHARCOAL,
+    'font-size': StyleConstants.FontSizes.MEDIUM,
     'font-weight': 'normal'
   },
   tooltip: {
-    color: '#FFF',
+    color: StyleConstants.Colors.WHITE,
     display: 'inline-block',
-    fontSize: '11px',
-    marginBottom: '3px',
-    marginTop: '3px',
-    minWidth: '50px',
-    padding: '5px'
+    fontSize: StyleConstants.FontSizes.SMALL,
+    marginBottom: 3,
+    marginTop: 3,
+    minWidth: 50,
+    padding: 5
   },
   tooltipWrapper: {
     display: 'inline-block',
     position: 'absolute',
-    zIndex: '1'
+    zIndex: 1
   },
   zeroState: {
     position: 'absolute',

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -22,6 +22,7 @@ module.exports = {
     CHARCOAL: '#56595A',  //Base Color 7
     FOG: '#E3E6E7',       //Base Color 1
     PORCELAIN: '#F7F8F8', //Base Color 0
+    WHITE: '#FFFFFF',
 
     //Status Colors
     BANANA: '#FBB600',    //Anything yellow


### PR DESCRIPTION
This PR corrects a few bugs with the TimeBasedLineChart.

- The component was updating two to three times on hover of a slice.  The multiple renders where causing some funkyness.  This fixes that issue my implementing the `shouldUpdateComponent` lifecycle method.  We now only update the chart if this.props.data or this.state.hoverData is not equal to the previous state.
- The hovered rectangle was no longer being rendered on mouse over.  This fixes that by moving the `this._renderSvgTooltipComponents` call from `this._renderTooltip` function to the `_handleDataPointMouseOver` function where it actually has correct reference to everything it needs to render properly.
- Tooltips where not positioned correctly next to the hovered rectangle slice since are last set of fixes where we fixed spacing issues.  This fixes that issue by removing the magic `10` numbers that were part of the equation for figuring out the left and right position of the tooltip
- And finally, the styles for the chart needed adjusted for text color/font size to match designs.  While I was updating the text color and font size I went ahead and cleaned up the styles objectby removing px and using style constants where required.

@mxenabled/frontend-engineers 

![screen shot 2016-01-11 at 4 59 19 pm](https://cloud.githubusercontent.com/assets/6463914/12250731/8c3c5de0-b886-11e5-8178-0f1d3b38baf7.png)
![screen shot 2016-01-11 at 4 59 26 pm](https://cloud.githubusercontent.com/assets/6463914/12250732/8caa3ab8-b886-11e5-94d1-219ebb2850e7.png)
