### PR TITLE
Drawer: Passes style prop to Drawer component

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -98,7 +98,7 @@ const Drawer = React.createClass({
     return (
       <div style={styles.componentWrapper}>
         <div onClick={this._handleCloseClick} style={styles.scrim}></div>
-        <div ref={(ref) => (this._component = ref)} style={styles.component}>
+        <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
           <header style={styles.header}>
             <span style={styles.backArrow}>
               <Button


### PR DESCRIPTION
This PR allows users of the `Drawer` component to pass a style object as a prop from the parent component.

- Adds `this.props.style`