### PR TITLE
Fix styles for Icon component in DatePicker components

### DIFF
--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -285,6 +285,13 @@ const DatePicker = React.createClass({
   render () {
     const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
+    let leftNavIconStyle = Object.assign({}, styles.navIcon, styles.navLeft);
+    let rightNavIconStyle = Object.assign({}, styles.navIcon, styles.navRight);
+
+    if (this.props.showDayBorders) {
+      leftNavIconStyle = Object.assign(leftNavIconStyle, styles.borderRight);
+      rightNavIconStyle = Object.assign(rightNavIconStyle, styles.borderLeft);
+    }
 
     return (
       <div
@@ -307,14 +314,14 @@ const DatePicker = React.createClass({
             <Icon
               onClick={this._handlePreviousClick}
               size='32px'
-              style={[styles.navIcon, styles.navLeft, this.props.showDayBorders && styles.borderRight]}
+              style={leftNavIconStyle}
               type='caret-left'
             />
             {currentDate.format('MMMM YYYY')}
             <Icon
               onClick={this._handleNextClick}
               size='32px'
-              style={[styles.navIcon, styles.navRight, this.props.showDayBorders && styles.borderLeft]}
+              style={rightNavIconStyle}
               type='caret-right'
             />
           </div>

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -232,6 +232,13 @@ const DatePickerFullScreen = React.createClass({
   render () {
     const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
+    let leftNavIconStyle = Object.assign({}, styles.navIcon, styles.navLeft);
+    let rightNavIconStyle = Object.assign({}, styles.navIcon, styles.navRight);
+
+    if (this.props.showDayBorders) {
+      leftNavIconStyle = Object.assign(leftNavIconStyle, styles.borderRight);
+      rightNavIconStyle = Object.assign(rightNavIconStyle, styles.borderLeft);
+    }
 
     return (
       <div
@@ -264,14 +271,14 @@ const DatePickerFullScreen = React.createClass({
               <Icon
                 onClick={this._handlePreviousClick}
                 size='32px'
-                style={[styles.navIcon, styles.navLeft, this.props.showDayBorders && styles.borderRight]}
+                style={leftNavIconStyle}
                 type='caret-left'
               />
               {currentDate.format('MMMM YYYY')}
               <Icon
                 onClick={this._handleNextClick}
                 size='32px'
-                style={[styles.navIcon, styles.navRight, this.props.showDayBorders && styles.borderLeft]}
+                style={rightNavIconStyle}
                 type='caret-right'
               />
             </div>


### PR DESCRIPTION
We were passing in an array of styles to the Icon component inside the DatePicker and DatePickerFullScreen components.  This was generating an `Invalid prop` warning since we update the Icon component.  This PR fixes the warning by using `Object.assign` rather than a Radium array for the offending Icons.

@mxenabled/frontend-engineers 

After change screen shots to show styling still working as intended.

![screen shot 2016-04-08 at 10 50 54 am](https://cloud.githubusercontent.com/assets/6463914/14391250/2b554870-fd78-11e5-9194-354e9a2d1ab9.png)
![screen shot 2016-04-08 at 10 51 03 am](https://cloud.githubusercontent.com/assets/6463914/14391251/2b557692-fd78-11e5-91b8-f74990d815bb.png)
