### PR TITLE
Add reset to errors on file select

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -564,7 +564,6 @@ const Demo = React.createClass({
   },
 
   _handleFileChange (uploadedFile) {
-    console.log('uploaded file', uploadedFile), ;
     this.setState({
       uploadedFile
     });

--- a/demo/app.js
+++ b/demo/app.js
@@ -564,6 +564,7 @@ const Demo = React.createClass({
   },
 
   _handleFileChange (uploadedFile) {
+    console.log('uploaded file', uploadedFile), ;
     this.setState({
       uploadedFile
     });
@@ -610,7 +611,7 @@ const Demo = React.createClass({
         <br/><br/>
         <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
           <FileUpload
-            allowedFileTypes={['image/jpeg', 'text/csv', 'image/tiff']}
+            allowedFileTypes={['image/jpeg', 'text/csv', 'image/png']}
             maxFileSize={3000}
             onFileAdd={this._handleFileChange}
             onFileRemove={this._handleFileChange}

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -40,6 +40,10 @@ const FileUpload = React.createClass({
 
     if (file) {
       this._validateFile(file);
+
+      this.setState({
+        invalidMessage: null
+      });
     }
   },
 


### PR DESCRIPTION
When a file is dropped onto the drop zone, the invalidMessage state is set to null. This adds that same behavior to the method that handles the file selection.

@mxenabled/frontend-engineers 