### PR TITLE
removed default prop for selected on select component

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -34,8 +34,7 @@ const Select = React.createClass({
   getInitialState () {
     return {
       highlightedValue: null,
-      isOpen: false,
-      selected: false
+      isOpen: false
     };
   },
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -27,7 +27,6 @@ const Select = React.createClass({
       onChange () {},
       options: [],
       placeholderText: 'Select One',
-      selected: false,
       valid: true
     };
   },


### PR DESCRIPTION
The `selected` prop type is an Object, but the default value was a boolean. Removing the default value here so there is no validation conflict. 