### PR TITLE
Time Based Line Chart - Fix y axis min max padding

### DIFF
--- a/src/utils/Chart.js
+++ b/src/utils/Chart.js
@@ -12,8 +12,8 @@ const Chart = {
 
     const maxDigits = Math.ceil(max).toString().length - 1;
     const minDigits = Math.floor(min).toString().length - 1;
-    const maxMultiplier = Math.pow(10, maxDigits);
-    const minMultiplier = Math.pow(10, minDigits);
+    const maxMultiplier = Math.pow(10, maxDigits) < 100 ? 100 : Math.pow(10, maxDigits);
+    const minMultiplier = Math.pow(10, minDigits) < 100 ? 100 : Math.pow(10, maxDigits);
 
     max = Math.ceil(max / maxMultiplier) * maxMultiplier;
     min = Math.floor(min / minMultiplier) * minMultiplier;


### PR DESCRIPTION
This PR addresses an issue where attempting to round a min or max value for the y axis that was small was ending up with a rounded number not large or small enough.  This was causing the min or max tick value to be weird for the given scale/step interval.  This fixes the issue by always defaulting to at least a multiplier of 100.

@mxenabled/frontend-engineers 

Y Axis Before
![screen shot 2016-02-16 at 3 22 24 pm](https://cloud.githubusercontent.com/assets/6463914/13093336/f72d5f08-d4c1-11e5-9af4-2e7089713f36.png)

Y Axis After
![screen shot 2016-02-16 at 3 22 50 pm](https://cloud.githubusercontent.com/assets/6463914/13093337/fcdeaeac-d4c1-11e5-8f8f-c6bdc6a8a441.png)

