### PR TITLE
Fix renderOptions conditional in Select component

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -188,7 +188,7 @@ const Select = React.createClass({
               type={this.state.isOpen ? 'caret-up' : 'caret-down'}
             />
           </div>
-          {this.props.options.length ? this._renderOptions() : null}
+          {this.props.options.length || this.props.children ? this._renderOptions() : null}
         </div>
 
         {isMobile ? (


### PR DESCRIPTION
We recently mad a change to the select component to fix an issue where the drop shadow was be rendered for the options div even when there was no options.  We fixed that issue be adding a conditional check to see if this.props.options had a length before rendering the options.  

While that worked for most use cases, we allow users of Select to pass options via children and in those cases the conditional was preventing the options from rendering.  This fixes that issue by adding `this.props.children` to the check.

Before Select with children
![screen shot 2016-02-11 at 11 42 55 am](https://cloud.githubusercontent.com/assets/6463914/12986557/220888b2-d0b5-11e5-8ef3-f056a59092a6.png)


After Select with children
![screen shot 2016-02-11 at 11 43 09 am](https://cloud.githubusercontent.com/assets/6463914/12986562/2ab0ffbc-d0b5-11e5-8305-f5e724234b6c.png)


@tumentumurchudur @jmophoto @paniclater @bsbeeks @lukeschunk 