### PR TITLE
Luke/remove select prop

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -607,7 +607,7 @@ const Demo = React.createClass({
 
   _handleSpinnerWithTextClick () {
     this.setState({
-      spinnernpWithTextIsActive: !this.state.spinnerWithTextIsActive
+      spinnerWithTextIsActive: !this.state.spinnerWithTextIsActive
     });
   },
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -607,7 +607,7 @@ const Demo = React.createClass({
 
   _handleSpinnerWithTextClick () {
     this.setState({
-      spinnerWithTextIsActive: !this.state.spinnerWithTextIsActive
+      spinnernpWithTextIsActive: !this.state.spinnerWithTextIsActive
     });
   },
 
@@ -805,12 +805,7 @@ const Demo = React.createClass({
         <br/><br/>
         <Select
           color='#359BCF'
-          isMobile={false}
           onChange={this._handleSelectChange}
-          optionHoverStyle={{
-            backgroundColor: '#359BCF',
-            color: '#fff'
-          }}
           optionStyle={{
             color: '#333'
           }}


### PR DESCRIPTION
Removed some props that are unavailable on the component in the demo app. Searched the component and looked at the validation and couldn't find anything.

If this is too minor of a change I can expand this PR and go through all the components to see which props we're passing that aren't available. 

Prop Validation on select comp:
```javascript
  propTypes: {
    color: React.PropTypes.string,
    dropdownStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
    onChange: React.PropTypes.func,
    options: React.PropTypes.array,
    optionsStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
    optionStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
    placeholderText: React.PropTypes.string,
    scrimStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
    selected: React.PropTypes.object,
    selectedStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
    valid: React.PropTypes.bool
  },
```
