### PR TITLE
Added navigation modal

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -14,6 +14,7 @@ const {
   Icon,
   Loader,
   Modal,
+  NavigationModal,
   RangeSelector,
   Select,
   SelectFullScreen,
@@ -619,6 +620,17 @@ const Demo = React.createClass({
       onPreviousClick: this._handlePreviousSiblingClick
     };
 
+    const navItems = [
+      {
+        content: 'View Details',
+        onClick: this._handleNavModalClick1
+      },
+      {
+        content: 'Edit Settings',
+        onClick: this._handleNavModalClick2
+      }
+    ];
+
     return (
       <div>
         <br/><br/>
@@ -638,6 +650,10 @@ const Demo = React.createClass({
             onFileRemove={this._handleFileChange}
             uploadedFile={this.state.uploadedFile}
           />
+        </div>
+
+        <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
+          <NavigationModal items={navItems}/>
         </div>
 
         <br/><br/>

--- a/demo/app.js
+++ b/demo/app.js
@@ -623,11 +623,11 @@ const Demo = React.createClass({
     const navItems = [
       {
         content: 'View Details',
-        onClick: this._handleNavModalClick1
+        onClick: this._handleNavModalClick
       },
       {
         content: 'Edit Settings',
-        onClick: this._handleNavModalClick2
+        onClick: this._handleNavModalClick
       }
     ];
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -8,6 +8,7 @@ module.exports = {
   Icon: require('./components/Icon'),
   Loader: require('./components/Loader'),
   Modal: require('./components/Modal'),
+  NavigationModal: require('./components/NavigationModal'),
   RajaIcon: require('./components/RajaIcon'),
   RangeSelector: require('./components/RangeSelector'),
   Select: require('./components/Select'),

--- a/src/components/NavigationModal.js
+++ b/src/components/NavigationModal.js
@@ -1,0 +1,83 @@
+const React = require('react');
+const _merge = require('lodash/merge');
+
+const Icon = require('./Icon');
+
+const StyleConstants = require('../constants/Style');
+
+const NavigationModal = React.createClass({
+  propTypes: {
+    componentStyle: React.PropTypes.object,
+    iconSize: React.PropTypes.number,
+    iconStyle: React.PropTypes.object,
+    iconType: React.PropTypes.string,
+    items: React.PropTypes.arrayOf(React.PropTypes.shape({
+      content: React.PropTypes.node,
+      onClick: React.PropTypes.func
+    })),
+    modalItemStyle: React.PropTypes.object,
+    modalStyle: React.PropTypes.object
+  },
+
+  getInitialState () {
+    return {
+      showModal: false
+    };
+  },
+
+  _handleToggle () {
+    this.setState({
+      showModal: !this.state.showModal
+    });
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div onClick={this._handleToggle} style={styles.component}>
+        <Icon size={this.props.iconSize || 30} style={styles.icon} type={this.props.iconType || 'caret-down'} />
+        {this.state.showModal ? (
+          <div style={styles.modal}>
+            {this.props.items.map((item, index) => {
+              return (<div key={index} onClick={item.onClick} style={styles.modalItem}>{item.content}</div>);
+            })}
+          </div>
+        ) : null }
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: _merge({
+        fontFamily: StyleConstants.Fonts.REGULAR,
+        position: 'relative',
+        cursor: 'pointer',
+        display: 'flex',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        textAlign: 'center',
+        alignSelf: 'stretch'
+      }, this.props.componentStyle),
+      icon: _merge({
+        alignSelf: 'center',
+        color: StyleConstants.Colors.ASH
+      }, this.props.iconStyle),
+      modal: _merge({
+        borderRadius: 3,
+        boxShadow: '0 0 30px rgba(0,0,0,0.15)',
+        width: 200,
+        backgroundColor: StyleConstants.Colors.WHITE,
+        position: 'absolute',
+        top: '50%',
+        left: '50%'
+      }, this.props.modalStyle),
+      modalItem: _merge({
+        padding: 20
+      }, this.props.modalItemStyle)
+    };
+  }
+});
+
+module.exports = NavigationModal;

--- a/src/components/NavigationModal.js
+++ b/src/components/NavigationModal.js
@@ -14,7 +14,7 @@ const NavigationModal = React.createClass({
     items: React.PropTypes.arrayOf(React.PropTypes.shape({
       content: React.PropTypes.node,
       onClick: React.PropTypes.func
-    })),
+    })).isRequired,
     modalItemStyle: React.PropTypes.object,
     modalStyle: React.PropTypes.object
   },


### PR DESCRIPTION
This adds a NavigationModal component. This is a simple caret (or other specified icon) that when clicked shows a modal of items.

### Props ###
- componentStyle: object with styles to be applied to the overall component
- iconSize: number to determine the size of the icon. Defaults to 30
- iconStyle: object with styles to be applied to the icon
- iconType: string to determine the icon. Defaults to `caret-down`
- items: array with each object containing content node and onClick function
- modalItemStyle: object with styles to be applied to the modal items
- modalStyle: object with styles to be applied to the modal

The naming of the component is up for suggestions.

![screen shot 2016-04-05 at 4 13 35 pm](https://cloud.githubusercontent.com/assets/488916/14299947/9f31f976-fb4a-11e5-8cd0-a2b2a89c0ca1.png)

@mxenabled/frontend-engineers 
