### PR TITLE
Add PageIndicator component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -14,6 +14,7 @@ const {
   Icon,
   Loader,
   Modal,
+  PageIndicator,
   RangeSelector,
   Select,
   SelectFullScreen,
@@ -471,6 +472,7 @@ const Demo = React.createClass({
         displayValue: 'Accounts'
       },
       lineChartData: [],
+      pageIndicatorIndex: 0,
       selectedDatePickerDate: moment().unix(),
       showDrawer: false,
       showDrawerButtonType: 'primary',
@@ -608,6 +610,18 @@ const Demo = React.createClass({
   _handleSpinnerWithTextClick () {
     this.setState({
       spinnerWithTextIsActive: !this.state.spinnerWithTextIsActive
+    });
+  },
+
+  _handlePageIndicatorClick (index) {
+    this.setState({
+      pageIndicatorIndex: index
+    });
+  },
+
+  _handleNextPageIndicatorClick () {
+    this.setState({
+      pageIndicatorIndex: this.state.pageIndicatorIndex === 2 ? 0 : this.state.pageIndicatorIndex + 1
     });
   },
 
@@ -942,6 +956,13 @@ const Demo = React.createClass({
           />
         </div>
         <br/><br/>
+
+        <div style={{ textAlign: 'center', fontSize: 20 }}>
+          Current Page Indicator Index: {this.state.pageIndicatorIndex}
+          <br/><br/>
+          <Button onClick={this._handleNextPageIndicatorClick}>Next Page</Button>
+          <PageIndicator activeIndex={this.state.pageIndicatorIndex} count={3} onClick={this._handlePageIndicatorClick} />
+        </div>
       </div>
     );
   }

--- a/src/Index.js
+++ b/src/Index.js
@@ -8,6 +8,7 @@ module.exports = {
   Icon: require('./components/Icon'),
   Loader: require('./components/Loader'),
   Modal: require('./components/Modal'),
+  PageIndicator: require('./components/PageIndicator'),
   RajaIcon: require('./components/RajaIcon'),
   RangeSelector: require('./components/RangeSelector'),
   Select: require('./components/Select'),

--- a/src/components/PageIndicator.js
+++ b/src/components/PageIndicator.js
@@ -1,0 +1,66 @@
+const React = require('react');
+
+const StyleConstants = require('../constants/Style');
+
+const PageIndicator = React.createClass({
+  propTypes: {
+    activeIndex: React.PropTypes.number,
+    count: React.PropTypes.number,
+    onClick: React.PropTypes.func
+  },
+
+  _handleDotClick (index = 0) {
+    if (this.props.onClick) {
+      this.props.onClick(index);
+    }
+  },
+
+  _renderDots () {
+    const styles = this.styles();
+    const dots = [];
+
+    for (let i = 0; i < this.props.count; i++) {
+      const dotStyles = this.props.activeIndex === i ? Object.assign({}, styles.dot, styles.dotActive) : styles.dot;
+
+      dots.push(
+        <span key={'dot' + i} onClick={this._handleDotClick.bind(null, i)} style={dotStyles} />
+      );
+    }
+
+    return dots;
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div style={styles.component}>
+        {this._renderDots()}
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: {
+        textAlign: 'center',
+        padding: '15px 0'
+      },
+      dot: {
+        width: 6,
+        height: 6,
+        margin: 10,
+        borderRadius: '100%',
+        display: 'inline-block',
+        verticalAlign: 'middle',
+        backgroundColor: StyleConstants.Colors.FOG,
+        cursor: 'pointer'
+      },
+      dotActive: {
+        backgroundColor: StyleConstants.Colors.CHARCOAL
+      }
+    };
+  }
+});
+
+module.exports = PageIndicator;

--- a/src/components/PageIndicator.js
+++ b/src/components/PageIndicator.js
@@ -5,7 +5,7 @@ const StyleConstants = require('../constants/Style');
 const PageIndicator = React.createClass({
   propTypes: {
     activeIndex: React.PropTypes.number,
-    count: React.PropTypes.number,
+    count: React.PropTypes.number.isRequired,
     onClick: React.PropTypes.func
   },
 


### PR DESCRIPTION
Follows the specs outlined in https://github.com/mxenabled/mx-react-components/issues/236.

![screen shot 2016-04-06 at 2 58 47 pm](https://cloud.githubusercontent.com/assets/714084/14332758/453d9e0c-fc08-11e5-95df-515273c680ae.png)

This component is just the Page Indicators at the bottom of the screenshot above. The other elements are simply part of the demo and for testing purposes.

## props
- **activeIndex** *Number*: The index of the active "page" or dot. Default is `0`;
- **count** *Number*: The number of "pages" or dots to display. Required. No default.
- **onClick** *Function*: A function to be called when a dot is clicked. The function will be passed the index of the clicked dot.

@mxenabled/frontend-engineers 
