### PR TITLE
Add ability to send existing imageUrl to FileUpload

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -75,35 +75,6 @@ const FileUpload = React.createClass({
     this._input.click();
   },
 
-  _validateFile (file) {
-    const isTooBig = this.props.maxFileSize < file.size / 1000;
-    const isInvalidType = this.props.allowedFileTypes && this.props.allowedFileTypes.indexOf(file.type) < 0;
-
-    if (isTooBig || isInvalidType) {
-      const invalidMessage = isTooBig ? 'The selected file exceeds maximum size of ' + this.props.maxFileSize + 'k' : 'The selected file type is not accepted';
-
-      this.setState({
-        dragging: false,
-        invalidMessage
-      });
-
-      this.props.onFileRemove(this.props.uploadedFile);
-    } else {
-      this.props.onFileAdd(file);
-    }
-  },
-
-  _removeImage (e) {
-    e.stopPropagation();
-    e.preventDefault();
-
-    this.setState({
-      imageSource: null,
-      invalidMessage: null
-    });
-    this.props.onFileRemove();
-  },
-
   _readFile (file) {
     if (file) {
       const reader = new FileReader();
@@ -121,6 +92,17 @@ const FileUpload = React.createClass({
     }
   },
 
+  _removeFile (e) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    this.setState({
+      imageSource: null,
+      invalidMessage: null
+    });
+    this.props.onFileRemove();
+  },
+
   _renderInvalidMessage () {
     if (this.state.invalidMessage) {
       return (
@@ -131,6 +113,24 @@ const FileUpload = React.createClass({
       );
     } else {
       return null;
+    }
+  },
+
+  _validateFile (file) {
+    const isTooBig = this.props.maxFileSize < file.size / 1000;
+    const isInvalidType = this.props.allowedFileTypes && this.props.allowedFileTypes.indexOf(file.type) < 0;
+
+    if (isTooBig || isInvalidType) {
+      const invalidMessage = isTooBig ? 'The selected file exceeds maximum size of ' + this.props.maxFileSize + 'k' : 'The selected file type is not accepted';
+
+      this.setState({
+        dragging: false,
+        invalidMessage
+      });
+
+      this.props.onFileRemove(this.props.uploadedFile);
+    } else {
+      this.props.onFileAdd(file);
     }
   },
 
@@ -159,7 +159,7 @@ const FileUpload = React.createClass({
               <div>
                 <div>{this.props.uploadedFile.name}</div>
                 <div>{numeral(this.props.uploadedFile.size / 1000).format('0.0')}k</div>
-                <Button icon='delete' onClick={this._removeImage} style={styles.button} type='secondary' />
+                <Button icon='delete' onClick={this._removeFile} style={styles.button} type='secondary' />
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
- Add imageUrl to FileUpload props
- If imageUrl is present, show preview of existing file on load
- Replace preview of existing file with uploaded file on drop
- Restore preview of existing file if uploadedFile is removed
- Fade preview image on drag
- Keep upload instructions in view even with image preview
- Add attention icon to invalid message
- Move invalid message rendering into a method since it is reused

@mxenabled/frontend-engineers 

Empty drop zone:
![screen shot 2016-03-09 at 1 46 25 pm](https://cloud.githubusercontent.com/assets/488916/13649927/5d483fc8-e5fd-11e5-9839-6e8199ab9e8e.png)

Loaded drop zone
![screen shot 2016-03-09 at 1 21 58 pm](https://cloud.githubusercontent.com/assets/488916/13649561/8fdb96d0-e5fb-11e5-83cd-69e5143c400d.png)

Existing image drop zone
![screen shot 2016-03-09 at 1 22 12 pm](https://cloud.githubusercontent.com/assets/488916/13649559/8fd7c4c4-e5fb-11e5-96ad-2b23539904b9.png)

Faded preview on fade
![screen shot 2016-03-09 at 1 23 10 pm](https://cloud.githubusercontent.com/assets/488916/13649560/8fd8baf0-e5fb-11e5-9ae7-84acd8fd5ac9.png)
