### PR TITLE
Button styles fix

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -169,10 +169,10 @@ const Button = React.createClass({
         fill: StyleConstants.Colors.FOG
       },
       icon: {
-        marginBottom: this.props.children ? -5 : -3,
+        marginBottom: -3,
         marginLeft: -5,
         marginRight: this.props.children ? 5 : -5,
-        marginTop: this.props.children ? -5 : -4,
+        marginTop: -4,
         verticalAlign: 'middle'
       },
       spinner: {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -40,7 +40,7 @@ const Button = React.createClass({
         {this.props.isActive ? (
           <div>
             <Spin direction='counterclockwise'>
-                <Icon size='20' style={[styles.icon, styles.spinner]} type='spinner' />
+                <Icon size='20' style={styles.spinner} type='spinner' />
             </Spin>
               {this.props.actionText ? <div style={styles.actionText}> {this.props.actionText} </div> : null }
           </div>
@@ -51,7 +51,7 @@ const Button = React.createClass({
 
   styles () {
     return {
-      component: {
+      component: Object.assign({
         borderRadius: 2,
         borderStyle: 'solid',
         borderWidth: 1,
@@ -65,7 +65,7 @@ const Button = React.createClass({
         transition: 'all .2s ease-in',
         minWidth: 16,
         minHeight: 15
-      },
+      }, this.props.style),
       primary: {
         backgroundColor: this.props.primaryColor,
         borderColor: this.props.primaryColor,
@@ -169,16 +169,17 @@ const Button = React.createClass({
         fill: StyleConstants.Colors.FOG
       },
       icon: {
-        marginTop: -3,
-        marginBottom: -5,
+        marginBottom: this.props.children ? -5 : -3,
         marginLeft: -5,
         marginRight: this.props.children ? 5 : -5,
-        verticalAlign: 'initial'
+        marginTop: this.props.children ? -5 : -4,
+        verticalAlign: 'middle'
       },
       spinner: {
+        marginBottom: -3,
+        marginLeft: -5,
         marginRight: -5,
-        marginTop: -6,
-        padding: this.props.actionText ? 0 : 3
+        marginTop: -4
       },
       actionText: {
         display: 'inline-block',

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,5 +1,4 @@
 const React = require('react');
-const Radium = require('radium');
 
 const Button = require('./Button');
 
@@ -63,11 +62,11 @@ const ButtonGroup = React.createClass({
 
   styles () {
     return {
-      component: {
+      component: Object.assign({
         borderRadius: 0,
         borderWidth: 1,
         borderRightWidth: 0
-      },
+      }, this.props.style),
       firstChild: {
         borderRadius: '2px 0 0 2px'
       },
@@ -90,4 +89,4 @@ const ButtonGroup = React.createClass({
   }
 });
 
-module.exports = Radium(ButtonGroup);
+module.exports = ButtonGroup;


### PR DESCRIPTION
Fixes #256 and reworks Button and ButtonGroup components to use the `Object.assign()` pattern on styles. Radium is still required on the Button component so I didn't remove it there. Note: button height goes from 31px to 29px which is more in line with the style guide anyway.