### PR TITLE
Add DropZone component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -506,12 +506,13 @@ const Demo = React.createClass({
     return (
       <div>
         <br/><br/>
-        <DropZone
-          dragging={true}
-          onFileAdd={this._handleFileChange}
-          onFileRemove={this._handleFileChange}
-          uploadedFile={this.state.uploadedFile}
-        />
+        <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
+          <DropZone
+            onFileAdd={this._handleFileChange}
+            onFileRemove={this._handleFileChange}
+            uploadedFile={this.state.uploadedFile}
+          />
+        </div>
 
         <br/><br/>
         <div style={{ textAlign: 'center', fontFamily: 'Helvetica, Arial, sans-serif' }}>

--- a/demo/app.js
+++ b/demo/app.js
@@ -7,7 +7,7 @@ const {
   DatePicker,
   DatePickerFullScreen,
   DonutChart,
-  DropZone,
+  FileUpload,
   Icon,
   Loader,
   Modal,
@@ -507,7 +507,7 @@ const Demo = React.createClass({
       <div>
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
-          <DropZone
+          <FileUpload
             allowedfileTypes={['image/jpeg', 'text/csv', 'image/tiff']}
             maxFileSize={3000}
             onFileAdd={this._handleFileChange}

--- a/demo/app.js
+++ b/demo/app.js
@@ -508,6 +508,8 @@ const Demo = React.createClass({
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
           <DropZone
+            allowedfileTypes={['image/jpeg', 'text/csv', 'image/tiff']}
+            maxFileSize={3000}
             onFileAdd={this._handleFileChange}
             onFileRemove={this._handleFileChange}
             uploadedFile={this.state.uploadedFile}

--- a/demo/app.js
+++ b/demo/app.js
@@ -508,7 +508,7 @@ const Demo = React.createClass({
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
           <FileUpload
-            allowedfileTypes={['image/jpeg', 'text/csv', 'image/tiff']}
+            allowedFileTypes={['image/jpeg', 'text/csv', 'image/tiff']}
             maxFileSize={3000}
             onFileAdd={this._handleFileChange}
             onFileRemove={this._handleFileChange}

--- a/demo/app.js
+++ b/demo/app.js
@@ -4,7 +4,10 @@ const moment = require('moment');
 
 const {
   Button,
+  DatePicker,
+  DatePickerFullScreen,
   DonutChart,
+  DropZone,
   Icon,
   Loader,
   Modal,
@@ -13,9 +16,7 @@ const {
   SelectFullScreen,
   TimeBasedLineChart,
   ToggleSwitch,
-  TypeAhead,
-  DatePicker,
-  DatePickerFullScreen
+  TypeAhead
 } = require('../src/Index');
 
 const styles = {
@@ -431,6 +432,7 @@ const Demo = React.createClass({
       selectedDatePickerDate: moment().unix(),
       showModal: false,
       showSmallModal: false,
+      uploadedFile: null,
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
     };
   },
@@ -494,9 +496,23 @@ const Demo = React.createClass({
     });
   },
 
+  _handleFileChange (uploadedFile) {
+    this.setState({
+      uploadedFile
+    });
+  },
+
   render () {
     return (
       <div>
+        <br/><br/>
+        <DropZone
+          dragging={true}
+          onFileAdd={this._handleFileChange}
+          onFileRemove={this._handleFileChange}
+          uploadedFile={this.state.uploadedFile}
+        />
+
         <br/><br/>
         <div style={{ textAlign: 'center', fontFamily: 'Helvetica, Arial, sans-serif' }}>
           <Button onClick={this._handleModalClick}>Show Default Modal (Primary Button)</Button>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.10.3",
     "numeral": "^1.5.3",
     "object-assign": "^4.0.1",
-    "radium": "^0.14.1",
+    "radium": "^0.16.6",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },

--- a/src/Index.js
+++ b/src/Index.js
@@ -3,7 +3,7 @@ module.exports = {
   DatePicker: require('./components/DatePicker'),
   DatePickerFullScreen: require('./components/DatePickerFullScreen'),
   DonutChart: require('./components/DonutChart'),
-  DropZone: require('./components/DropZone'),
+  FileUpload: require('./components/FileUpload'),
   Icon: require('./components/Icon'),
   Loader: require('./components/Loader'),
   Modal: require('./components/Modal'),

--- a/src/Index.js
+++ b/src/Index.js
@@ -1,6 +1,9 @@
 module.exports = {
   Button: require('./components/Button'),
+  DatePicker: require('./components/DatePicker'),
+  DatePickerFullScreen: require('./components/DatePickerFullScreen'),
   DonutChart: require('./components/DonutChart'),
+  DropZone: require('./components/DropZone'),
   Icon: require('./components/Icon'),
   Loader: require('./components/Loader'),
   Modal: require('./components/Modal'),
@@ -12,8 +15,6 @@ module.exports = {
   TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),
   TypeAhead: require('./components/TypeAhead'),
-  DatePicker: require('./components/DatePicker'),
-  DatePickerFullScreen: require('./components/DatePickerFullScreen'),
 
   Styles: require('./constants/Style')
 };

--- a/src/components/DropZone.js
+++ b/src/components/DropZone.js
@@ -1,0 +1,168 @@
+const React = require('react');
+const Radium = require('Radium');
+const numeral = require('numeral');
+
+const StyleConstants = require('../constants/Style');
+
+const Button = require('./Button');
+
+const DropZone = React.createClass({
+  propTypes: {
+    dragging: React.PropTypes.bool,
+    onFileAdd: React.PropTypes.func,
+    onFileRemove: React.PropTypes.func,
+    uploadedFile: React.PropTypes.any,
+    validationMessage: React.PropTypes.string
+  },
+
+  getInitialState () {
+    return {
+      dragging: false,
+      imageSource: null
+    };
+  },
+
+  componentDidMount () {
+    window.addEventListener('mouseover', this._handleMouseOver);
+    window.addEventListener('mouseout', this._handleMouseOut);
+  },
+
+  componentWillUnmount () {
+    window.removeEventListener('mouseover', this._handleMouseOver);
+    window.removeEventListener('mouseout', this._handleMouseOut);
+  },
+
+  _handleMouseOver (e) {
+    if (e.buttons === 1) {
+      this.setState({
+        dragging: true
+      });
+    }
+  },
+
+  _handleMouseOut () {
+    this.setState({
+      dragging: false
+    });
+  },
+
+  _handleFileSelect (e) {
+    const file = e.target.files[0];
+
+    this._processFile(file);
+  },
+
+  _onDragOver (e) {
+    e.stopPropagation();
+    e.preventDefault();
+  },
+
+  _onDrop (e) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    const file = e.dataTransfer.files[0];
+
+    this._processFile(file);
+  },
+
+  _onDropzoneClick () {
+    this.refs.hiddenInput.click();
+  },
+
+  _processFile (file) {
+    const reader = new FileReader();
+
+    reader.readAsDataURL(file);
+
+    reader.onload = function () {
+      this.setState({
+        dragging: false,
+        imageSource: reader.result
+      });
+      this.props.onFileAdd(file);
+    }.bind(this);
+  },
+
+  _removeImage (e) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    this.setState({
+      imageSource: null
+    });
+    this.props.onFileRemove();
+  },
+
+  render () {
+    return (
+      <div
+        onClick={this._onDropzoneClick}
+        onDragOver={this._onDragOver}
+        onDrop={this._onDrop}
+        style={[styles.dropzone, this.state.dragging && styles.dragging, this.props.uploadedFile && styles.dropzoneLoaded]}
+      >
+        {this.props.uploadedFile ? (
+          <div style={styles.fileInfo}>
+            <img src={this.state.imageSource} style={styles.previewImage} />
+            <div>{this.props.uploadedFile.name}</div>
+            <div>{numeral(this.props.uploadedFile.size / 1000).format('0.0')}k</div>
+            <Button icon='delete' onClick={this._removeImage} style={styles.button} type='secondary' />
+          </div>
+        ) : (
+          <div>Drag and drop files here or click to browse</div>
+        )}
+        <input
+          name='files'
+          onChange={this._handleFileSelect}
+          ref='hiddenInput'
+          style={styles.hiddenInput}
+          type='file'
+        />
+      </div>
+    );
+  }
+});
+
+const styles = {
+  dropzone: {
+    fontSize: StyleConstants.FontSizes.MEDIUM,
+    fontFamily: StyleConstants.Fonts.REGULAR,
+    textAlign: 'center',
+    position: 'relative',
+    width: '100%',
+    borderRadius: 3,
+    padding: 40,
+    color: StyleConstants.Colors.ASH,
+    backgroundColor: StyleConstants.Colors.PORCELAIN,
+    border: '1px solid ' + StyleConstants.Colors.FOG
+  },
+  dragging: {
+    backgroundColor: StyleConstants.Colors.WHITE,
+    border: '1px dashed ' + StyleConstants.Colors.PRIMARY
+  },
+  dropzoneLoaded: {
+    padding: 20
+  },
+  hiddenInput: {
+    visibility: 'hidden',
+    position: 'absolute'
+  },
+  fileIcon: {
+    color: StyleConstants.Colors.ASH
+  },
+  fileInfo: {
+    fontSize: StyleConstants.FontSizes.SMALL,
+    lineHeight: '1.2em',
+    textAlign: 'center'
+  },
+  previewImage: {
+    maxWidth: '90%',
+    marginBottom: 10
+  },
+  button: {
+    marginTop: 10
+  }
+};
+
+module.exports = Radium(DropZone);

--- a/src/components/DropZone.js
+++ b/src/components/DropZone.js
@@ -8,11 +8,9 @@ const Button = require('./Button');
 
 const DropZone = React.createClass({
   propTypes: {
-    dragging: React.PropTypes.bool,
     onFileAdd: React.PropTypes.func,
     onFileRemove: React.PropTypes.func,
-    uploadedFile: React.PropTypes.any,
-    validationMessage: React.PropTypes.string
+    uploadedFile: React.PropTypes.any
   },
 
   getInitialState () {

--- a/src/components/DropZone.js
+++ b/src/components/DropZone.js
@@ -130,7 +130,6 @@ const styles = {
     fontFamily: StyleConstants.Fonts.REGULAR,
     textAlign: 'center',
     position: 'relative',
-    width: '100%',
     borderRadius: 3,
     padding: 40,
     color: StyleConstants.Colors.ASH,

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -9,7 +9,7 @@ const Icon = require('./Icon');
 
 const FileUpload = React.createClass({
   propTypes: {
-    allowedfileTypes: React.PropTypes.array,
+    allowedFileTypes: React.PropTypes.array,
     maxFileSize: React.PropTypes.number,
     onFileAdd: React.PropTypes.func,
     onFileRemove: React.PropTypes.func,
@@ -66,7 +66,7 @@ const FileUpload = React.createClass({
 
   _processFile (file) {
     const isTooBig = this.props.maxFileSize < file.size / 1000;
-    const isInvalidType = this.props.allowedfileTypes.indexOf(file.type) < 0;
+    const isInvalidType = this.props.allowedFileTypes.indexOf(file.type) < 0;
 
     if (isTooBig || isInvalidType) {
       const invalidMessage = isTooBig ? 'This file exceeds maximum size of ' + this.props.maxFileSize + 'k' : 'This file type is not accepted';

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -1,14 +1,13 @@
-const React = require('react');
-const Radium = require('Radium');
 const numeral = require('numeral');
+const Radium = require('Radium');
+const React = require('react');
 
 const StyleConstants = require('../constants/Style');
 
 const Button = require('./Button');
 const Icon = require('./Icon');
-const Loader = require('./Loader');
 
-const DropZone = React.createClass({
+const FileUpload = React.createClass({
   propTypes: {
     allowedfileTypes: React.PropTypes.array,
     maxFileSize: React.PropTypes.number,
@@ -125,7 +124,6 @@ const DropZone = React.createClass({
         onDrop={this._onDrop}
         style={[styles.dropzone, this.state.dragging && styles.dragging, this.props.uploadedFile && styles.dropzoneLoaded]}
       >
-        <Loader isLoading={this.state.loading} isRelative={true} isSmall={true} />
         {this.props.uploadedFile ? (
           <div style={styles.fileInfo}>
             {this.state.imageSource ? (
@@ -199,4 +197,4 @@ const styles = {
   }
 };
 
-module.exports = Radium(DropZone);
+module.exports = Radium(FileUpload);

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -24,31 +24,6 @@ const FileUpload = React.createClass({
     };
   },
 
-  componentDidMount () {
-    window.addEventListener('mouseover', this._handleMouseOver);
-    window.addEventListener('mouseout', this._handleMouseOut);
-  },
-
-  componentWillUnmount () {
-    window.removeEventListener('mouseover', this._handleMouseOver);
-    window.removeEventListener('mouseout', this._handleMouseOut);
-  },
-
-  _handleMouseOver (e) {
-    if (e.buttons === 1) {
-      this.setState({
-        dragging: true,
-        invalidMessage: null
-      });
-    }
-  },
-
-  _handleMouseOut () {
-    this.setState({
-      dragging: false
-    });
-  },
-
   _handleFileSelect (e) {
     const file = e.target.files[0];
 
@@ -60,6 +35,20 @@ const FileUpload = React.createClass({
   _onDragOver (e) {
     e.stopPropagation();
     e.preventDefault();
+
+    this.setState({
+      dragging: true,
+      invalidMessage: null
+    });
+  },
+
+  _onDragLeave (e) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    this.setState({
+      dragging: false
+    });
   },
 
   _onDrop (e) {
@@ -80,7 +69,7 @@ const FileUpload = React.createClass({
     const isInvalidType = this.props.allowedfileTypes.indexOf(file.type) < 0;
 
     if (isTooBig || isInvalidType) {
-      const invalidMessage = isTooBig ? 'This file exceeds maximum size of ' + this.props.maxFileSize + 'k' : 'This file type is not accepted.';
+      const invalidMessage = isTooBig ? 'This file exceeds maximum size of ' + this.props.maxFileSize + 'k' : 'This file type is not accepted';
 
       this.setState({
         dragging: false,
@@ -120,10 +109,12 @@ const FileUpload = React.createClass({
     return (
       <div
         onClick={this._onDropzoneClick}
+        onDragLeave={this._onDragLeave}
         onDragOver={this._onDragOver}
         onDrop={this._onDrop}
         style={[styles.dropzone, this.state.dragging && styles.dragging, this.props.uploadedFile && styles.dropzoneLoaded]}
       >
+
         {this.props.uploadedFile ? (
           <div style={styles.fileInfo}>
             {this.state.imageSource ? (
@@ -136,9 +127,20 @@ const FileUpload = React.createClass({
             <Button icon='delete' onClick={this._removeImage} style={styles.button} type='secondary' />
           </div>
         ) : (
-          <div>{this.state.dragging ? 'Drop file here to upload' : 'Drag and drop files here or click to browse'}</div>
+          <div style={styles.dropzoneChild}>
+            {this.state.dragging ? (
+              <div style={[styles.centered, styles.draggingText]}>
+                <Icon size={60} style={styles.importIcon} type='import' />
+                <div>Drop file here to upload</div>
+              </div>
+            ) : (
+              <div style={styles.centered}>
+              {this.state.invalidMessage ? <div style={styles.invalidMessage}>{this.state.invalidMessage}</div> : null}
+              <div>Drag and drop files here or click to browse</div>
+              </div>
+            )}
+          </div>
         )}
-        {this.state.invalidMessage ? <div style={styles.invalidMessage}>{this.state.invalidMessage}</div> : null}
         <input
           name='files'
           onChange={this._handleFileSelect}
@@ -153,47 +155,65 @@ const FileUpload = React.createClass({
 
 const styles = {
   dropzone: {
-    fontSize: StyleConstants.FontSizes.MEDIUM,
-    fontFamily: StyleConstants.Fonts.REGULAR,
-    textAlign: 'center',
-    position: 'relative',
-    borderRadius: 3,
-    padding: 40,
-    color: StyleConstants.Colors.ASH,
     backgroundColor: StyleConstants.Colors.PORCELAIN,
-    border: '1px solid ' + StyleConstants.Colors.FOG
-  },
-  dragging: {
-    backgroundColor: StyleConstants.Colors.WHITE,
-    border: '1px dashed ' + StyleConstants.Colors.PRIMARY
-  },
-  dropzoneLoaded: {
-    padding: 20
+    border: '1px solid ' + StyleConstants.Colors.FOG,
+    borderRadius: 3,
+    color: StyleConstants.Colors.ASH,
+    fontFamily: StyleConstants.Fonts.REGULAR,
+    fontSize: StyleConstants.FontSizes.MEDIUM,
+    height: 100,
+    position: 'relative'
   },
   hiddenInput: {
-    visibility: 'hidden',
-    position: 'absolute'
+    position: 'absolute',
+    visibility: 'hidden'
   },
-  fileIcon: {
-    color: StyleConstants.Colors.ASH
+
+  // Dragging Styles
+  dragging: {
+    backgroundColor: StyleConstants.Colors.WHITE,
+    border: '1px dashed ' + StyleConstants.Colors.PRIMARY,
+    height: 150
   },
-  fileInfo: {
-    fontSize: StyleConstants.FontSizes.SMALL,
-    lineHeight: '1.2em',
-    textAlign: 'center'
+  importIcon: {
+    color: StyleConstants.Colors.PRIMARY
+  },
+  draggingText: {
+    color: StyleConstants.Colors.PRIMARY,
+    fontFamily: StyleConstants.Fonts.SEMIBOLD,
+    fontSize: StyleConstants.FontSizes.LARGE
+  },
+
+  // Loaded Styles
+  dropzoneLoaded: {
+    height: 'auto',
+    padding: 20
   },
   previewImage: {
-    maxWidth: '90%',
-    marginBottom: 10
+    marginBottom: 10,
+    maxWidth: '90%'
+  },
+  documentIcon: {
+    color: StyleConstants.Colors.ASH
   },
   button: {
     marginTop: 10
   },
-  invalidMessage: {
-    marginTop: 10
+
+  // Dropzone Text
+  dropzoneChild: {
+    height: '100%',
+    pointerEvents: 'none'
   },
-  documentIcon: {
-    color: StyleConstants.Colors.ASH
+  centered: {
+    left: '50%',
+    position: 'absolute',
+    top: '50%',
+    transform: 'translate(-50%, -50%)'
+  },
+  invalidMessage: {
+    fontSize: StyleConstants.FontSizes.LARGE,
+    marginBottom: 10
   }
 };
 


### PR DESCRIPTION
Adds drop zone component that will accept a file, either by dragging or through a file browser, and return that file.

Props:
- onFileAdd: function returning the file dropped or selected
- onFileRemove: function called on remove click
- uploadedFile: file that is passed back to the component on drop/select

This incorporates @tumentumurchudur's hover effect, changing the border to dashed blue and a white background when dragging onto the window.

Validation and file processing is left up to the parent component. 

DropZone name could use some suggestions. ImageUpload doesn't seem to work because any file can be dropped. FileUpload might work, but the component doesn't actually upload. Thoughts @mxenabled/frontend-engineers?

Initial State:
<img width="929" alt="screen shot 2016-03-02 at 10 05 50 pm" src="https://cloud.githubusercontent.com/assets/488916/13485460/34f1c888-e0c5-11e5-8dc1-56c6e52092bc.png">

Drag State:
<img width="927" alt="screen shot 2016-03-02 at 10 06 35 pm" src="https://cloud.githubusercontent.com/assets/488916/13485459/34f1bd02-e0c5-11e5-9836-3d7b6ff25416.png">

Loaded State:
<img width="919" alt="screen shot 2016-03-02 at 10 06 50 pm" src="https://cloud.githubusercontent.com/assets/488916/13485461/34f2343a-e0c5-11e5-9172-dc86486c7330.png">
