### PR TITLE
Luke/select bug

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -35,11 +35,13 @@ const Select = React.createClass({
   },
 
   getInitialState () {
+    console.log("getInitial Stateis running");
     return {
       highlightedValue: null,
       isOpen: false,
       selected: false,
-      hoverItem: null
+      hoverItem: null,
+      scrollLocation: 0
     };
   },
 
@@ -63,20 +65,40 @@ const Select = React.createClass({
   },
 
   _handleClick () {
+    const divy = document.getElementById('test');
+
+    console.log("handle Click is running", document.getElementById('test'));
     if (!isMobile) {
       this.setState({
         isOpen: !this.state.isOpen
+      }, () => {
+        if (divy) {
+          divy.scrollTop = this.state.scrollLocation
+        }
       });
     }
   },
 
+  // test () {
+  //   const divy = document.getElementById('test');
+  //   console.log("this is divy", divy);
+  //   divy.scrollTop = 1200;
+  // },
+
   _handleOptionClick (option) {
+    const divy = document.getElementById('test');
+    
+    console.log('this is divy.scrollTop', divy.scrollTop);
+    
     this.setState({
       selected: option,
       isOpen: false,
       highlightedValue: option,
-      hoverItem: null
+      hoverItem: null,
+      scrollLocation: divy.scrollTop
     });
+    
+    
 
     this.props.onChange(option);
   },
@@ -132,6 +154,7 @@ const Select = React.createClass({
   },
 
   _scrollListDown (nextIndex) {
+    console.log("scrollListDown", nextIndex);
     const ul = ReactDOM.findDOMNode(this.refs.optionList);
     const activeLi = ul.children[nextIndex];
     const heightFromTop = nextIndex * activeLi.clientHeight;
@@ -142,6 +165,7 @@ const Select = React.createClass({
   },
 
   _scrollListUp (prevIndex) {
+    console.log("UPUP UP", prevIndex);
     const ul = ReactDOM.findDOMNode(this.refs.optionList);
     const activeLi = ul.children[prevIndex];
     const heightFromBottom = (this.props.options.length - prevIndex) * activeLi.clientHeight;
@@ -176,8 +200,9 @@ const Select = React.createClass({
         );
       } else {
         return (
-          <ul className='mx-select-options' ref='optionList' style={[styles.options, this.props.optionsStyle]}>
+          <ul id='test' className='mx-select-options' ref='optionList' style={[styles.options, this.props.optionsStyle]}>
             {this.props.options.map(option => {
+            
               return (
                 <li
                   className='mx-select-option'

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -65,14 +65,15 @@ const Select = React.createClass({
   },
 
   _handleClick () {
-    const divy = document.getElementById('test');
+    
 
     console.log("handle Click is running", document.getElementById('test'));
     if (!isMobile) {
       this.setState({
         isOpen: !this.state.isOpen
       }, () => {
-        if (divy) {
+        if (document.getElementById('test')) {
+          const divy = document.getElementById('test');
           divy.scrollTop = this.state.scrollLocation
         }
       });

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -35,7 +35,6 @@ const Select = React.createClass({
   },
 
   getInitialState () {
-    console.log("getInitial Stateis running");
     return {
       highlightedValue: null,
       isOpen: false,
@@ -65,41 +64,29 @@ const Select = React.createClass({
   },
 
   _handleClick () {
-    
-
-    console.log("handle Click is running", document.getElementById('test'));
     if (!isMobile) {
       this.setState({
         isOpen: !this.state.isOpen
       }, () => {
-        if (document.getElementById('test')) {
-          const divy = document.getElementById('test');
-          divy.scrollTop = this.state.scrollLocation
+        if (document.getElementById('items')) {
+          const items = document.getElementById('items');
+
+          items.scrollTop = this.state.scrollLocation;
         }
       });
     }
   },
 
-  // test () {
-  //   const divy = document.getElementById('test');
-  //   console.log("this is divy", divy);
-  //   divy.scrollTop = 1200;
-  // },
-
   _handleOptionClick (option) {
-    const divy = document.getElementById('test');
-    
-    console.log('this is divy.scrollTop', divy.scrollTop);
-    
+    const items = document.getElementById('items');
+
     this.setState({
       selected: option,
       isOpen: false,
       highlightedValue: option,
       hoverItem: null,
-      scrollLocation: divy.scrollTop
+      scrollLocation: items.scrollTop
     });
-    
-    
 
     this.props.onChange(option);
   },
@@ -155,7 +142,6 @@ const Select = React.createClass({
   },
 
   _scrollListDown (nextIndex) {
-    console.log("scrollListDown", nextIndex);
     const ul = ReactDOM.findDOMNode(this.refs.optionList);
     const activeLi = ul.children[nextIndex];
     const heightFromTop = nextIndex * activeLi.clientHeight;
@@ -166,7 +152,6 @@ const Select = React.createClass({
   },
 
   _scrollListUp (prevIndex) {
-    console.log("UPUP UP", prevIndex);
     const ul = ReactDOM.findDOMNode(this.refs.optionList);
     const activeLi = ul.children[prevIndex];
     const heightFromBottom = (this.props.options.length - prevIndex) * activeLi.clientHeight;
@@ -201,9 +186,13 @@ const Select = React.createClass({
         );
       } else {
         return (
-          <ul id='test' className='mx-select-options' ref='optionList' style={[styles.options, this.props.optionsStyle]}>
+          <ul
+          className='mx-select-options'
+          id='items'
+          ref='optionList'
+          style={[styles.options, this.props.optionsStyle]}
+          >
             {this.props.options.map(option => {
-            
               return (
                 <li
                   className='mx-select-option'


### PR DESCRIPTION
### First pass at fixing a bug where select component would start from top no matter what
* I don't believe that this is a perfect implementation - I know the callback in `setState` is an odd pattern. Looking for other ideas on how to make this work 
* Also adding an ID and using `getElementById` seems cumbersome but again, I'm still working out a better way. If you use the existing classname `mx-select-options` will not work in this case (2 elements with that class)

### BEFORE: 
* Notice how when an item is selected, then the component is reopened, it starts from the top

![select_before](https://cloud.githubusercontent.com/assets/13579578/13992097/4fd2e10c-f0e0-11e5-9107-e79e9e0ab87b.gif)

### AFTER:

![select_after](https://cloud.githubusercontent.com/assets/13579578/13992105/5592f6f4-f0e0-11e5-84b6-d25e4b1d7a2c.gif)
 
