### PR TITLE
Remove validation message in favor of validation callback

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -19,12 +19,6 @@ const FileUpload = React.createClass({
     uploadedFile: React.PropTypes.any
   },
 
-  getDefaultProps () {
-    return {
-      onFileValidation () {}
-    };
-  },
-
   getInitialState () {
     return {
       dragging: false,
@@ -125,15 +119,17 @@ const FileUpload = React.createClass({
       this.props.onFileAdd(file);
     }
 
-    if (isTooBig) {
-      validationMessages.push('file_size');
-    }
+    if (this.props.onFileValidation) {
+      if (isTooBig) {
+        validationMessages.push('file_size');
+      }
 
-    if (isInvalidType) {
-      validationMessages.push('file_type');
-    }
+      if (isInvalidType) {
+        validationMessages.push('file_type');
+      }
 
-    this.props.onFileValidation(validationMessages);
+      this.props.onFileValidation(validationMessages);
+    }
   },
 
   render () {


### PR DESCRIPTION
The validation messages and placeholder text were not displaying correctly if the dropzone was smaller.

This changes the placeholder text to be a child passed into the component, allowing the user to customize the message.

This also adds an onValidation prop to be used as a callback. This allows the parent component to handle validation errors, passing messages back through the children props if desired. 

This also changes the hidden input used for the file selection to `display: none` instead of `visibility: hidden`. Before, there was an issue with a container scrolling because of the input.

@mxenabled/frontend-engineers  