### PR TITLE
Add adjustOpacity method to Styles

### DIFF
--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -84,7 +84,7 @@ module.exports = {
   },
 
 
-  adjustOpacity (color, opacity) {
+  adjustHexOpacity (color, opacity) {
     const r = parseInt(color.slice(1, 3), 16);
     const g = parseInt(color.slice(3, 5), 16);
     const b = parseInt(color.slice(5, 7), 16);

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -81,5 +81,14 @@ module.exports = {
     }
 
     return (usePound ? '#' : '') + (g | (b << 8) | (r << 16)).toString(16);
+  },
+
+
+  adjustOpacity (color, opacity) {
+    const r = parseInt(color.slice(1, 3), 16);
+    const g = parseInt(color.slice(3, 5), 16);
+    const b = parseInt(color.slice(5, 7), 16);
+
+    return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + opacity + ')';
   }
 };


### PR DESCRIPTION
Add adjustOpacity method to Styles constants.

This takes hex color and opacity params and returns an rbga string.

To use
```
<div style={{ backgroundColor: Styles.Colors.ORANGE }}></div>
<div style={{ backgroundColor: Styles.adjustOpacity(Styles.Colors.ORANGE, 0.1) }}></div>
```
![screen shot 2016-04-01 at 4 39 11 pm](https://cloud.githubusercontent.com/assets/488916/14221988/c23f7b48-f828-11e5-9492-afa31a3576ff.png)
