### PR TITLE
Rename npm test script to eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "release": "eslint src && babel src --out-dir dist",
     "demo": "webpack demo/app.js demo/bundle.js --config demo/webpack.config.js -w & node demo/server.js",
-    "test": "eslint src"
+    "eslint": "eslint src"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This was done to avoid confusion where we use the script name `test` for travis config stuff in other applications.