### PR TITLE
SearchInput: Removed border

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -54,7 +54,6 @@ const SearchInput = React.createClass({
         width: '100%'
       },
       searchBar: {
-        border: '1px solid ' + StyleConstants.Colors.FOG,
         position: 'relative',
         marginBottom: 10
       },


### PR DESCRIPTION
This PR removes the heavy gray border from the `SearchInput` component.

Before
<img width="1179" alt="screen shot 2016-04-11 at 4 13 20 pm" src="https://cloud.githubusercontent.com/assets/9920303/14444088/a5834d42-0000-11e6-8156-df5e05f0ffbd.png">

After
<img width="1184" alt="screen shot 2016-04-11 at 4 10 28 pm" src="https://cloud.githubusercontent.com/assets/9920303/14444090/aa97fd96-0000-11e6-8278-6d5fef3f247f.png">

@mxenabled/frontend-engineers 
