### PR TITLE
Fix setState calls when using props

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -717,12 +717,6 @@ const Demo = React.createClass({
     });
   },
 
-  _handleSelectChange (option) {
-    this.setState({
-      icon: option
-    });
-  },
-
   _handleModalClick () {
     this.setState({
       showModal: true,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -11,21 +11,21 @@ class DatePicker extends React.Component {
     super(props);
     this.state = {
       currentDate: null,
-      inputValue: this._getInputValueByDate(this.props.defaultDate),
+      inputValue: this._getInputValueByDate(props.defaultDate, props),
       isValid: true,
-      selectedDate: this.props.defaultDate,
+      selectedDate: props.defaultDate,
       showCalendar: false
     };
   }
 
-  _getInputValueByDate (date) {
+  _getInputValueByDate (date, props = this.props) {
     let inputValue = null;
 
     if (date) {
       const newDate = moment.unix(date);
 
       if (newDate.isValid()) {
-        inputValue = newDate.format(this.props.format);
+        inputValue = newDate.format(props.format);
       } else {
         inputValue = date;
       }

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -11,9 +11,9 @@ class DatePickerFullScreen extends React.Component {
     super(props);
     this.state = {
       currentDate: null,
-      inputValue: this._getInputValueByDate(this.props.defaultDate),
+      inputValue: this._getInputValueByDate(props.defaultDate, props),
       isValid: true,
-      selectedDate: this.props.defaultDate,
+      selectedDate: props.defaultDate,
       showCalendar: false
     };
   }
@@ -26,14 +26,14 @@ class DatePickerFullScreen extends React.Component {
     };
   }
 
-  _getInputValueByDate (date) {
+  _getInputValueByDate (date, props = this.props) {
     let inputValue = null;
 
     if (date) {
       const newDate = moment.unix(date);
 
       if (newDate.isValid()) {
-        inputValue = newDate.format(this.props.format);
+        inputValue = newDate.format(props.format);
       } else {
         inputValue = date;
       }

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -9,16 +9,16 @@ class RangeSelector extends React.Component {
   constructor (props) {
     super(props);
 
-    const lowerValue = this.props.defaultLowerValue;
-    const upperValue = this.props.defaultUpperValue;
+    const lowerValue = props.defaultLowerValue;
+    const upperValue = props.defaultUpperValue;
 
     this.state = {
       dragging: null,
       lowerPixels: 0,
       lowerValue,
-      range: this.props.upperBound - this.props.lowerBound,
-      selectedLabel: this._getSelectedLabel(lowerValue, upperValue),
-      showPresets: !!this.props.presets.length && !lowerValue && !upperValue,
+      range: props.upperBound - props.lowerBound,
+      selectedLabel: this._getSelectedLabel(lowerValue, upperValue, props),
+      showPresets: !!props.presets.length && !lowerValue && !upperValue,
       upperPixels: 1,
       upperValue,
       trackClicked: false
@@ -35,9 +35,9 @@ class RangeSelector extends React.Component {
     window.removeEventListener('resize', _throttle(this._setDefaultRangeValues.bind(this), 300));
   }
 
-  _getSelectedLabel (lowerValue, upperValue) {
-    if (this.props.presets) {
-      const preset = this.props.presets.filter(preset => {
+  _getSelectedLabel (lowerValue, upperValue, props = this.props) {
+    if (props.presets) {
+      const preset = props.presets.filter(preset => {
         return preset.lowerValue === lowerValue && preset.upperValue === upperValue;
       })[0];
 

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -13,8 +13,8 @@ class TimeBasedLineChart extends React.Component {
   constructor (props) {
     super(props);
 
-    const adjustedWidth = this.props.width - this.props.margin.right - this.props.margin.left;
-    const adjustedHeight = this.props.height - this.props.margin.top - this.props.margin.bottom;
+    const adjustedWidth = props.width - props.margin.right - props.margin.left;
+    const adjustedHeight = props.height - props.margin.top - props.margin.bottom;
 
     this.state = {
       adjustedHeight,

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -6,7 +6,7 @@ class ToggleSwitch extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
-      activePosition: this.props.defaultPosition
+      activePosition: props.defaultPosition
     };
   }
 


### PR DESCRIPTION
Calling this.props in a component constructor in other browsers works, but in IE10 it returns null. This was causing an error for any of those components in IE10. 

This PR changes this.props to props in the constructors.

There were also a few that called a method that referenced this.props, so I have set props to default to this.props if not included and then included props in the constructor. (See DatePicker.js)

There was also a duplicate method in app.js for _handleSelectChange, so removed that.

The demo now runs in IE10 and all of the components changed were tested in Chrome, Safari and IE11.

@mxenabled/frontend-engineers 