### PR TITLE
Remove global box-sizing from demo app and fix Drawer/Button components

### DIFF
--- a/demo/reset.css
+++ b/demo/reset.css
@@ -56,8 +56,6 @@
 /* Eric Meyer's Reset CSS v2.0 - http://cssreset.com */
 html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video{border:0;font-size:100%;font:inherit;vertical-align:baseline;margin:0;padding:0}article,aside,details,figcaption,figure,footer,header,hgroup,menu,nav,section{display:block}body{line-height:1}ol,ul{list-style:none}blockquote,q{quotes:none}blockquote:before,blockquote:after,q:before,q:after{content:none}table{border-collapse:collapse;border-spacing:0}
 
-* { box-sizing: border-box; }
-
 body, html {
   height: 100%;
   -webkit-font-smoothing: antialiased;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -65,7 +65,6 @@ const Button = React.createClass({
         cursor: 'pointer',
         transition: 'all .2s ease-in',
         minWidth: 16,
-        height: 30,
         lineHeight: '1.2em'
       }, this.props.style),
       primary: {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -182,7 +182,6 @@ const Drawer = React.createClass({
         display: 'flex',
         fontFamily: StyleConstants.Fonts.NORMAL,
         fontSize: StyleConstants.FontSizes.LARGE,
-        height: 45,
         justifyContent: 'center',
         padding: '7px 7px',
         position: 'relative'

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -189,6 +189,7 @@ const Drawer = React.createClass({
       },
       title: {
         overflow: 'hidden',
+        textAlign: 'center',
         textOverflow: 'ellipsis',
         width: '50%',
         whiteSpace: 'nowrap'

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -90,6 +90,7 @@ const Drawer = React.createClass({
         />
       </nav>
     ) : null;
+    ) : <div style={styles.nav} />;
   },
 
   render () {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -89,7 +89,6 @@ const Drawer = React.createClass({
           type='base'
         />
       </nav>
-    ) : null;
     ) : <div style={styles.nav} />;
   },
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -128,7 +128,7 @@ const Drawer = React.createClass({
         top: 0,
         bottom: 0,
         left: '100%',
-        position: 'relative',
+        position: 'absolute',
         width: '80%',
         overflow: 'hidden',
         backgroundColor: StyleConstants.Colors.PORCELAIN,


### PR DESCRIPTION
- Kills the global box-sizing being added via the reset.css in the demo app.
- Removes un-needed heights from button and drawer components now that the demo app is working as expected.
- Fixes a position issue in the drawer component. 
- Aligns title text for drawer component.
- Adds place holder for nav element in header of the drawer component so items retain their correct position if a navConfig is not provided.

Demo app after change:
![screen shot 2016-05-04 at 10 23 53 am](https://cloud.githubusercontent.com/assets/6463914/15021143/6466586a-11e2-11e6-8a83-2977a91add20.png)
