### PR TITLE
Add slide and fade transitions

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -588,7 +588,7 @@ const Demo = React.createClass({
           <span style={styles.button} onClick={this._handleTransitionClick.bind(null, 'slide')}>Slide Transition</span>
         </div>
         <br/><br/>
-        <Transition shouldAnimate={this.state.showSlideTransition} type='slide'>
+        <Transition isShown={this.state.showSlideTransition} type='slide'>
             <div style={{
               backgroundColor: '#F7F8F8',
               border: '1px solid #E3E6E7' ,
@@ -605,7 +605,7 @@ const Demo = React.createClass({
           <span style={styles.button} onClick={this._handleTransitionClick.bind(null, 'fade')}>Fade Transition</span>
         </div>
         <br/><br/>
-        <Transition shouldAnimate={this.state.showFadeTransition} type='fade'>
+        <Transition isShown={this.state.showFadeTransition} type='fade'>
             <div style={{
               backgroundColor: '#F7F8F8',
               border: '1px solid #E3E6E7' ,

--- a/demo/app.js
+++ b/demo/app.js
@@ -12,6 +12,7 @@ const {
   SelectFullScreen,
   TimeBasedLineChart,
   ToggleSwitch,
+  Transition,
   TypeAhead,
   DatePicker,
   DatePickerFullScreen
@@ -447,6 +448,9 @@ const Demo = React.createClass({
       selectedDatePickerDate: moment().unix(),
       showModal: false,
       showSmallModal: false,
+      showFadeTransition: false,
+      showSlideTransition: false,
+      transitionType: 'slide',
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
     }
   },
@@ -483,10 +487,21 @@ const Demo = React.createClass({
     })
   },
 
+  _handleTransitionClick (transitionType) {
+    if (transitionType === 'slide') {
+      this.setState({
+        showSlideTransition: !this.state.showSlideTransition,
+      });
+    } else {
+      this.setState({
+        showFadeTransition: !this.state.showFadeTransition,
+      });
+    }
+  },
+
   render () {
     return (
       <div>
-        <br/><br/>
         <div style={{ textAlign: 'center', fontFamily: 'Helvetica, Arial, sans-serif' }}>
           <span style={styles.button} onClick={this._handleModalClick}>Show Default Modal</span>
           <span style={styles.button} onClick={this._handleSmallModalClick}>Show Small Modal</span>
@@ -567,6 +582,40 @@ const Demo = React.createClass({
         <div style={{ textAlign: 'center' }}>
           <ToggleSwitch />
         </div>
+
+        <br/><br/>
+        <div style={{ textAlign: 'center', fontFamily: 'Helvetica, Arial, sans-serif' }}>
+          <span style={styles.button} onClick={this._handleTransitionClick.bind(null, 'slide')}>Slide Transition</span>
+        </div>
+        <br/><br/>
+        <Transition shouldAnimate={this.state.showSlideTransition} type='slide'>
+            <div style={{
+              backgroundColor: '#F7F8F8',
+              border: '1px solid #E3E6E7' ,
+              boxSizing: 'border-box',
+              height: 400,
+              padding: '10px',
+              position: 'relative',
+              width: '100%'
+            }}></div>
+        </Transition>
+
+        <br/><br/>
+        <div style={{ textAlign: 'center', fontFamily: 'Helvetica, Arial, sans-serif' }}>
+          <span style={styles.button} onClick={this._handleTransitionClick.bind(null, 'fade')}>Fade Transition</span>
+        </div>
+        <br/><br/>
+        <Transition shouldAnimate={this.state.showFadeTransition} type='fade'>
+            <div style={{
+              backgroundColor: '#F7F8F8',
+              border: '1px solid #E3E6E7' ,
+              boxSizing: 'border-box',
+              height: 400,
+              padding: '10px',
+              position: 'relative',
+              width: '100%'
+            }}></div>
+        </Transition>
 
         <br/><br/>
         <TypeAhead

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "object-assign": "^4.0.1",
     "radium": "^0.14.1",
     "react": "^0.14.0",
+    "react-addons-transition-group": "^0.14.6",
     "react-dom": "^0.14.0"
   },
   "devDependencies": {

--- a/src/Index.js
+++ b/src/Index.js
@@ -1,4 +1,6 @@
 module.exports = {
+  DatePicker: require('./components/DatePicker'),
+  DatePickerFullScreen: require('./components/DatePickerFullScreen'),
   DonutChart: require('./components/DonutChart'),
   Icon: require('./components/Icon'),
   Loader: require('./components/Loader'),
@@ -10,7 +12,6 @@ module.exports = {
   Spin: require('./components/Spin'),
   TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),
-  TypeAhead: require('./components/TypeAhead'),
-  DatePicker: require('./components/DatePicker'),
-  DatePickerFullScreen: require('./components/DatePickerFullScreen')
+  Transition: require('./components/Transition'),
+  TypeAhead: require('./components/TypeAhead')
 };

--- a/src/components/Transition.js
+++ b/src/components/Transition.js
@@ -24,7 +24,7 @@ class Transition extends React.Component {
   render () {
     return (
       <TransitionGroup>
-        {this.props.shouldAnimate && this._renderTransition()}
+        {this.props.isShown && this._renderTransition()}
       </TransitionGroup>
     );
   }
@@ -33,12 +33,13 @@ class Transition extends React.Component {
 Transition.propTypes = {
   children: React.PropTypes.node,
   duration: React.PropTypes.number, // In milliseconds
-  shouldAnimate: React.PropTypes.bool,
+  isShown: React.PropTypes.bool,
   type: React.PropTypes.string
 };
 
 Transition.defaultProps = {
   duration: 500,
+  isShown: false,
   type: 'slide'
 };
 

--- a/src/components/Transition.js
+++ b/src/components/Transition.js
@@ -1,0 +1,45 @@
+const React = require('react');
+const TransitionGroup = require('react-addons-transition-group');
+//All react addons are listed as experimental and may change.
+
+const Fade = require('./transitions/Fade');
+const Slide = require('./transitions/Slide');
+
+class Transition extends React.Component {
+  constructor (props) {
+    super(props);
+  }
+
+  _renderTransition () {
+    switch (this.props.type) {
+      case 'slide':
+        return (<Slide {...this.props} />);
+      case 'fade':
+        return (<Fade {...this.props} />);
+      default:
+        return null;
+    }
+  }
+
+  render () {
+    return (
+      <TransitionGroup>
+        {this.props.shouldAnimate && this._renderTransition()}
+      </TransitionGroup>
+    );
+  }
+}
+
+Transition.propTypes = {
+  children: React.PropTypes.node,
+  duration: React.PropTypes.number, // In milliseconds
+  shouldAnimate: React.PropTypes.bool,
+  type: React.PropTypes.string
+};
+
+Transition.defaultProps = {
+  duration: 500,
+  type: 'slide'
+};
+
+module.exports = Transition;

--- a/src/components/transitions/Fade.js
+++ b/src/components/transitions/Fade.js
@@ -1,31 +1,30 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 
-const Fade = React.createClass({
-  propTypes: {
-    children: React.PropTypes.object,
-    duration: React.PropTypes.number
-  },
+class Fade extends React.Component {
+  constructor (props) {
+    super(props);
+  }
 
   componentWillAppear (callback) {
     setTimeout(callback, 1); // need at least one tick to fire transition
-  },
+  }
 
   componentDidAppear () {
     const el = ReactDOM.findDOMNode(this.refs.component);
 
     el.style.opacity = 0;
-  },
+  }
 
   componentWillEnter (callback) {
     setTimeout(callback, 1);
-  },
+  }
 
   componentDidEnter () {
     const el = ReactDOM.findDOMNode(this.refs.component);
 
     el.style.opacity = 1;
-  },
+  }
 
   componentWillLeave (callback) {
     const el = ReactDOM.findDOMNode(this.refs.component);
@@ -33,7 +32,7 @@ const Fade = React.createClass({
     el.style.opacity = 0;
 
     setTimeout(callback, this.props.duration); // matches transition duration
-  },
+  }
 
   render () {
     const style = {
@@ -47,6 +46,11 @@ const Fade = React.createClass({
       </div>
     );
   }
-});
+}
+
+Fade.PropTypes = {
+  children: React.PropTypes.object,
+  duration: React.PropTypes.number
+};
 
 module.exports = Fade;

--- a/src/components/transitions/Fade.js
+++ b/src/components/transitions/Fade.js
@@ -1,0 +1,52 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const Fade = React.createClass({
+  propTypes: {
+    children: React.PropTypes.object,
+    duration: React.PropTypes.number
+  },
+
+  componentWillAppear (callback) {
+    setTimeout(callback, 1); // need at least one tick to fire transition
+  },
+
+  componentDidAppear () {
+    const el = ReactDOM.findDOMNode(this.refs.component);
+
+    el.style.opacity = 0;
+  },
+
+  componentWillEnter (callback) {
+    setTimeout(callback, 1);
+  },
+
+  componentDidEnter () {
+    const el = ReactDOM.findDOMNode(this.refs.component);
+
+    el.style.opacity = 1;
+  },
+
+  componentWillLeave (callback) {
+    const el = ReactDOM.findDOMNode(this.refs.component);
+
+    el.style.opacity = 0;
+
+    setTimeout(callback, this.props.duration); // matches transition duration
+  },
+
+  render () {
+    const style = {
+      opacity: '0',
+      transition: 'opacity ' + this.props.duration + 'ms'
+    };
+
+    return (
+      <div ref='component' style={style}>
+        {this.props.children}
+      </div>
+    );
+  }
+});
+
+module.exports = Fade;

--- a/src/components/transitions/Slide.js
+++ b/src/components/transitions/Slide.js
@@ -1,0 +1,58 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+class Slide extends React.Component {
+  constructor (props) {
+    super(props);
+  }
+
+  componentWillAppear (callback) {
+    setTimeout(callback, 1); // need at least one tick to fire transition
+  }
+
+  componentDidAppear () {
+    const el = ReactDOM.findDOMNode(this.refs.component);
+
+    el.style.height = 0;
+  }
+
+  componentWillEnter (callback) {
+    setTimeout(callback, 1);
+  }
+
+  componentDidEnter () {
+    const el = ReactDOM.findDOMNode(this.refs.component);
+    const height = el.scrollHeight;
+
+    el.style.height = height + 'px';
+  }
+
+  componentWillLeave (callback) {
+    const el = ReactDOM.findDOMNode(this.refs.component);
+
+    el.style.height = 0;
+
+    setTimeout(callback, this.props.duration); // matches transition duration
+  }
+
+  render () {
+    const style = {
+      height: '0',
+      overflow: 'hidden',
+      transition: 'height ' + this.props.duration + 'ms'
+    };
+
+    return (
+      <div ref='component' style={style}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+Slide.propTypes = {
+  children: React.PropTypes.object,
+  duration: React.PropTypes.number
+};
+
+module.exports = Slide;


### PR DESCRIPTION
This adds slide up/down and fade in/out transitions components.

To use, wrap the content to be toggled in <Transition> tags wit isShown, type and duration params. Defaults to false, slide and 500ms.

This is ported from the Robinhood repo where it is used to toggle tables open and closed. It uses the react animation life-cycle and removes the component on unmount, which is good.

It uses TransitionGroup, which like all react addons is listed as experimental, so that could be an issue.

I've looked into other ways to animate and here are some options;
1. Not use the TransitionGroup and instead alter the state at an interval, changing a specified value
2. Use a outside module such as react-tween-state or react-motion, which pretty much does the above

I am open to any thoughts on this.

@mxenabled/frontend-engineers

