### PR TITLE
Do not show break point label if to close to right edge of graph

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -494,6 +494,7 @@ const TimeBasedLineChart = React.createClass({
               {showBreakPoint ? (
                 <BreakPointGroup
                   adjustedHeight={adjustedHeight}
+                  adjustedWidth={adjustedWidth}
                   breakPointDate={breakPointDate}
                   breakPointLabel={breakPointLabel}
                   margin={margin}

--- a/src/components/d3/BreakPointGroup.js
+++ b/src/components/d3/BreakPointGroup.js
@@ -3,6 +3,7 @@ const React = require('react');
 const BreakPointGroup = React.createClass({
   propTypes: {
     adjustedHeight: React.PropTypes.number.isRequired,
+    adjustedWidth: React.PropTypes.number.isRequired,
     breakPointDate: React.PropTypes.number.isRequired,
     breakPointLabel: React.PropTypes.string.isRequired,
     margin: React.PropTypes.object.isRequired,
@@ -17,7 +18,7 @@ const BreakPointGroup = React.createClass({
   },
 
   render () {
-    const { adjustedHeight, breakPointDate, breakPointLabel, margin, translation, xScaleValueFunction } = this.props;
+    const { adjustedHeight, adjustedWidth, breakPointDate, breakPointLabel, margin, translation, xScaleValueFunction } = this.props;
     const breakPointXValue = xScaleValueFunction(breakPointDate);
     const breakPointLabelOffSet = 10;
     const breakPointLabelYPosition = 40;
@@ -31,13 +32,15 @@ const BreakPointGroup = React.createClass({
           y1={margin.top}
           y2={adjustedHeight + margin.bottom}
         />
-        <text
-          className='break-point-label'
-          x={breakPointXValue + breakPointLabelOffSet}
-          y={breakPointLabelYPosition}
-        >
-          {breakPointLabel}
-        </text>
+        {adjustedWidth - breakPointXValue - breakPointLabelOffSet > 100 ? (
+          <text
+            className='break-point-label'
+            x={breakPointXValue + breakPointLabelOffSet}
+            y={breakPointLabelYPosition}
+          >
+            {breakPointLabel}
+          </text>
+        ) : null}
       </g>
     );
   }


### PR DESCRIPTION
We ran into a situation where the break point label was being extended past the edge of the graph on the right side if it's position was to close to the edge.  This PR fixes that issue by choosing to NOT draw the svg text label if it's position is less than 100 pixels from the right edge of the graph.

@mxenabled/frontend-engineers 

Break Point in center
![screen shot 2016-02-16 at 2 43 24 pm](https://cloud.githubusercontent.com/assets/6463914/13092248/209d7f2c-d4bc-11e5-93f4-b9026e5c2754.png)


Break Point close to right edge
![screen shot 2016-02-16 at 2 43 04 pm](https://cloud.githubusercontent.com/assets/6463914/13092255/2a69b28c-d4bc-11e5-81b8-6fb251899b82.png)
