### PR TITLE
Luke/React to v15.0.1

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -861,7 +861,7 @@ const Demo = React.createClass({
           <Icon
             size={150}
             style={{
-              color: '#359BCF'
+              fill: '#359BCF'
             }}
             type={this.state.icon.value}
           />
@@ -894,7 +894,7 @@ const Demo = React.createClass({
             <Icon
               size={150}
               style={{
-                color: '#359BCF'
+                fill: '#359BCF'
               }}
               type={this.state.icon.value}
             />

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "moment": "^2.10.3",
     "numeral": "^1.5.3",
     "radium": "^0.14.0",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1",
     "velocity-animate": "^1.2.3"
   },
   "devDependencies": {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -40,7 +40,7 @@ const Button = React.createClass({
         {this.props.isActive ? (
           <div>
             <Spin direction='counterclockwise'>
-                <Icon size='20' style={[styles.icon, styles.spinner]} type='spinner' />
+                <Icon size={20} style={[styles.icon, styles.spinner]} type='spinner' />
             </Spin>
               {this.props.actionText ? <div style={styles.actionText}> {this.props.actionText} </div> : null }
           </div>

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -271,7 +271,7 @@ const DatePicker = React.createClass({
         <div style={[styles.caretWrapper, this.props.caretWrapperStyle]}>
           <Icon
             onClick={this._toggleCalendar}
-            size='20'
+            size={20}
             style={styles.caret}
             type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
           />
@@ -296,7 +296,7 @@ const DatePicker = React.createClass({
     return (
       <div
         style={[styles.component, styles.clearFix, this.props.style]}
-        tabIndex='0'
+        tabIndex={0}
       >
         <div key='selectedDateWrapper' style={[
           styles.selectedDateWrapper,
@@ -313,14 +313,14 @@ const DatePicker = React.createClass({
           <div key='calendarHeader' style={[styles.calendarHeader, { borderBottomStyle: this.props.showDayBorders ? 'solid' : 'none' }, styles.clearFix]}>
             <Icon
               onClick={this._handlePreviousClick}
-              size='32px'
+              size={32}
               style={leftNavIconStyle}
               type='caret-left'
             />
             {currentDate.format('MMMM YYYY')}
             <Icon
               onClick={this._handleNextClick}
-              size='32px'
+              size={32}
               style={rightNavIconStyle}
               type='caret-right'
             />
@@ -494,13 +494,13 @@ const styles = {
   },
   navLeft: {
     position: 'absolute',
-    left: '0',
+    left: 0,
     top: '50%',
     transform: 'translateY(-50%)'
   },
   navRight: {
     position: 'absolute',
-    right: '0',
+    right: 0,
     top: '50%',
     transform: 'translateY(-50%)'
   },

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -40,6 +40,16 @@ const DatePickerFullScreen = React.createClass({
     };
   },
 
+  getInitialState () {
+    return {
+      currentDate: null,
+      inputValue: this._getInputValueByDate(this.props.defaultDate),
+      isValid: true,
+      selectedDate: this.props.defaultDate,
+      showCalendar: false
+    };
+  },
+
   componentDidMount () {
     window.onkeyup = e => {
       if (e.keyCode === 27) {

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -270,14 +270,14 @@ const DatePickerFullScreen = React.createClass({
             <div className='mx-date-picker-full-screen-calendar-header' key='calendarHeader' style={[styles.calendarHeader, { borderBottomStyle: this.props.showDayBorders ? 'solid' : 'none' }, styles.clearFix]}>
               <Icon
                 onClick={this._handlePreviousClick}
-                size='32px'
+                size={32}
                 style={leftNavIconStyle}
                 type='caret-left'
               />
               {currentDate.format('MMMM YYYY')}
               <Icon
                 onClick={this._handleNextClick}
-                size='32px'
+                size={32}
                 style={rightNavIconStyle}
                 type='caret-right'
               />
@@ -455,13 +455,13 @@ const styles = {
   },
   navLeft: {
     position: 'absolute',
-    left: '0',
+    left: 0,
     top: '50%',
     transform: 'translateY(-50%)'
   },
   navRight: {
     position: 'absolute',
-    right: '0',
+    right: 0,
     top: '50%',
     transform: 'translateY(-50%)'
   },

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -2,7 +2,7 @@ const React = require('react');
 
 const Icon = React.createClass({
   propTypes: {
-    size: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
+    size: React.PropTypes.number,
     style: React.PropTypes.object,
     type: React.PropTypes.string
   },

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -2,7 +2,7 @@ const React = require('react');
 
 const Icon = React.createClass({
   propTypes: {
-    size: React.PropTypes.number,
+    size: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
     style: React.PropTypes.object,
     type: React.PropTypes.string
   },

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -193,7 +193,7 @@ const Select = React.createClass({
                   ]}
                 >
                 {option.displayValue}
-                {_isEqual(option, this.state.highlightedValue) ? <Icon size='20' style={styles.check} type='check' /> : null }
+                {_isEqual(option, this.state.highlightedValue) ? <Icon size={20} style={styles.check} type='check' /> : null }
                 </li>
               );
             })}
@@ -221,7 +221,7 @@ const Select = React.createClass({
           <div className='mx-select-selected' key='selected' style={[styles.selected, this.props.selectedStyle]}>
             {selected.displayValue}
             <Icon
-              size='20'
+              size={20}
               style={styles.caret}
               type={this.state.isOpen ? 'caret-up' : 'caret-down'}
             />

--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -228,7 +228,7 @@ const TypeAhead = React.createClass({
           {item}
           <Icon
             onClick={this._handleItemRemove.bind(null, item)}
-            size='15px'
+            size={15}
             style={styles.removeIcon}
             type='close'
           />


### PR DESCRIPTION
When I was trying to update Gunny to React `v15.0.1` I got an error that involved two different versions of React Installed - `v0.14.x` from the open source, and `v15.0.1` from gunny. 

This PR updates React in the Open Source. It also addresses all the errors in the demo app that were caused by the update. 
* React 15 doesn't like strings of numbers without px: ie `size='20'` is bad - we decided on `size={20}`
* The DatePickerFullScreen was mad that the value was null in some cases, I emulated the normal DatePicker and added getInitialState to the full screen version. This fixed the error. 

I noticed some other things that need to be cleaned up in the components - ie potential unused state in the datePicker, but that's for another PR. 

### Important:
Because this updates our OSS components to `react 15.0.1` i'm assuming this would be a major version bump? Any thoughts on this? 