### PR TITLE
Fixed deprecation warning in modal

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,6 +1,5 @@
 const React = require('react');
 const Radium = require('radium');
-const _has = require('lodash/has');
 
 const Button = require('./Button');
 const Icon = require('./Icon');
@@ -61,7 +60,7 @@ const Modal = React.createClass({
 
   componentDidMount () {
   /*eslint-disable */
-    if (_has(this.props, 'isOpen')) {
+    if (this.props.hasOwnProperty('isOpen')) {
       console.warn('WARNING: The prop "isOpen" is deprecated in this version of the component. Please handle Modal opening from its parent.');
     }
   /*eslint-enable */

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const Radium = require('radium');
+const _has = require('lodash/has');
 
 const Button = require('./Button');
 const Icon = require('./Icon');
@@ -60,8 +61,8 @@ const Modal = React.createClass({
 
   componentDidMount () {
   /*eslint-disable */
-    if (this.props.isOpen !== null) {
-      console.warn('WARNING: The prop "isOpen" is depracated in this version of the component. Please handle Modal opening from its parent.');
+    if (_has(this.props, 'isOpen')) {
+      console.warn('WARNING: The prop "isOpen" is deprecated in this version of the component. Please handle Modal opening from its parent.');
     }
   /*eslint-enable */
   },


### PR DESCRIPTION
In implementing these changes, I found that not passing isOpen into the Modal component still triggered the error. 

Since `this.props.isOpen` would be `undefined` `this.props.isOpen !== null` would be true.

This adds the lodash _has method to check.

@mxenabled/frontend-engineers 