### PR TITLE
Moore/simple drawer component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -523,10 +523,10 @@ const Demo = React.createClass({
     });
   },
 
-  _nextSibling () {
+  _handleNextSiblingClick () {
   },
 
-  _previousSibling () {
+  _handlePreviousSiblingClick () {
   },
 
   _toggleDrawer () {
@@ -538,9 +538,9 @@ const Demo = React.createClass({
   render () {
     const navConfig = {
       duration: 200,
-      onNextClick: this._nextSibling,
+      onNextClick: this._handleNextSiblingClick,
       label: _find(this.state.drawerSiblings, { selected: true }).id + ' of ' + this.state.drawerSiblings.length,
-      onPreviousClick: this._previousSibling
+      onPreviousClick: this._handlePreviousSiblingClick
     };
 
     return (
@@ -549,7 +549,6 @@ const Demo = React.createClass({
           <Button onClick={this._toggleDrawer} style={{ position: 'absolute', left: 15, top: 15 }}>Toggle Drawer</Button>
           {this.state.showDrawer ?
           <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
-            <p>Drawer</p>
             <Drawer navConfig={navConfig} onClose={this._toggleDrawer}>
               <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
             </Drawer>

--- a/demo/app.js
+++ b/demo/app.js
@@ -450,7 +450,7 @@ const Demo = React.createClass({
       },
       lineChartData: [],
       selectedDatePickerDate: moment().unix(),
-      showDrawer: false,
+      showDrawer: true,
       showModal: false,
       showSmallModal: false,
       uploadedFile: null,
@@ -524,11 +524,9 @@ const Demo = React.createClass({
   },
 
   _nextSibling () {
-    console.log('next');
   },
 
   _previousSibling () {
-    console.log('previous');
   },
 
   _toggleDrawer () {
@@ -548,12 +546,14 @@ const Demo = React.createClass({
     return (
       <div>
         <br/><br/>
-        <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
           <Button onClick={this._toggleDrawer} style={{ position: 'absolute', left: 15, top: 15 }}>Toggle Drawer</Button>
-          <Drawer isOpen={this.state.showDrawer} navContent={navContent} onClose={this._toggleDrawer}>
-            <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
-          </Drawer>
-        </div>
+          {this.state.showDrawer ?
+          <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
+            <p>Drawer</p>
+            <Drawer navContent={navContent} onClose={this._toggleDrawer}>
+              <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
+            </Drawer>
+          </div> : null}
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
           <FileUpload

--- a/demo/app.js
+++ b/demo/app.js
@@ -550,7 +550,9 @@ const Demo = React.createClass({
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
           <Button onClick={this._toggleDrawer} style={{ position: 'absolute', left: 15, top: 15 }}>Toggle Drawer</Button>
-          <Drawer isOpen={this.state.showDrawer} onClose={this._toggleDrawer} siblingContent={drawerSiblingContent}/>
+          <Drawer isOpen={this.state.showDrawer} onClose={this._toggleDrawer} siblingContent={drawerSiblingContent}>
+            <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif'}}>Insert Custom Content Here</div>
+          </Drawer>
         </div>
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>

--- a/demo/app.js
+++ b/demo/app.js
@@ -536,7 +536,7 @@ const Demo = React.createClass({
   },
 
   render () {
-    const navContent = {
+    const navConfig = {
       duration: 200,
       onNextClick: this._nextSibling,
       label: _find(this.state.drawerSiblings, { selected: true }).id + ' of ' + this.state.drawerSiblings.length,
@@ -550,7 +550,7 @@ const Demo = React.createClass({
           {this.state.showDrawer ?
           <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
             <p>Drawer</p>
-            <Drawer navContent={navContent} onClose={this._toggleDrawer}>
+            <Drawer navConfig={navConfig} onClose={this._toggleDrawer}>
               <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
             </Drawer>
           </div> : null}

--- a/demo/app.js
+++ b/demo/app.js
@@ -538,11 +538,10 @@ const Demo = React.createClass({
   },
 
   render () {
-    const drawerSiblingContent = {
-      currentSiblingIndex: _find(this.state.drawerSiblings, { selected: true }).id,
-      nextSibling: this._nextSibling,
-      previousSibling: this._previousSibling,
-      totalSiblings: this.state.drawerSiblings.length
+    const navContent = {
+      onNextClick: this._nextSibling,
+      label: _find(this.state.drawerSiblings, { selected: true }).id + ' of ' + this.state.drawerSiblings.length,
+      onPreviousClick: this._previousSibling
     };
 
     return (
@@ -550,7 +549,7 @@ const Demo = React.createClass({
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
           <Button onClick={this._toggleDrawer} style={{ position: 'absolute', left: 15, top: 15 }}>Toggle Drawer</Button>
-          <Drawer isOpen={this.state.showDrawer} onClose={this._toggleDrawer} siblingContent={drawerSiblingContent}>
+          <Drawer isOpen={this.state.showDrawer} navContent={navContent} onClose={this._toggleDrawer}>
             <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
           </Drawer>
         </div>

--- a/demo/app.js
+++ b/demo/app.js
@@ -539,6 +539,7 @@ const Demo = React.createClass({
 
   render () {
     const navContent = {
+      duration: 200,
       onNextClick: this._nextSibling,
       label: _find(this.state.drawerSiblings, { selected: true }).id + ' of ' + this.state.drawerSiblings.length,
       onPreviousClick: this._previousSibling

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,3 +1,4 @@
+const _find = require('lodash/find');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const moment = require('moment');
@@ -7,6 +8,7 @@ const {
   DatePicker,
   DatePickerFullScreen,
   DonutChart,
+  Drawer,
   FileUpload,
   Icon,
   Loader,
@@ -424,12 +426,31 @@ const lineChartData = [
 const Demo = React.createClass({
   getInitialState () {
     return {
+      drawerSiblings: [
+        {
+          id: 1,
+          selected: true
+        },
+        {
+          id: 2,
+          selected: false
+        },
+        {
+          id: 3,
+          selected: false
+        },
+        {
+          id: 4,
+          selected: false
+        }
+      ],
       icon: {
         value: 'accounts',
         displayValue: 'Accounts'
       },
       lineChartData: [],
       selectedDatePickerDate: moment().unix(),
+      showDrawer: false,
       showModal: false,
       showSmallModal: false,
       uploadedFile: null,
@@ -502,9 +523,35 @@ const Demo = React.createClass({
     });
   },
 
+  _nextSibling () {
+    console.log('next');
+  },
+
+  _previousSibling () {
+    console.log('previous');
+  },
+
+  _toggleDrawer () {
+    this.setState({
+      showDrawer: !this.state.showDrawer
+    });
+  },
+
   render () {
+    const drawerSiblingContent = {
+      currentSiblingIndex: _find(this.state.drawerSiblings, { selected: true }).id,
+      nextSibling: this._nextSibling,
+      previousSibling: this._previousSibling,
+      totalSiblings: this.state.drawerSiblings.length
+    };
+
     return (
       <div>
+        <br/><br/>
+        <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
+          <Button onClick={this._toggleDrawer} style={{ position: 'absolute', left: 15, top: 15 }}>Toggle Drawer</Button>
+          <Drawer isOpen={this.state.showDrawer} onClose={this._toggleDrawer} siblingContent={drawerSiblingContent}/>
+        </div>
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
           <FileUpload

--- a/demo/app.js
+++ b/demo/app.js
@@ -551,7 +551,7 @@ const Demo = React.createClass({
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto', position: 'relative', height: '200', overflow: 'hidden' }}>
           <Button onClick={this._toggleDrawer} style={{ position: 'absolute', left: 15, top: 15 }}>Toggle Drawer</Button>
           <Drawer isOpen={this.state.showDrawer} onClose={this._toggleDrawer} siblingContent={drawerSiblingContent}>
-            <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif'}}>Insert Custom Content Here</div>
+            <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
           </Drawer>
         </div>
         <br/><br/>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "object-assign": "^4.0.1",
     "radium": "^0.14.0",
     "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react-dom": "^0.14.0",
+    "velocity-animate": "^1.2.3"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",

--- a/src/Index.js
+++ b/src/Index.js
@@ -3,6 +3,7 @@ module.exports = {
   DatePicker: require('./components/DatePicker'),
   DatePickerFullScreen: require('./components/DatePickerFullScreen'),
   DonutChart: require('./components/DonutChart'),
+  Drawer: require('./components/Drawer'),
   FileUpload: require('./components/FileUpload'),
   Icon: require('./components/Icon'),
   Loader: require('./components/Loader'),

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -10,7 +10,8 @@ const Drawer = React.createClass({
   getDefaultProps () {
     return {
       duration: 500,
-      isOpen: false
+      isOpen: false,
+      easing: [.28, .14, .34, 1.04]
     };
   },
 
@@ -26,9 +27,10 @@ const Drawer = React.createClass({
 
   _renderTransition (isOpen) {
     const el = this.refs.component;
-    const transition = isOpen ? { left: 0 } : { left: 400 };
+    const transition = isOpen ? { right: -800 } : { right: 0 };
     const options = {
-      duration: this.props.duration
+      duration: this.props.duration,
+      easing: this.props.easing
     };
 
     Velocity(el, transition, options);
@@ -45,12 +47,11 @@ const Drawer = React.createClass({
 });
 
 const styles = {
-  left: 0,
   top: 0,
   bottom: 0,
-  right: 0,
-  position: 'relative',
-  width: 400,
+  right: -800,
+  position: 'absolute',
+  width: 800,
   backgroundColor: '#eaeaea'
 };
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -12,7 +12,7 @@ const Drawer = React.createClass({
     isOpen: React.PropTypes.bool,
     onClose: React.PropTypes.func.isRequired,
     siblingContent: React.PropTypes.shape({
-      currentSibling: React.PropTypes.number.isRequired,
+      currentSiblingIndex: React.PropTypes.number.isRequired,
       nextSibling: React.PropTypes.func.isRequired,
       previousSibling: React.PropTypes.func.isRequired,
       totalSiblings: React.PropTypes.number.isRequired
@@ -40,7 +40,9 @@ const Drawer = React.createClass({
   _renderSiblingContent () {
     return (
       <div ref='siblingContent' style={styles.siblingContent}>
-        <Icon onClick={this.props.onClose} size={25} style={styles.icon} type='caret-left'/> {this.props.siblingContent.currentSibling} of {this.props.siblingContent.totalSiblings} <Icon onClick={this.props.onClose} size={25} style={styles.icon} type='caret-right'/>
+        <Icon onClick={this.props.siblingContent.previousSibling} size={25} style={styles.icon} type='caret-left'/>
+        {this.props.siblingContent.currentSiblingIndex} of {this.props.siblingContent.totalSiblings}
+        <Icon onClick={this.props.siblingContent.nextSibling} size={25} style={styles.icon} type='caret-right'/>
       </div>
     );
   },

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -38,6 +38,8 @@ const Drawer = React.createClass({
   },
 
   _renderSiblingContent () {
+    const styles = this.styles();
+
     return (
       <div ref='siblingContent' style={styles.siblingContent}>
         <Icon onClick={this.props.siblingContent.previousSibling} size={25} style={styles.icon} type='caret-left'/>
@@ -77,7 +79,7 @@ const Drawer = React.createClass({
 
   _slideSiblingContent (isOpen) {
     const el = this.refs.siblingContent;
-    const transition = isOpen ? { top: -15 } : { top: 15 };
+    const transition = isOpen ? { top: -12 } : { top: 12 };
     const options = {
       duration: 200,
       easing: this.props.easing
@@ -87,6 +89,8 @@ const Drawer = React.createClass({
   },
 
   render () {
+    const styles = this.styles();
+
     return (
       <div ref='component' style={styles.component}>
         <nav style={styles.nav}>
@@ -99,40 +103,42 @@ const Drawer = React.createClass({
         <div></div>
       </div>
     );
+  },
+
+  styles () {
+    return {
+      component: {
+        top: 0,
+        bottom: 0,
+        right: -800,
+        position: 'absolute',
+        width: 800,
+        overflow: 'hidden'
+      },
+      icon: {
+        color: StyleConstants.Colors.ASH
+      },
+      iconContainer: {
+        position: 'absolute',
+        left: -25,
+        top: 12
+      },
+      nav: {
+        backgroundColor: StyleConstants.Colors.PORCELAIN,
+        borderBottom: 'solid 1px ' + StyleConstants.Colors.ASH,
+        height: 15,
+        padding: '15px 25px'
+      },
+      siblingContent: {
+        fontFamily: StyleConstants.Fonts.THIN,
+        color: StyleConstants.Colors.ASH,
+        position: 'absolute',
+        right: 25,
+        top: -12
+      }
+    };
   }
 
 });
-
-const styles = {
-  component: {
-    top: 0,
-    bottom: 0,
-    right: -800,
-    position: 'absolute',
-    width: 800,
-    overflow: 'hidden'
-  },
-  icon: {
-    color: StyleConstants.Colors.ASH
-  },
-  iconContainer: {
-    position: 'absolute',
-    left: -25,
-    top: 12
-  },
-  nav: {
-    backgroundColor: StyleConstants.Colors.PORCELAIN,
-    borderBottom: 'solid 1px ' + StyleConstants.Colors.ASH,
-    height: 15,
-    padding: '15px 25px'
-  },
-  siblingContent: {
-    fontFamily: StyleConstants.Fonts.THIN,
-    color: StyleConstants.Colors.ASH,
-    position: 'absolute',
-    right: 25,
-    top: -15
-  }
-};
 
 module.exports = Drawer;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -99,8 +99,9 @@ const Drawer = React.createClass({
           </span>
           {this.props.siblingContent ? this._renderSiblingContent() : null}
         </nav>
-        <header></header>
-        <div></div>
+        <div>
+          {this.props.children}
+        </div>
       </div>
     );
   },
@@ -113,7 +114,8 @@ const Drawer = React.createClass({
         right: -800,
         position: 'absolute',
         width: 800,
-        overflow: 'hidden'
+        overflow: 'hidden',
+        backgroundColor: StyleConstants.Colors.PORCELAIN
       },
       icon: {
         color: StyleConstants.Colors.ASH

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,0 +1,58 @@
+const React = require('react');
+const Velocity = require('velocity-animate');
+
+const Drawer = React.createClass({
+  propTypes: {
+    duration: React.PropTypes.number,
+    isOpen: React.PropTypes.bool
+  },
+
+  getDefaultProps () {
+    return {
+      duration: 500,
+      isOpen: false
+    };
+  },
+
+  componentDidMount () {
+    this._renderTransition(this.props.isOpen);
+  },
+
+  componentWillReceiveProps (newProps) {
+    if (newProps.isOpen !== this.props.isOpen) {
+      this._renderTransition(newProps.isOpen);
+    }
+  },
+
+  _renderTransition (isOpen) {
+    const el = this.refs.component;
+    const transition = isOpen ? { left: 0 } : { left: 400 };
+    const options = {
+      duration: this.props.duration
+    };
+
+    Velocity(el, transition, options);
+  },
+
+  render () {
+    return (
+      <div ref='component' style={styles}>
+        HELLO DRAWER
+      </div>
+    );
+  }
+
+});
+
+const styles = {
+  left: 0,
+  top: 0,
+  bottom: 0,
+  right: 0,
+  position: 'relative',
+  width: 400,
+  backgroundColor: '#eaeaea'
+};
+
+module.exports = Drawer;
+

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -9,7 +9,8 @@ const Drawer = React.createClass({
   propTypes: {
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
-    isOpen: React.PropTypes.bool
+    isOpen: React.PropTypes.bool,
+    onClose: React.PropTypes.func.isRequired
   },
 
   getDefaultProps () {
@@ -30,15 +31,23 @@ const Drawer = React.createClass({
     }
   },
 
-  _handleArrowClick () {
-    this._renderTransition(true);
-  },
-
   _renderTransition (isOpen) {
     const el = this.refs.component;
     const transition = isOpen ? { right: -800 } : { right: 0 };
     const options = {
+      complete: this._slideArrow.bind(this, isOpen),
       duration: this.props.duration,
+      easing: this.props.easing
+    };
+
+    Velocity(el, transition, options);
+  },
+
+  _slideArrow (isOpen) {
+    const el = this.refs.arrow;
+    const transition = isOpen ? { left: -25 } : { left: 25 };
+    const options = {
+      duration: 200,
       easing: this.props.easing
     };
 
@@ -48,7 +57,9 @@ const Drawer = React.createClass({
   render () {
     return (
       <div ref='component' style={styles.component}>
-        <nav style={styles.nav}><Icon onClick={this._handleArrowClick} size={20} style={styles.icon} type='arrow-left'/></nav>
+        <nav style={styles.nav}>
+          <span ref='arrow' style={styles.iconContainer}><Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/></span>
+        </nav>
         <header></header>
         <div></div>
       </div>
@@ -64,17 +75,21 @@ const styles = {
     right: -800,
     position: 'absolute',
     width: 800,
-    backgroundColor: '#eaeaea'
+    overflow: 'hidden'
   },
   icon: {
-    color: StyleConstants.Colors.ASH,
+    color: StyleConstants.Colors.ASH
+  },
+  iconContainer: {
     position: 'absolute',
-    left: 25
+    left: -25,
+    top: 12
   },
   nav: {
-    padding: '15px 25px',
+    backgroundColor: StyleConstants.Colors.PORCELAIN,
     borderBottom: 'solid 1px ' + StyleConstants.Colors.ASH,
-    height: 15
+    height: 15,
+    padding: '15px 25px'
   }
 };
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -48,11 +48,11 @@ const Drawer = React.createClass({
   },
 
   _handleCloseClick () {
+
   },
 
   _animateComponent (transition) {
     const el = this._component;
-//    const transition = { right: 0 };
     const options = {
       duration: this.props.duration,
       easing: this.props.easing
@@ -63,7 +63,6 @@ const Drawer = React.createClass({
 
   _animateBackArrow (transition) {
     const el = this._backArrow;
-//    const transition = { left: 25 };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,
@@ -75,7 +74,6 @@ const Drawer = React.createClass({
 
   _animateNav (transition) {
     const el = this._nav;
-//    const transition = { top: 12 };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -10,13 +10,12 @@ const Drawer = React.createClass({
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
     isOpen: React.PropTypes.bool,
-    onClose: React.PropTypes.func.isRequired,
-    siblingContent: React.PropTypes.shape({
-      currentSiblingIndex: React.PropTypes.number.isRequired,
-      nextSibling: React.PropTypes.func.isRequired,
-      previousSibling: React.PropTypes.func.isRequired,
-      totalSiblings: React.PropTypes.number.isRequired
-    })
+    navContent: React.PropTypes.shape({
+      label: React.PropTypes.string.isRequired,
+      onNextClick: React.PropTypes.func.isRequired,
+      onPreviousClick: React.PropTypes.func.isRequired
+    }),
+    onClose: React.PropTypes.func.isRequired
   },
 
   getDefaultProps () {
@@ -37,14 +36,14 @@ const Drawer = React.createClass({
     }
   },
 
-  _renderSiblingContent () {
+  _renderNavContent () {
     const styles = this.styles();
 
     return (
-      <div ref={(ref) => (this._siblingContent = ref)} style={styles.siblingContent}>
-        <Icon onClick={this.props.siblingContent.previousSibling} size={25} style={styles.icon} type='caret-left'/>
-        {this.props.siblingContent.currentSiblingIndex} of {this.props.siblingContent.totalSiblings}
-        <Icon onClick={this.props.siblingContent.nextSibling} size={25} style={styles.icon} type='caret-right'/>
+      <div ref={(ref) => (this._navContent = ref)} style={styles.navContent}>
+        <Icon onClick={this.props.navContent.onPreviousClick} size={25} style={styles.icon} type='caret-left'/>
+        {this.props.navContent.label}
+        <Icon onClick={this.props.navContent.onNextClick} size={25} style={styles.icon} type='caret-right'/>
       </div>
     );
   },
@@ -53,7 +52,7 @@ const Drawer = React.createClass({
     const el = this._component;
     const transition = isOpen ? { right: -800 } : { right: 0 };
     const options = {
-      complete: this._slideArrowAndSiblingContent.bind(this, isOpen),
+      complete: this._doNavAnimation.bind(this, isOpen),
       duration: this.props.duration,
       easing: this.props.easing
     };
@@ -61,9 +60,9 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
-  _slideArrowAndSiblingContent (isOpen) {
+  _doNavAnimation (isOpen) {
     this._slideArrow(isOpen);
-    this._slideSiblingContent(isOpen);
+    this._slideNavContent(isOpen);
   },
 
   _slideArrow (isOpen) {
@@ -77,8 +76,8 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
-  _slideSiblingContent (isOpen) {
-    const el = this._siblingContent;
+  _slideNavContent (isOpen) {
+    const el = this._navContent;
     const transition = isOpen ? { top: -25 } : { top: 12 };
     const options = {
       duration: 200,
@@ -97,7 +96,7 @@ const Drawer = React.createClass({
           <span ref={(ref) => (this._arrow = ref)} style={styles.iconContainer}>
             <Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/>
           </span>
-          {this.props.siblingContent ? this._renderSiblingContent() : null}
+          {this.props.navContent ? this._renderNavContent() : null}
         </nav>
         <div>
           {this.props.children}
@@ -131,7 +130,7 @@ const Drawer = React.createClass({
         height: 15,
         padding: '15px 25px'
       },
-      siblingContent: {
+      navContent: {
         fontFamily: StyleConstants.Fonts.THIN,
         color: StyleConstants.Colors.ASH,
         position: 'absolute',

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -37,6 +37,10 @@ const Drawer = React.createClass({
     }
   },
 
+  componentWillUnmount () {
+    console.log('component unmounting');
+  },
+
   _renderNavContent () {
     const styles = this.styles();
 
@@ -51,8 +55,14 @@ const Drawer = React.createClass({
   _renderTransition (isOpen) {
     const el = this._component;
     const transition = isOpen ? { right: -800 } : { right: 0 };
+    let onComplete = this._doNavAnimation.bind(this, isOpen);
+
+    if (isOpen) {
+      onComplete = this.props.onClose;
+    }
+
     const options = {
-      complete: this._doNavAnimation.bind(this, isOpen),
+      complete: onComplete,
       duration: this.props.duration,
       easing: this.props.easing
     };
@@ -63,6 +73,10 @@ const Drawer = React.createClass({
   _doNavAnimation (isOpen) {
     this._slideArrow(isOpen);
     this._slideNavContent(isOpen);
+  },
+
+  _handleCloseClick () {
+    this._renderTransition(true);
   },
 
   _slideArrow (isOpen) {
@@ -94,7 +108,7 @@ const Drawer = React.createClass({
       <div ref={(ref) => (this._component = ref)} style={styles.component}>
         <nav style={styles.nav}>
           <span ref={(ref) => (this._arrow = ref)} style={styles.iconContainer}>
-            <Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/>
+            <Icon onClick={this._handleCloseClick} size={25} style={styles.icon}type='arrow-left'/>
           </span>
           {this._renderNavContent()}
         </nav>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -9,7 +9,7 @@ const Drawer = React.createClass({
   propTypes: {
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
-    navContent: React.PropTypes.shape({
+    navConfig: React.PropTypes.shape({
       label: React.PropTypes.string.isRequired,
       onNextClick: React.PropTypes.func.isRequired,
       onPreviousClick: React.PropTypes.func.isRequired
@@ -33,30 +33,32 @@ const Drawer = React.createClass({
     };
 
     Velocity(el, transition, options);
-    this._slideArrow();
-    this._slideNavContent();
+    this._animateBackArrow();
+    if (this.props.navConfig) {
+      this._animateNav();
+    }
   },
 
   componentWillUnmount () {
     console.log('component unmounting');
   },
 
-  _renderNavContent () {
+  _renderNav () {
     const styles = this.styles();
 
-    return this.props.navContent ?
-      <div ref={(ref) => (this._navContent = ref)} style={styles.navContent}>
-        <Icon onClick={this.props.navContent.onPreviousClick} size={25} style={styles.icon} type='caret-left'/>
-        {this.props.navContent.label}
-        <Icon onClick={this.props.navContent.onNextClick} size={25} style={styles.icon} type='caret-right'/>
-      </div> : null;
+    return this.props.navConfig ?
+      <nav ref={(ref) => (this._nav = ref)} style={styles.nav}>
+        <Icon onClick={this.props.navConfig.onPreviousClick} size={25} style={styles.icons} type='caret-left'/>
+        {this.props.navConfig.label}
+        <Icon onClick={this.props.navConfig.onNextClick} size={25} style={styles.icons} type='caret-right'/>
+      </nav> : null;
   },
 
   _handleCloseClick () {
   },
 
-  _slideArrow () {
-    const el = this._arrow;
+  _animateBackArrow () {
+    const el = this._backArrow;
     const transition = { left: 25 };
     const options = {
       delay: this.props.duration,
@@ -67,8 +69,8 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
-  _slideNavContent () {
-    const el = this._navContent;
+  _animateNav () {
+    const el = this._nav;
     const transition = { top: 12 };
     const options = {
       delay: this.props.duration,
@@ -84,12 +86,12 @@ const Drawer = React.createClass({
 
     return (
       <div ref={(ref) => (this._component = ref)} style={styles.component}>
-        <nav style={styles.nav}>
-          <span ref={(ref) => (this._arrow = ref)} style={styles.iconContainer}>
-            <Icon onClick={this._handleCloseClick} size={25} style={styles.icon}type='arrow-left'/>
+        <header style={styles.header}>
+          <span ref={(ref) => (this._backArrow = ref)} style={styles.backArrowContainer}>
+            <Icon onClick={this._handleCloseClick} size={25} style={styles.icons}type='arrow-left'/>
           </span>
-          {this._renderNavContent()}
-        </nav>
+          {this._renderNav()}
+        </header>
         <div>
           {this.props.children}
         </div>
@@ -108,21 +110,21 @@ const Drawer = React.createClass({
         overflow: 'hidden',
         backgroundColor: StyleConstants.Colors.PORCELAIN
       },
-      icon: {
+      icons: {
         color: StyleConstants.Colors.ASH
       },
-      iconContainer: {
+      backArrowContainer: {
         position: 'absolute',
         left: -25,
         top: 12
       },
-      nav: {
+      header: {
         backgroundColor: StyleConstants.Colors.PORCELAIN,
         borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
         height: 15,
         padding: '15px 25px'
       },
-      navContent: {
+      nav: {
         fontFamily: StyleConstants.Fonts.THIN,
         color: StyleConstants.Colors.ASH,
         position: 'absolute',

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -25,17 +25,10 @@ const Drawer = React.createClass({
   },
 
   componentDidMount () {
-    const el = this._component;
-    const transition = { right: 0 };
-    const options = {
-      duration: this.props.duration,
-      easing: this.props.easing
-    };
-
-    Velocity(el, transition, options);
-    this._animateBackArrow();
+    this._animateComponent({ right: 0 });
+    this._animateBackArrow({ left: 25 });
     if (this.props.navConfig) {
-      this._animateNav();
+      this._animateNav({ top: 12 });
     }
   },
 
@@ -57,9 +50,20 @@ const Drawer = React.createClass({
   _handleCloseClick () {
   },
 
-  _animateBackArrow () {
+  _animateComponent (transition) {
+    const el = this._component;
+//    const transition = { right: 0 };
+    const options = {
+      duration: this.props.duration,
+      easing: this.props.easing
+    };
+
+    Velocity(el, transition, options);
+  },
+
+  _animateBackArrow (transition) {
     const el = this._backArrow;
-    const transition = { left: 25 };
+//    const transition = { left: 25 };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,
@@ -69,9 +73,9 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
-  _animateNav () {
+  _animateNav (transition) {
     const el = this._nav;
-    const transition = { top: 12 };
+//    const transition = { top: 12 };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -11,6 +11,7 @@ const Drawer = React.createClass({
     easing: React.PropTypes.array,
     isOpen: React.PropTypes.bool,
     navContent: React.PropTypes.shape({
+      duration: React.PropTypes.number
       label: React.PropTypes.string.isRequired,
       onNextClick: React.PropTypes.func.isRequired,
       onPreviousClick: React.PropTypes.func.isRequired
@@ -69,7 +70,7 @@ const Drawer = React.createClass({
     const el = this._arrow;
     const transition = isOpen ? { left: -25 } : { left: 25 };
     const options = {
-      duration: 200,
+      duration: this.props.navContent.duration | this.props.duration,
       easing: this.props.easing
     };
 
@@ -80,7 +81,7 @@ const Drawer = React.createClass({
     const el = this._navContent;
     const transition = isOpen ? { top: -25 } : { top: 12 };
     const options = {
-      duration: 200,
+      duration: this.props.navContent.duration | this.props.duration,
       easing: this.props.easing
     };
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -9,9 +9,7 @@ const Drawer = React.createClass({
   propTypes: {
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
-    isOpen: React.PropTypes.bool,
     navContent: React.PropTypes.shape({
-      duration: React.PropTypes.number,
       label: React.PropTypes.string.isRequired,
       onNextClick: React.PropTypes.func.isRequired,
       onPreviousClick: React.PropTypes.func.isRequired
@@ -22,19 +20,21 @@ const Drawer = React.createClass({
   getDefaultProps () {
     return {
       duration: 500,
-      isOpen: false,
       easing: [0.28, 0.14, 0.34, 1.04]
     };
   },
 
   componentDidMount () {
-    this._renderTransition(this.props.isOpen);
-  },
+    const el = this._component;
+    const transition = { right: 0 };
+    const options = {
+      duration: this.props.duration,
+      easing: this.props.easing
+    };
 
-  componentWillReceiveProps (newProps) {
-    if (newProps.isOpen !== this.props.isOpen) {
-      this._renderTransition(newProps.isOpen);
-    }
+    Velocity(el, transition, options);
+    this._slideArrow();
+    this._slideNavContent();
   },
 
   componentWillUnmount () {
@@ -52,17 +52,14 @@ const Drawer = React.createClass({
       </div> : null;
   },
 
-  _renderTransition (isOpen) {
-    const el = this._component;
-    const transition = isOpen ? { right: -800 } : { right: 0 };
-    let onComplete = this._doNavAnimation.bind(this, isOpen);
+  _handleCloseClick () {
+  },
 
-    if (isOpen) {
-      onComplete = this.props.onClose;
-    }
-
+  _slideArrow () {
+    const el = this._arrow;
+    const transition = { left: 25 };
     const options = {
-      complete: onComplete,
+      delay: this.props.duration,
       duration: this.props.duration,
       easing: this.props.easing
     };
@@ -70,31 +67,12 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
-  _doNavAnimation (isOpen) {
-    this._slideArrow(isOpen);
-    this._slideNavContent(isOpen);
-  },
-
-  _handleCloseClick () {
-    this._renderTransition(true);
-  },
-
-  _slideArrow (isOpen) {
-    const el = this._arrow;
-    const transition = isOpen ? { left: -25 } : { left: 25 };
-    const options = {
-      duration: this.props.navContent.duration | this.props.duration,
-      easing: this.props.easing
-    };
-
-    Velocity(el, transition, options);
-  },
-
-  _slideNavContent (isOpen) {
+  _slideNavContent () {
     const el = this._navContent;
-    const transition = isOpen ? { top: -25 } : { top: 12 };
+    const transition = { top: 12 };
     const options = {
-      duration: this.props.navContent.duration | this.props.duration,
+      delay: this.props.duration,
+      duration: this.props.duration,
       easing: this.props.easing
     };
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -40,13 +40,12 @@ const Drawer = React.createClass({
   _renderNavContent () {
     const styles = this.styles();
 
-    return (
+    return this.props.navContent ?
       <div ref={(ref) => (this._navContent = ref)} style={styles.navContent}>
         <Icon onClick={this.props.navContent.onPreviousClick} size={25} style={styles.icon} type='caret-left'/>
         {this.props.navContent.label}
         <Icon onClick={this.props.navContent.onNextClick} size={25} style={styles.icon} type='caret-right'/>
-      </div>
-    );
+      </div> : null;
   },
 
   _renderTransition (isOpen) {
@@ -97,7 +96,7 @@ const Drawer = React.createClass({
           <span ref={(ref) => (this._arrow = ref)} style={styles.iconContainer}>
             <Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/>
           </span>
-          {this.props.navContent ? this._renderNavContent() : null}
+          {this._renderNavContent()}
         </nav>
         <div>
           {this.props.children}

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -25,7 +25,7 @@ const Drawer = React.createClass({
   },
 
   componentDidMount () {
-    this._animateComponent({ right: 0 });
+    this._animateComponent({ left: '20%' });
     this._animateBackArrow();
     if (this.props.navConfig) {
       this._animateNav();
@@ -48,7 +48,7 @@ const Drawer = React.createClass({
   },
 
   _handleCloseClick () {
-    this._animateComponent({ right: -800 })
+    this._animateComponent({ left: '100%' })
     .then(() => {
       this.props.onClose();
     });
@@ -78,7 +78,7 @@ const Drawer = React.createClass({
 
   _animateNav () {
     const el = this._nav;
-    const transition = { top: 12 };
+    const transition = { top: '50%' };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,
@@ -111,9 +111,9 @@ const Drawer = React.createClass({
       component: {
         top: 0,
         bottom: 0,
-        right: -800,
+        left: '100%',
         position: 'absolute',
-        width: 800,
+        width: '80%',
         overflow: 'hidden',
         backgroundColor: StyleConstants.Colors.PORCELAIN
       },
@@ -122,21 +122,24 @@ const Drawer = React.createClass({
       },
       backArrow: {
         position: 'absolute',
-        left: -25,
-        top: 12
+        right: '100%',
+        top: '50%',
+        transform: 'translateY(-50%)'
       },
       header: {
         backgroundColor: StyleConstants.Colors.PORCELAIN,
         borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
         height: 15,
-        padding: '15px 25px'
+        padding: '15px 25px',
+        position: 'relative'
       },
       nav: {
         fontFamily: StyleConstants.Fonts.THIN,
         color: StyleConstants.Colors.ASH,
         position: 'absolute',
         right: 25,
-        top: -25
+        top: '-100%',
+        transform: 'translateY(-50%)'
       }
     };
   }

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -87,7 +87,7 @@ const Drawer = React.createClass({
     return (
       <div ref={(ref) => (this._component = ref)} style={styles.component}>
         <header style={styles.header}>
-          <span ref={(ref) => (this._backArrow = ref)} style={styles.backArrowContainer}>
+          <span ref={(ref) => (this._backArrow = ref)} style={styles.backArrow}>
             <Icon onClick={this._handleCloseClick} size={25} style={styles.icons}type='arrow-left'/>
           </span>
           {this._renderNav()}
@@ -113,7 +113,7 @@ const Drawer = React.createClass({
       icons: {
         color: StyleConstants.Colors.ASH
       },
-      backArrowContainer: {
+      backArrow: {
         position: 'absolute',
         left: -25,
         top: 12

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,9 +1,14 @@
 const React = require('react');
 const Velocity = require('velocity-animate');
 
+const StyleConstants = require('../constants/Style');
+
+const Icon = require('../components/Icon');
+
 const Drawer = React.createClass({
   propTypes: {
     duration: React.PropTypes.number,
+    easing: React.PropTypes.array,
     isOpen: React.PropTypes.bool
   },
 
@@ -11,7 +16,7 @@ const Drawer = React.createClass({
     return {
       duration: 500,
       isOpen: false,
-      easing: [.28, .14, .34, 1.04]
+      easing: [0.28, 0.14, 0.34, 1.04]
     };
   },
 
@@ -23,6 +28,10 @@ const Drawer = React.createClass({
     if (newProps.isOpen !== this.props.isOpen) {
       this._renderTransition(newProps.isOpen);
     }
+  },
+
+  _handleArrowClick () {
+    this._renderTransition(true);
   },
 
   _renderTransition (isOpen) {
@@ -38,8 +47,10 @@ const Drawer = React.createClass({
 
   render () {
     return (
-      <div ref='component' style={styles}>
-        HELLO DRAWER
+      <div ref='component' style={styles.component}>
+        <nav style={styles.nav}><Icon onClick={this._handleArrowClick} size={20} style={styles.icon} type='arrow-left'/></nav>
+        <header></header>
+        <div></div>
       </div>
     );
   }
@@ -47,12 +58,24 @@ const Drawer = React.createClass({
 });
 
 const styles = {
-  top: 0,
-  bottom: 0,
-  right: -800,
-  position: 'absolute',
-  width: 800,
-  backgroundColor: '#eaeaea'
+  component: {
+    top: 0,
+    bottom: 0,
+    right: -800,
+    position: 'absolute',
+    width: 800,
+    backgroundColor: '#eaeaea'
+  },
+  icon: {
+    color: StyleConstants.Colors.ASH,
+    position: 'absolute',
+    left: 25
+  },
+  nav: {
+    padding: '15px 25px',
+    borderBottom: 'solid 1px ' + StyleConstants.Colors.ASH,
+    height: 15
+  }
 };
 
 module.exports = Drawer;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -11,7 +11,7 @@ const Drawer = React.createClass({
     easing: React.PropTypes.array,
     isOpen: React.PropTypes.bool,
     navContent: React.PropTypes.shape({
-      duration: React.PropTypes.number
+      duration: React.PropTypes.number,
       label: React.PropTypes.string.isRequired,
       onNextClick: React.PropTypes.func.isRequired,
       onPreviousClick: React.PropTypes.func.isRequired
@@ -127,7 +127,7 @@ const Drawer = React.createClass({
       },
       nav: {
         backgroundColor: StyleConstants.Colors.PORCELAIN,
-        borderBottom: 'solid 1px ' + StyleConstants.Colors.ASH,
+        borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
         height: 15,
         padding: '15px 25px'
       },

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -26,9 +26,9 @@ const Drawer = React.createClass({
 
   componentDidMount () {
     this._animateComponent({ right: 0 });
-    this._animateBackArrow({ left: 25 });
+    this._animateBackArrow();
     if (this.props.navConfig) {
-      this._animateNav({ top: 12 });
+      this._animateNav();
     }
   },
 
@@ -48,7 +48,10 @@ const Drawer = React.createClass({
   },
 
   _handleCloseClick () {
-
+    this._animateComponent({ right: -800 })
+    .then(() => {
+      this.props.onClose();
+    });
   },
 
   _animateComponent (transition) {
@@ -58,11 +61,12 @@ const Drawer = React.createClass({
       easing: this.props.easing
     };
 
-    Velocity(el, transition, options);
+    return Velocity(el, transition, options);
   },
 
-  _animateBackArrow (transition) {
+  _animateBackArrow () {
     const el = this._backArrow;
+    const transition = { left: 25 };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,
@@ -72,8 +76,9 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
-  _animateNav (transition) {
+  _animateNav () {
     const el = this._nav;
+    const transition = { top: 12 };
     const options = {
       delay: this.props.duration,
       duration: this.props.duration,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -10,7 +10,13 @@ const Drawer = React.createClass({
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
     isOpen: React.PropTypes.bool,
-    onClose: React.PropTypes.func.isRequired
+    onClose: React.PropTypes.func.isRequired,
+    siblingContent: React.PropTypes.shape({
+      currentSibling: React.PropTypes.number.isRequired,
+      nextSibling: React.PropTypes.func.isRequired,
+      previousSibling: React.PropTypes.func.isRequired,
+      totalSiblings: React.PropTypes.number.isRequired
+    })
   },
 
   getDefaultProps () {
@@ -31,16 +37,29 @@ const Drawer = React.createClass({
     }
   },
 
+  _renderSiblingContent () {
+    return (
+      <div ref='siblingContent' style={styles.siblingContent}>
+        <Icon onClick={this.props.onClose} size={25} style={styles.icon} type='caret-left'/> {this.props.siblingContent.currentSibling} of {this.props.siblingContent.totalSiblings} <Icon onClick={this.props.onClose} size={25} style={styles.icon} type='caret-right'/>
+      </div>
+    );
+  },
+
   _renderTransition (isOpen) {
     const el = this.refs.component;
     const transition = isOpen ? { right: -800 } : { right: 0 };
     const options = {
-      complete: this._slideArrow.bind(this, isOpen),
+      complete: this._slideArrowAndSiblingContent.bind(this, isOpen),
       duration: this.props.duration,
       easing: this.props.easing
     };
 
     Velocity(el, transition, options);
+  },
+
+  _slideArrowAndSiblingContent (isOpen) {
+    this._slideArrow(isOpen);
+    this._slideSiblingContent(isOpen);
   },
 
   _slideArrow (isOpen) {
@@ -54,11 +73,25 @@ const Drawer = React.createClass({
     Velocity(el, transition, options);
   },
 
+  _slideSiblingContent (isOpen) {
+    const el = this.refs.siblingContent;
+    const transition = isOpen ? { top: -15 } : { top: 15 };
+    const options = {
+      duration: 200,
+      easing: this.props.easing
+    };
+
+    Velocity(el, transition, options);
+  },
+
   render () {
     return (
       <div ref='component' style={styles.component}>
         <nav style={styles.nav}>
-          <span ref='arrow' style={styles.iconContainer}><Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/></span>
+          <span ref='arrow' style={styles.iconContainer}>
+            <Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/>
+          </span>
+          {this.props.siblingContent ? this._renderSiblingContent() : null}
         </nav>
         <header></header>
         <div></div>
@@ -90,8 +123,14 @@ const styles = {
     borderBottom: 'solid 1px ' + StyleConstants.Colors.ASH,
     height: 15,
     padding: '15px 25px'
+  },
+  siblingContent: {
+    fontFamily: StyleConstants.Fonts.THIN,
+    color: StyleConstants.Colors.ASH,
+    position: 'absolute',
+    right: 25,
+    top: -15
   }
 };
 
 module.exports = Drawer;
-

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -41,7 +41,7 @@ const Drawer = React.createClass({
     const styles = this.styles();
 
     return (
-      <div ref='siblingContent' style={styles.siblingContent}>
+      <div ref={(ref) => (this._siblingContent = ref)} style={styles.siblingContent}>
         <Icon onClick={this.props.siblingContent.previousSibling} size={25} style={styles.icon} type='caret-left'/>
         {this.props.siblingContent.currentSiblingIndex} of {this.props.siblingContent.totalSiblings}
         <Icon onClick={this.props.siblingContent.nextSibling} size={25} style={styles.icon} type='caret-right'/>
@@ -50,7 +50,7 @@ const Drawer = React.createClass({
   },
 
   _renderTransition (isOpen) {
-    const el = this.refs.component;
+    const el = this._component;
     const transition = isOpen ? { right: -800 } : { right: 0 };
     const options = {
       complete: this._slideArrowAndSiblingContent.bind(this, isOpen),
@@ -67,7 +67,7 @@ const Drawer = React.createClass({
   },
 
   _slideArrow (isOpen) {
-    const el = this.refs.arrow;
+    const el = this._arrow;
     const transition = isOpen ? { left: -25 } : { left: 25 };
     const options = {
       duration: 200,
@@ -78,8 +78,8 @@ const Drawer = React.createClass({
   },
 
   _slideSiblingContent (isOpen) {
-    const el = this.refs.siblingContent;
-    const transition = isOpen ? { top: -12 } : { top: 12 };
+    const el = this._siblingContent;
+    const transition = isOpen ? { top: -25 } : { top: 12 };
     const options = {
       duration: 200,
       easing: this.props.easing
@@ -92,9 +92,9 @@ const Drawer = React.createClass({
     const styles = this.styles();
 
     return (
-      <div ref='component' style={styles.component}>
+      <div ref={(ref) => (this._component = ref)} style={styles.component}>
         <nav style={styles.nav}>
-          <span ref='arrow' style={styles.iconContainer}>
+          <span ref={(ref) => (this._arrow = ref)} style={styles.iconContainer}>
             <Icon onClick={this.props.onClose} size={25} style={styles.icon}type='arrow-left'/>
           </span>
           {this.props.siblingContent ? this._renderSiblingContent() : null}
@@ -136,7 +136,7 @@ const Drawer = React.createClass({
         color: StyleConstants.Colors.ASH,
         position: 'absolute',
         right: 25,
-        top: -12
+        top: -25
       }
     };
   }


### PR DESCRIPTION
Behold The Humble Beginnings of \<Drawer /\>
--
![screen shot 2016-03-10 at 1 40 05 pm](https://cloud.githubusercontent.com/assets/1081167/13684882/0c20b99e-e6cb-11e5-979d-75a78ed0ee69.png)

--
This adds a new animated `Drawer` component to be used to replacing stacking modals.
Example
--
```
<Drawer 
  isOpen={this.state.showDrawer}
  onClose={this._toggleDrawer}
  siblingContent={navContent}>
    <div>
      Insert Custom Content Here
    </div>
</Drawer>
```
Props
--
-`duration` _Number_ **optional**
Number of miliseconds for opening animation to take. Defaults to 500 if not provided.

-`easing` _Array_ **optional**
Bezier line curve array for easing. Defaults to [0.28, 0.14, 0.34, 1.04] if not provided.
See [here](http://cubic-bezier.com/#.17,.67,.83,.67) for more information on crafting this prop.

- `isOpen` _Boolean_ **optional**
Simple flag to be used to tell the drawer whether or not it should animate or remain open or closed

- `onClose` _Function_ **optional** 
Function to be called when drawer is closed

- `navContent` _Object_ **Optional**
Object passed in to render sibling content navigation and handlers. If `siblingContent` is passed in, it must adhere to the following `shape` propType requirement. The next sibling navigation will not be displayed unless this object is passed in with all required types.
  - `duration` _Number_ **Optional**
 Optional duration for nav animations, if not provided, top level duration will be used.

  - `label` _String_ **Required**
  Text and other elements to be displayed in navContent

  - `onNextClick` _Function_ **Required**
  Function to be called when the next sibling caret is clicked

  - `onPreviousClick` _Function_ **Required**
  Function to be called when the previous sibling caret is clicked