### PR TITLE
Fix button actionText on modal to use props.

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -88,7 +88,7 @@ const Modal = React.createClass({
             {this.props.buttons.map((button, i) => {
               return (
                 <Button
-                  actionText={'Loading'}
+                  actionText={button.actionText}
                   className={'mx-modal-button ' + button.className}
                   icon={button.icon}
                   isActive={button.isActive}


### PR DESCRIPTION
In the last PR, the actionText for the buttons was hard coded to be 'Loading'. This changes that to pull from the actionText prop.

@mxenabled/frontend-engineers 