### PR TITLE
Fix Modal component button alignment on no footerContent

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -57,7 +57,7 @@ class Modal extends React.Component {
   _renderFooterContent () {
     return (
       <div className='mx-modal-footer-content' style={styles.footerContent}>
-        {this.props.footerContent ? this.props.footerContent : null}
+        {this.props.footerContent}
       </div>
     );
   }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -227,7 +227,6 @@ const styles = {
     textAlign: 'left'
   },
   buttons: {
-    alignSelf: 'flex-end',
     textAlign: 'right'
   },
   button: {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -55,13 +55,11 @@ class Modal extends React.Component {
   }
 
   _renderFooterContent () {
-    if (this.props.footerContent) {
-      return (
-        <div className='mx-modal-footer-content' style={styles.footerContent}>
-          {this.props.footerContent}
-        </div>
-      );
-    }
+    return (
+      <div className='mx-modal-footer-content' style={styles.footerContent}>
+        {this.props.footerContent ? this.props.footerContent : null}
+      </div>
+    );
   }
 
   _renderTooltip () {
@@ -229,6 +227,7 @@ const styles = {
     textAlign: 'left'
   },
   buttons: {
+    alignSelf: 'flex-end',
     textAlign: 'right'
   },
   button: {


### PR DESCRIPTION
@mxenabled/frontend-engineers 

When I added the footerContent prop to the Modal component I caused an issue with the buttons alignment in the footer when no footerContent was provided.  This fixes the issue by always rendering the footerContent div even if it is empty to ensure that flex box aligns things correctly in the footer.

 Before:
![screen shot 2016-01-14 at 3 42 14 pm](https://cloud.githubusercontent.com/assets/6463914/12340087/fd83e6fc-bad5-11e5-9711-5ac0cb17f9cd.png)


After:
![screen shot 2016-01-14 at 3 42 32 pm](https://cloud.githubusercontent.com/assets/6463914/12340096/049a22e4-bad6-11e5-9448-352151594fb2.png)
![screen shot 2016-01-14 at 3 43 05 pm](https://cloud.githubusercontent.com/assets/6463914/12340097/049ba5ce-bad6-11e5-8137-843d3425262b.png)
![screen shot 2016-01-14 at 3 43 19 pm](https://cloud.githubusercontent.com/assets/6463914/12340098/049bca72-bad6-11e5-93af-dec708ed3ef7.png)
