### PR TITLE
Return dataSet object on hover or click instead of index

### DIFF
--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -80,7 +80,7 @@ const DonutChart = React.createClass({
   },
 
   _handleClick (index) {
-    this.props.onClick(index);
+    this.props.onClick(this.props.data[index]);
   },
 
   _handleMouseEnter (index) {
@@ -90,7 +90,7 @@ const DonutChart = React.createClass({
       });
     }
 
-    this.props.onMouseEnter(index);
+    this.props.onMouseEnter(this.props.data[index]);
   },
 
   _handleMouseLeave () {


### PR DESCRIPTION
This changes the onClick and onMouseEnter callbacks to return the active dataset object instead of an index. This helps with the accuracy for the user since the data could change and not match with the index in the chart.

@mxenabled/frontend-engineers 