### PR TITLE
luke/moved handle modal open to parent component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -666,41 +666,42 @@ const Demo = React.createClass({
           <br/><br/>
           <Button actionText='Spinning...' isActive={this.state.spinnerWithTextIsActive} onClick={this._handleSpinnerWithTextClick}>Button with text and actionText</Button>
         </div>
-        <Modal
-          buttons={[
-            {
-              icon: 'close',
-              label: 'Secondary',
-              onClick: this._handleModalSecondaryClick,
-              type: 'secondary'
-            },
-            {
-              icon: 'rocket',
-              label: 'Primary',
-              onClick: this._handleModalPrimaryClick,
-              type: 'primary'
-            }
-          ]}
-          footerContent={(
-            <div style={styles.modalFooterContent}>
-              Footer Content
+        {this.state.showModal ? (
+          <Modal
+            buttons={[
+              {
+                icon: 'close',
+                label: 'Secondary',
+                onClick: this._handleModalSecondaryClick,
+                type: 'secondary'
+              },
+              {
+                icon: 'rocket',
+                label: 'Primary',
+                onClick: this._handleModalPrimaryClick,
+                type: 'primary'
+              }
+            ]}
+            footerContent={(
+              <div style={styles.modalFooterContent}>
+                Footer Content
+              </div>
+            )}
+            footerStyle={{ padding: '40px 20px' }}
+            onRequestClose={this._handleModalClose}
+            showFooter={true}
+            showTitleBar={true}
+            title='This is the header text'
+            tooltip='This is my tooltip content'
+            tooltipLabel='This is the footer text.'
+            tooltipTitle='This is my tooltip title'
+          >
+            <div style={{ padding: 20 }}>
+              <p style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</p>
+              <img src='http://www.mx.com/images/home/top-t-i.png' style={[{ maxWidth: '100%', height: 'auto', margin: 'auto' }, this.state.showSmallModal && { width: 400 }]} />
             </div>
-          )}
-          footerStyle={{ padding: '40px 20px' }}
-          isOpen={this.state.showModal}
-          onRequestClose={this._handleModalClose}
-          showFooter={true}
-          showTitleBar={true}
-          title='This is the header text'
-          tooltip='This is my tooltip content'
-          tooltipLabel='This is the footer text.'
-          tooltipTitle='This is my tooltip title'
-        >
-          <div style={{ padding: 20 }}>
-            <p style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</p>
-            <img src='http://www.mx.com/images/home/top-t-i.png' style={[{ maxWidth: '100%', height: 'auto', margin: 'auto' }, this.state.showSmallModal && { width: 400 }]} />
-          </div>
-        </Modal>
+          </Modal>
+      ) : null}
 
         <br/><br/>
         <div style={{ textAlign: 'center' }}>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -160,9 +160,11 @@ const Modal = React.createClass({
   },
 
   render () {
+    /*eslint-disable */
     if (this.props.isOpen) {
       console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
     }
+    /*eslint-enable */
 
     return (
       <div className='mx-modal' style={[styles.scrim, this.props.isRelative && styles.relative]}>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -160,8 +160,8 @@ const Modal = React.createClass({
   },
 
   render () {
-    if(this.props.isOpen) {
-      console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.')
+    if (this.props.isOpen) {
+      console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
     }
 
     return (

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -60,7 +60,7 @@ const Modal = React.createClass({
 
   componentDidMount () {
   /*eslint-disable */
-    if (this.props.isOpen) {
+    if (this.props.isOpen !== null) {
       console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
     }
   /*eslint-enable */

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -58,6 +58,14 @@ const Modal = React.createClass({
     };
   },
 
+  componentDidMount () {
+  /*eslint-disable */
+    if (this.props.isOpen) {
+      console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
+    }
+  /*eslint-enable */    
+  },
+
   _handleTooltipToggle (show) {
     this.setState({
       showTooltip: show
@@ -160,12 +168,6 @@ const Modal = React.createClass({
   },
 
   render () {
-    /*eslint-disable */
-    if (this.props.isOpen) {
-      console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
-    }
-    /*eslint-enable */
-
     return (
       <div className='mx-modal' style={[styles.scrim, this.props.isRelative && styles.relative]}>
         <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={[styles.scrim, styles.overlay, this.props.isRelative && styles.relative]}></div>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -160,6 +160,10 @@ const Modal = React.createClass({
   },
 
   render () {
+    if(this.props.isOpen) {
+      console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.')
+    }
+
     return (
       <div className='mx-modal' style={[styles.scrim, this.props.isRelative && styles.relative]}>
         <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={[styles.scrim, styles.overlay, this.props.isRelative && styles.relative]}></div>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -28,7 +28,6 @@ const Modal = React.createClass({
       React.PropTypes.array,
       React.PropTypes.object
     ]),
-    isOpen: React.PropTypes.bool,
     isRelative: React.PropTypes.bool,
     onRequestClose: React.PropTypes.func,
     showFooter: React.PropTypes.bool,
@@ -43,7 +42,6 @@ const Modal = React.createClass({
     return {
       buttons: [],
       color: StyleConstants.Colors.PRIMARY,
-      isOpen: false,
       isRelative: false,
       showFooter: false,
       showTitleBar: false,
@@ -162,34 +160,29 @@ const Modal = React.createClass({
   },
 
   render () {
-    if (this.props.isOpen)
-      return (
-        <div className='mx-modal' style={[styles.scrim, this.props.isRelative && styles.relative]}>
-          <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={[styles.scrim, styles.overlay, this.props.isRelative && styles.relative]}></div>
-          <div
-            className='mx-modal-container'
-            style={[styles.container, this.props.style]}
-          >
-            <Icon
-              className='mx-modal-close'
-              onClick={this.props.onRequestClose}
-              size={24}
-              style={styles.close}
-              type='close-solid'
-            />
-            {this._renderTitleBar()}
-            <div className='mx-modal-content' style={[styles.content, this.props.contentStyle]}>
-              {this.props.children}
-              {this._renderTooltip()}
-            </div>
-            {this._renderFooter()}
+    return (
+      <div className='mx-modal' style={[styles.scrim, this.props.isRelative && styles.relative]}>
+        <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={[styles.scrim, styles.overlay, this.props.isRelative && styles.relative]}></div>
+        <div
+          className='mx-modal-container'
+          style={[styles.container, this.props.style]}
+        >
+          <Icon
+            className='mx-modal-close'
+            onClick={this.props.onRequestClose}
+            size={24}
+            style={styles.close}
+            type='close-solid'
+          />
+          {this._renderTitleBar()}
+          <div className='mx-modal-content' style={[styles.content, this.props.contentStyle]}>
+            {this.props.children}
+            {this._renderTooltip()}
           </div>
+          {this._renderFooter()}
         </div>
-      );
-    else
-      return (
-        null
-      );
+      </div>
+    );
   }
 });
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -63,7 +63,7 @@ const Modal = React.createClass({
     if (this.props.isOpen) {
       console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
     }
-  /*eslint-enable */    
+  /*eslint-enable */
   },
 
   _handleTooltipToggle (show) {


### PR DESCRIPTION
@bsbeeks I might have misunderstood the reasoning for keeping the prop `isOpen` around. This seems to be working fine in the demo app, but perhaps there's something I'm not considering. 

What I did:
* Removed the conditional from the main render method in `Modal` - it now renders no matter what
* Added a ternary in the parent component `demo` that is dependent on `this.state.showModal`