### PR TITLE
updated -8 to -30 for background color hover

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -51,8 +51,8 @@ const Button = React.createClass({
         transition: 'all .2s ease-in',
 
         ':hover': {
-          backgroundColor: StyleConstants.adjustColor(this.props.primaryColor, -8),
-          borderColor: StyleConstants.adjustColor(this.props.primaryColor, -8),
+          backgroundColor: StyleConstants.adjustColor(this.props.primaryColor, -30),
+          borderColor: StyleConstants.adjustColor(this.props.primaryColor, -30),
           transition: 'all .2s ease-in'
         },
         ':active': {


### PR DESCRIPTION
Derek came over and we discussed how the button component hover effect (in the demo app ) is not noticeable enough. We decided that changing the value passed in from `-8` to `-30` would be a good change.

The only thing I'm worried about with this PR is it having an adverse effect on all the apps? Perhaps some of them (due to color difference, etc) have a hover effect that is actually dialed in nicely and this will push it overboard? 