### PR TITLE
Remove duplicate _handleSelectChange from app.js

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -717,12 +717,6 @@ const Demo = React.createClass({
     });
   },
 
-  _handleSelectChange (option) {
-    this.setState({
-      icon: option
-    });
-  },
-
   _handleModalClick () {
     this.setState({
       showModal: true,


### PR DESCRIPTION
The _handleSelectChange method was duplicated, causing an error in IE10. 

This removes the second one.

@mxenabled/frontend-engineers 