### PR TITLE
Select: No shadow onClick when there is no options

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -188,7 +188,7 @@ const Select = React.createClass({
               type={this.state.isOpen ? 'caret-up' : 'caret-down'}
             />
           </div>
-          {this._renderOptions()}
+          {this.props.options.length ? this._renderOptions() : null}
         </div>
 
         {isMobile ? (


### PR DESCRIPTION
https://git.moneydesktop.com/product/MoneyDesktop/issues/327

- No shadow when there is no options to show onClick

Before
<img width="1244" alt="screen shot 2016-02-05 at 3 11 29 pm" src="https://cloud.githubusercontent.com/assets/9920303/12860689/9ca95b8a-cc1b-11e5-9971-c37471b5b7c8.png">

After
<img width="1225" alt="screen shot 2016-02-05 at 3 12 01 pm" src="https://cloud.githubusercontent.com/assets/9920303/12860696/a39adee6-cc1b-11e5-98cc-3cf25205492f.png">
