### PR TITLE
Add isActive and actionText to Button in Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-core": "^6.0.0",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "5.0.0",
     "babel-loader": "^6.0.0",
     "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.0.0",

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -85,8 +85,10 @@ const Modal = React.createClass({
             {this.props.buttons.map((button, i) => {
               return (
                 <Button
+                  actionText={'Loading'}
                   className={'mx-modal-button ' + button.className}
                   icon={button.icon}
+                  isActive={button.isActive}
                   key={button.type + i}
                   onClick={button.onClick}
                   style={[styles.button, button.style]}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -9,7 +9,10 @@ const StyleConstants = require('../constants/Style');
 const Modal = React.createClass({
   propTypes: {
     buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
+      actionText: React.PropTypes.string,
       className: React.PropTypes.string,
+      isActive: React.PropTypes.bool,
+      icon: React.PropTypes.string,
       label: React.PropTypes.string,
       onClick: React.PropTypes.func,
       style: React.PropTypes.oneOfType([


### PR DESCRIPTION
This incorporates @iheartrachie's action button changes into the modal component.

- Add actionText, isActive and icon to buttons propTypes
- Pass actionText and isActive to button icon

@mxenabled/frontend-engineers 

![screen shot 2016-03-28 at 12 25 06 pm](https://cloud.githubusercontent.com/assets/488916/14086192/14e87ac0-f4e1-11e5-924d-e827fd9608d3.png)
