### PR TITLE
Select: Removed opacity of options

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -268,12 +268,10 @@ const styles = {
     backgroundColor: '#FFFFFF',
     padding: '10px',
     whiteSpace: 'nowrap',
-    opacity: 0.4,
 
     ':hover': {
       backgroundColor: StyleConstants.Colors.PRIMARY,
-      color: StyleConstants.Colors.WHITE,
-      opacity: 1
+      color: StyleConstants.Colors.WHITE
     }
   },
   scrim: {


### PR DESCRIPTION
- Removed opacity of options in the Select component

Before
<img width="498" alt="screen shot 2016-01-29 at 10 03 53 am" src="https://cloud.githubusercontent.com/assets/9920303/12682308/f6b3bbf4-c66f-11e5-8659-7f63eb77fb3a.png">

After
<img width="463" alt="screen shot 2016-01-29 at 10 04 31 am" src="https://cloud.githubusercontent.com/assets/9920303/12682311/fb56c5f2-c66f-11e5-88ba-93e2d39b8f39.png">
