### PR TITLE
ButtonGroup Component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -675,11 +675,10 @@ const Demo = React.createClass({
           <br/><br/>
           <ButtonGroup
             buttons={[
-              { text: 'Button 1' },
-              { text: 'Button 2' },
-              { text: 'Button 3' }
+              { text: 'Mar 2015 - Feb 2016' }
             ]}
-            type='neutral' />
+            controlAarows={true}
+            type='primaryOutline' />
         </div>
         <Modal
           buttons={[

--- a/demo/app.js
+++ b/demo/app.js
@@ -673,14 +673,14 @@ const Demo = React.createClass({
             ]}
             controlArrows={true}
             type='primaryOutline' />
-            <br/><br/>
-            <ButtonGroup
-              buttons={[
-                { icon: 'download' },
-                { icon: 'search' },
-                { icon: 'add' }
-              ]}
-              type='base' />
+          <br/><br/>
+          <ButtonGroup
+            buttons={[
+              { icon: 'download' },
+              { icon: 'search' },
+              { icon: 'add' }
+            ]}
+            type='base' />
         </div>
         <Modal
           buttons={[

--- a/demo/app.js
+++ b/demo/app.js
@@ -679,7 +679,7 @@ const Demo = React.createClass({
               { text: 'Mar 2015 - Feb 2016' }
             ]}
             controlArrows={true}
-            type='neutral' />
+            type='disabled' />
         </div>
         <Modal
           buttons={[

--- a/demo/app.js
+++ b/demo/app.js
@@ -669,16 +669,17 @@ const Demo = React.createClass({
           <br/><br/>
           <ButtonGroup
             buttons={[
-              { text: 'Button 1' },
-              { text: 'Button 2' }
-            ]} />
+              { text: 'ButtonGroup 1' },
+              { text: 'ButtonGroup 2' }
+            ]}
+            type='neutral' />
           <br/><br/>
           <ButtonGroup
             buttons={[
               { text: 'Mar 2015 - Feb 2016' }
             ]}
-            controlAarows={true}
-            type='primaryOutline' />
+            controlArrows={true}
+            type='neutral' />
         </div>
         <Modal
           buttons={[

--- a/demo/app.js
+++ b/demo/app.js
@@ -676,7 +676,8 @@ const Demo = React.createClass({
           <ButtonGroup
             buttons={[
               { text: 'Button 1' },
-              { text: 'Button 2' }
+              { text: 'Button 2' },
+              { text: 'Button 3' }
             ]}
             type='neutral' />
         </div>

--- a/demo/app.js
+++ b/demo/app.js
@@ -6,6 +6,7 @@ const moment = require('moment');
 
 const {
   Button,
+  ButtonGroup,
   DatePicker,
   DatePickerFullScreen,
   DonutChart,
@@ -665,6 +666,19 @@ const Demo = React.createClass({
             type='secondary'>Button with text & without actionText</Button>
           <br/><br/>
           <Button actionText='Spinning...' isActive={this.state.spinnerWithTextIsActive} onClick={this._handleSpinnerWithTextClick}>Button with text and actionText</Button>
+          <br/><br/>
+          <ButtonGroup
+            buttons={[
+              { text: 'Button 1' },
+              { text: 'Button 2' }
+            ]} />
+          <br/><br/>
+          <ButtonGroup
+            buttons={[
+              { text: 'Button 1' },
+              { text: 'Button 2' }
+            ]}
+            type='neutral' />
         </div>
         <Modal
           buttons={[

--- a/demo/app.js
+++ b/demo/app.js
@@ -669,17 +669,18 @@ const Demo = React.createClass({
           <br/><br/>
           <ButtonGroup
             buttons={[
-              { text: 'ButtonGroup 1' },
-              { text: 'ButtonGroup 2' }
-            ]}
-            type='neutral' />
-          <br/><br/>
-          <ButtonGroup
-            buttons={[
               { text: 'Mar 2015 - Feb 2016' }
             ]}
             controlArrows={true}
-            type='disabled' />
+            type='primaryOutline' />
+            <br/><br/>
+            <ButtonGroup
+              buttons={[
+                { icon: 'download' },
+                { icon: 'search' },
+                { icon: 'add' }
+              ]}
+              type='base' />
         </div>
         <Modal
           buttons={[

--- a/demo/app.js
+++ b/demo/app.js
@@ -669,10 +669,12 @@ const Demo = React.createClass({
           <br/><br/>
           <ButtonGroup
             buttons={[
-              { text: 'Mar 2015 - Feb 2016' }
+              { icon: 'caret-left' },
+              { text: 'Mar 2015 - Feb 2016' },
+              { icon: 'caret-right' }
             ]}
-            controlArrows={true}
-            type='primaryOutline' />
+            type='primaryOutline'
+          />
           <br/><br/>
           <ButtonGroup
             buttons={[
@@ -680,7 +682,8 @@ const Demo = React.createClass({
               { icon: 'search' },
               { icon: 'add' }
             ]}
-            type='base' />
+            type='base'
+          />
         </div>
         <Modal
           buttons={[

--- a/src/Index.js
+++ b/src/Index.js
@@ -1,5 +1,6 @@
 module.exports = {
   Button: require('./components/Button'),
+  ButtonGroup: require('./components/ButtonGroup'),
   DatePicker: require('./components/DatePicker'),
   DatePickerFullScreen: require('./components/DatePickerFullScreen'),
   DonutChart: require('./components/DonutChart'),

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -154,6 +154,7 @@ const Button = React.createClass({
         borderRadius: 2,
         borderWidth: 1,
         color: this.props.primaryColor,
+        fill: this.props.primaryColor,
         ':hover': {
           backgroundColor: StyleConstants.Colors.PORCELAIN
         },

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -165,7 +165,8 @@ const Button = React.createClass({
       disabled: {
         backgroundColor: 'transparent',
         borderColor: StyleConstants.Colors.FOG,
-        color: StyleConstants.Colors.FOG
+        color: StyleConstants.Colors.FOG,
+        fill: StyleConstants.Colors.FOG
       },
       icon: {
         marginTop: -3,

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -53,7 +53,7 @@ const ButtonGroup = React.createClass({
               ]}
               type={this.props.type}
             >
-                {button.text}
+              {button.text}
             </Button>);
         })}
       </div>

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -11,6 +11,7 @@ const ButtonGroup = React.createClass({
       icon: React.PropTypes.string,
       text: React.PropTypes.string
     })),
+    controlAarows: React.PropTypes.bool,
     type: React.PropTypes.oneOf([
       'base',
       'disabled',
@@ -23,8 +24,14 @@ const ButtonGroup = React.createClass({
   getDefaultProps () {
     return {
       buttons: [],
+      controlAarows: false,
       type: 'primaryOutline'
     };
+  },
+
+  _getAarows () {
+    this.props.buttons.unshift({ icon: 'caret-left' });
+    this.props.buttons.push({ icon: 'caret-right' });
   },
 
   render () {
@@ -34,15 +41,17 @@ const ButtonGroup = React.createClass({
 
     return (
       <div {...this.props}>
+        {this.props.controlAarows ? this._getAarows : null}
         {this.props.buttons.map(function (button, index, arr) {
           const isFirstChild = index === 0;
           const isLastChild = index === arr.length - 1;
 
           return (
             <Button
+              icon={button.icon}
               key={index}
               style={[styles.component,
-                hasHoverStyles && styles.hoverStyles,
+                hasHoverStyles && styles.buttonHover,
                 isFirstChild && styles.firstChild,
                 isLastChild && styles.lastChild]}
               type={buttonType}>
@@ -57,7 +66,8 @@ const ButtonGroup = React.createClass({
     return {
       component: {
         borderRadius: 0,
-        borderRightWidth: 0
+        borderRightWidth: 0,
+        verticalAlign: 'middle'
       },
       firstChild: {
         borderRadius: '2px 0 0 2px'
@@ -66,7 +76,7 @@ const ButtonGroup = React.createClass({
         borderRadius: '0 2px 2px 0',
         borderRightWidth: 1
       },
-      hoverStyles: {
+      buttonHover: {
         borderRightWidth: 1,
         ':hover': {
           borderColor: StyleConstants.Colors.FOG,

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,0 +1,67 @@
+const React = require('react');
+const Radium = require('radium');
+
+const Button = require('./Button');
+
+const ButtonGroup = React.createClass({
+  propTypes: {
+    buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
+      icon: React.PropTypes.string,
+      text: React.PropTypes.string
+    })),
+    type: React.PropTypes.oneOf([
+      'base',
+      'disabled',
+      'neutral',
+      'primary',
+      'primaryOutline'
+    ])
+  },
+
+  getDefaultProps () {
+    return {
+      buttons: [],
+      type: 'primary'
+    };
+  },
+
+  render () {
+    const styles = this.styles();
+    const buttonType = this.props.type;
+
+    return (
+      <div {...this.props}>
+        {this.props.buttons.map(function (button, index, arr) {
+          const isFirstChild = index === 0;
+          const isLastChild = index === arr.length - 1;
+
+          return (
+            <Button
+              key={index}
+              style={[styles.component, isFirstChild && styles.firstChild, isLastChild && styles.lastChild]}
+              type={buttonType}>
+                {button.text}
+            </Button>);
+        })}
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: {
+        borderRadius: 0,
+        borderRightWidth: 0
+      },
+      firstChild: {
+        borderRadius: '2px 0 0 2px'
+      },
+      lastChild: {
+        borderRadius: '0 2px 2px 0',
+        borderRightWidth: 1
+      }
+    };
+  }
+});
+
+module.exports = Radium(ButtonGroup);

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -39,6 +39,7 @@ const ButtonGroup = React.createClass({
   render () {
     const styles = this.styles();
     const buttonType = this.props.type;
+    const primaryColor = this.props.primaryColor;
 
     return (
       <div {...this.props}>
@@ -52,6 +53,7 @@ const ButtonGroup = React.createClass({
             <Button
               icon={button.icon}
               key={index}
+              primaryColor={primaryColor}
               style={[
                 styles.component,
                 styles[buttonType],

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -11,7 +11,6 @@ const ButtonGroup = React.createClass({
       icon: React.PropTypes.string,
       text: React.PropTypes.string
     }).isRequired),
-    controlArrows: React.PropTypes.bool,
     primaryColor: React.PropTypes.string,
     type: React.PropTypes.oneOf([
       'base',
@@ -25,15 +24,9 @@ const ButtonGroup = React.createClass({
   getDefaultProps () {
     return {
       buttons: [],
-      controlArrows: false,
       primaryColor: StyleConstants.Colors.PRIMARY,
       type: 'primaryOutline'
     };
-  },
-
-  _getArrows () {
-    this.props.buttons.unshift({ icon: 'caret-left' });
-    this.props.buttons.push({ icon: 'caret-right' });
   },
 
   render () {
@@ -43,7 +36,6 @@ const ButtonGroup = React.createClass({
 
     return (
       <div {...this.props}>
-        {this.props.controlArrows ? this._getArrows() : null}
         {this.props.buttons.map(function (button, index, arr) {
           const isFirstChild = index === 0;
           const isLastChild = index === arr.length - 1;

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -11,7 +11,8 @@ const ButtonGroup = React.createClass({
       icon: React.PropTypes.string,
       text: React.PropTypes.string
     })),
-    controlAarows: React.PropTypes.bool,
+    controlArrows: React.PropTypes.bool,
+    primaryColor: React.PropTypes.string,
     type: React.PropTypes.oneOf([
       'base',
       'disabled',
@@ -24,12 +25,13 @@ const ButtonGroup = React.createClass({
   getDefaultProps () {
     return {
       buttons: [],
-      controlAarows: false,
+      controlArrows: false,
+      primaryColor: StyleConstants.Colors.PRIMARY,
       type: 'primaryOutline'
     };
   },
 
-  _getAarows () {
+  _getArrows () {
     this.props.buttons.unshift({ icon: 'caret-left' });
     this.props.buttons.push({ icon: 'caret-right' });
   },
@@ -37,23 +39,26 @@ const ButtonGroup = React.createClass({
   render () {
     const styles = this.styles();
     const buttonType = this.props.type;
-    const hasHoverStyles = buttonType === 'base' || buttonType === 'neutral';
 
     return (
       <div {...this.props}>
-        {this.props.controlAarows ? this._getAarows : null}
+        {this.props.controlArrows ? this._getArrows() : null}
         {this.props.buttons.map(function (button, index, arr) {
           const isFirstChild = index === 0;
           const isLastChild = index === arr.length - 1;
+          const isOnlyChild = isFirstChild && isLastChild;
 
           return (
             <Button
               icon={button.icon}
               key={index}
-              style={[styles.component,
-                hasHoverStyles && styles.buttonHover,
+              style={[
+                styles.component,
+                styles[buttonType],
                 isFirstChild && styles.firstChild,
-                isLastChild && styles.lastChild]}
+                isLastChild && styles.lastChild,
+                isOnlyChild && styles.onlyChild
+              ]}
               type={buttonType}>
                 {button.text}
             </Button>);
@@ -66,8 +71,8 @@ const ButtonGroup = React.createClass({
     return {
       component: {
         borderRadius: 0,
-        borderRightWidth: 0,
-        verticalAlign: 'middle'
+        borderWidth: 1,
+        borderRightWidth: 0
       },
       firstChild: {
         borderRadius: '2px 0 0 2px'
@@ -76,13 +81,15 @@ const ButtonGroup = React.createClass({
         borderRadius: '0 2px 2px 0',
         borderRightWidth: 1
       },
-      buttonHover: {
-        borderRightWidth: 1,
+      onlyChild: {
+        borderRadius: 2,
+        borderWidth: 1
+      },
+      base: {
+        borderRight: '1px solid transparent',
         ':hover': {
-          borderColor: StyleConstants.Colors.FOG,
           borderRadius: 2,
-          borderStyle: 'solid',
-          borderWidth: '1px 1px 1px 1px'
+          borderRight: '1px solid initial'
         }
       }
     };

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -31,30 +31,27 @@ const ButtonGroup = React.createClass({
 
   render () {
     const styles = this.styles();
-    const buttonType = this.props.type;
-    const primaryColor = this.props.primaryColor;
-    const buttons = this.props.buttons;
 
     return (
       <div {...this.props}>
-        {this.props.buttons.map(function (button, i) {
+        {this.props.buttons.map((button, i) => {
           const isFirstChild = i === 0;
-          const isLastChild = i === buttons.length - 1;
+          const isLastChild = i === this.props.buttons.length - 1;
           const isOnlyChild = isFirstChild && isLastChild;
 
           return (
             <Button
               icon={button.icon}
               key={i}
-              primaryColor={primaryColor}
+              primaryColor={this.props.primaryColor}
               style={[
                 styles.component,
-                styles[buttonType],
+                styles[this.props.type],
                 isFirstChild && styles.firstChild,
                 isLastChild && styles.lastChild,
                 isOnlyChild && styles.onlyChild
               ]}
-              type={buttonType}
+              type={this.props.type}
             >
                 {button.text}
             </Button>);

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -33,18 +33,19 @@ const ButtonGroup = React.createClass({
     const styles = this.styles();
     const buttonType = this.props.type;
     const primaryColor = this.props.primaryColor;
+    const buttons = this.props.buttons;
 
     return (
       <div {...this.props}>
-        {this.props.buttons.map(function (button, index, arr) {
-          const isFirstChild = index === 0;
-          const isLastChild = index === arr.length - 1;
+        {this.props.buttons.map(function (button, i) {
+          const isFirstChild = i === 0;
+          const isLastChild = i === buttons.length - 1;
           const isOnlyChild = isFirstChild && isLastChild;
 
           return (
             <Button
               icon={button.icon}
-              key={index}
+              key={i}
               primaryColor={primaryColor}
               style={[
                 styles.component,
@@ -53,7 +54,8 @@ const ButtonGroup = React.createClass({
                 isLastChild && styles.lastChild,
                 isOnlyChild && styles.onlyChild
               ]}
-              type={buttonType}>
+              type={buttonType}
+            >
                 {button.text}
             </Button>);
         })}

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -10,7 +10,7 @@ const ButtonGroup = React.createClass({
     buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
       icon: React.PropTypes.string,
       text: React.PropTypes.string
-    })),
+    }).isRequired),
     controlArrows: React.PropTypes.bool,
     primaryColor: React.PropTypes.string,
     type: React.PropTypes.oneOf([

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -54,7 +54,8 @@ const ButtonGroup = React.createClass({
               type={this.props.type}
             >
               {button.text}
-            </Button>);
+            </Button>
+          );
         })}
       </div>
     );

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -3,6 +3,8 @@ const Radium = require('radium');
 
 const Button = require('./Button');
 
+const StyleConstants = require('../constants/Style');
+
 const ButtonGroup = React.createClass({
   propTypes: {
     buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
@@ -21,13 +23,14 @@ const ButtonGroup = React.createClass({
   getDefaultProps () {
     return {
       buttons: [],
-      type: 'primary'
+      type: 'primaryOutline'
     };
   },
 
   render () {
     const styles = this.styles();
     const buttonType = this.props.type;
+    const hasHoverStyles = buttonType === 'base' || buttonType === 'neutral';
 
     return (
       <div {...this.props}>
@@ -38,7 +41,10 @@ const ButtonGroup = React.createClass({
           return (
             <Button
               key={index}
-              style={[styles.component, isFirstChild && styles.firstChild, isLastChild && styles.lastChild]}
+              style={[styles.component,
+                hasHoverStyles && styles.hoverStyles,
+                isFirstChild && styles.firstChild,
+                isLastChild && styles.lastChild]}
               type={buttonType}>
                 {button.text}
             </Button>);
@@ -59,6 +65,15 @@ const ButtonGroup = React.createClass({
       lastChild: {
         borderRadius: '0 2px 2px 0',
         borderRightWidth: 1
+      },
+      hoverStyles: {
+        borderRightWidth: 1,
+        ':hover': {
+          borderColor: StyleConstants.Colors.FOG,
+          borderRadius: 2,
+          borderStyle: 'solid',
+          borderWidth: '1px 1px 1px 1px'
+        }
       }
     };
   }


### PR DESCRIPTION
This adds the ButtonGroup component and addresses half of #184. ButtonGroup works with every Button `type` and icon-only buttons. Loading buttons are *not* supported.

## Example
```
<ButtonGroup
  buttons={[
    { text: 'Mar 2015 - Feb 2016' }
  ]}
  controlArrows={true}
  type='primaryOutline' />

<ButtonGroup
  buttons={[
    { icon: 'download' },
    { icon: 'search' },
    { icon: 'add' }
  ]}
  type='base' />
```
![6pg324n8a1](https://cloud.githubusercontent.com/assets/1916697/14192770/0026ed96-f75d-11e5-9a55-ab9807d85b18.gif)

## Props
`buttons` *array of objects* **required**
Default: an empty array
An array of objects that will populate the button values. Works with as little as one object. Objects take an `icon`, `text`, or both.

`icon` *string* **optional**
The name of the icon.
Default: undefined

`text` *string* **optional**
The text to be displayed in the button
Default: undefined
```
<ButtonGroup
  buttons={[
     { icon: 'download' },
     { icon: 'search' },
     { icon: 'add' }
  ]} />
```
<br/>
`controlArrows` *boolean* **optional**
Default: false
A boolean value to add arrows to the beginning and end of the button array.
```
<ButtonGroup
  buttons={[
    { text: 'Mar 2015 - Feb 2016' }
  ]}
  controlArrows={true} />
```
<br/>
`primaryColor` *string* **optional**
Default: PRIMARY
A string that changes the brand color if there is one.
```
<ButtonGroup
  buttons={[
     { text: 'Button 1' },
     { text: 'Button 2' }
  ]}
  primaryColor='#FFC0CB' />
```
<br/>
`type` *string* **optional**
Default: primaryOutline
The type of buttons for the entire group. The same types that are supported in the Button component work here.
```
<ButtonGroup
  buttons={[
     { text: 'Button 1' },
     { text: 'Button 2' }
  ]}
  type='base' />
```