### PR TITLE
Add footerStyle to modal and use Button component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -640,11 +640,13 @@ const Demo = React.createClass({
         <Modal
           buttons={[
             {
+              icon: 'close',
               label: 'Secondary',
               onClick: this._handleModalSecondaryClick,
               type: 'secondary'
             },
             {
+              icon: 'rocket',
               label: 'Primary',
               onClick: this._handleModalPrimaryClick,
               type: 'primary'
@@ -655,6 +657,7 @@ const Demo = React.createClass({
               Footer Content
             </div>
           )}
+          footerStyle={{ padding: '40px 20px' }}
           isOpen={this.state.showModal}
           onRequestClose={this._handleModalClose}
           showFooter={true}
@@ -749,7 +752,7 @@ const Demo = React.createClass({
         </div>
 
         <br/><br/><br/><br/>
-        <div style={{ textAlign: 'center' }}>
+        <div>
           <ToggleSwitch />
         </div>
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const Radium = require('radium');
 
+const Button = require('./Button');
 const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
@@ -20,6 +21,10 @@ const Modal = React.createClass({
     color: React.PropTypes.string,
     contentStyle: React.PropTypes.object,
     footerContent: React.PropTypes.node,
+    footerStyle: React.PropTypes.oneOfType([
+      React.PropTypes.array,
+      React.PropTypes.object
+    ]),
     isOpen: React.PropTypes.bool,
     isRelative: React.PropTypes.bool,
     onRequestClose: React.PropTypes.func,
@@ -73,20 +78,22 @@ const Modal = React.createClass({
   _renderFooter () {
     if (this.props.showFooter) {
       return (
-        <div className='mx-modal-footer' style={styles.footer}>
+        <div className='mx-modal-footer' style={[styles.footer, this.props.footerStyle]}>
           {this._renderTooltipIconAndLabel()}
           {this._renderFooterContent()}
           <div className='mx-modal-buttons'>
             {this.props.buttons.map((button, i) => {
               return (
-                <div
+                <Button
                   className={'mx-modal-button ' + button.className}
+                  icon={button.icon}
                   key={button.type + i}
                   onClick={button.onClick}
-                  style={[styles.button, styles[button.type + 'Button'], button.style]}
+                  style={[styles.button, button.style]}
+                  type={button.type}
                 >
                   {button.label}
-                </div>
+                </Button>
               );
             })}
           </div>
@@ -277,21 +284,7 @@ const styles = {
     textAlign: 'right'
   },
   button: {
-    display: 'inline-block',
-    borderRadius: 2,
-    cursor: 'pointer',
-    fontSize: StyleConstants.FontSizes.MEDIUM,
-    fontWeight: 600,
-    padding: '7px 14px',
     marginLeft: 5
-  },
-  primaryButton: {
-    backgroundColor: StyleConstants.Colors.PRIMARY,
-    color: StyleConstants.Colors.WHITE
-  },
-  secondaryButton: {
-    backgroundColor: StyleConstants.Colors.FOG,
-    color: StyleConstants.Colors.CHARCOAL
   },
   small: {
     width: 400,


### PR DESCRIPTION
This adds a footerStyle prop to the modal component and switches the buttons to use the Button component.

This allows for more control of the style of the footer and the ability to add icons to the buttons.

@mxenabled/frontend-engineers 

After (passin in different padding that the default):
![screen shot 2016-03-24 at 9 29 39 am](https://cloud.githubusercontent.com/assets/488916/14022034/91532a56-f1a3-11e5-8c3b-a175cbdf5a3b.png)

Before:
![screen shot 2016-03-24 at 9 38 01 am](https://cloud.githubusercontent.com/assets/488916/14022134/23621650-f1a4-11e5-9266-da2779c4b4a2.png)

