### PR TITLE
DatePicker: Expose a method to Datepicker, so selected date can be changed

### DIFF
--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -54,6 +54,15 @@ const DatePicker = React.createClass({
     };
   },
 
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.defaultDate !== this.props.defaultDate) {
+      this.setState({
+        selectedDate: nextProps.defaultDate,
+        inputValue: moment.unix(nextProps.defaultDate).format(this.props.format)
+      });
+    }
+  },
+
   _getInputValueByDate (date) {
     let inputValue = null;
 
@@ -74,13 +83,6 @@ const DatePicker = React.createClass({
     const selectedDate = this.state.selectedDate;
 
     return selectedDate && moment.unix(selectedDate).isValid() ? this.state.selectedDate : moment().unix();
-  },
-
-  _changeSelectedDate (selectedDate) {
-    this.setState({
-      selectedDate,
-      inputValue: moment.unix(selectedDate).format(this.props.format)
-    });
   },
 
   _handleDateSelect (date) {

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -76,6 +76,13 @@ const DatePicker = React.createClass({
     return selectedDate && moment.unix(selectedDate).isValid() ? this.state.selectedDate : moment().unix();
   },
 
+  _changeSelectedDate (selectedDate) {
+    this.setState({
+      selectedDate,
+      inputValue: moment.unix(selectedDate).format(this.props.format)
+    });
+  },
+
   _handleDateSelect (date) {
     if (this.props.closeOnDateSelect) {
       this._handleScrimClick();


### PR DESCRIPTION
This PR allows users to change its internal `selectedDate` state through a method. We need to be able to change the selected date in the calendar because I have two instances of the DatePicker component that  need to communicate and change each other's selected date.

