### PR TITLE
Debounce the RangeSelector callbacks

### DIFF
--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -2,6 +2,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const Radium = require('radium');
 const _throttle = require('lodash/throttle');
+const _debounce = require('lodash/debounce');
 
 const StyleConstants = require('../constants/Style');
 
@@ -57,6 +58,13 @@ const RangeSelector = React.createClass({
     this._setDefaultRangeValues();
 
     window.addEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
+
+    this._handlePropCallback = _debounce((who) => {
+      // Who represents which switch is actually being moved.
+      const currentValue = this.state[who.toLowerCase() + 'Value'];
+
+      this.props['on' + who + 'DragStop'](currentValue);
+    }, 300);
   },
 
   componentWillUnmount () {
@@ -188,8 +196,8 @@ const RangeSelector = React.createClass({
         newState.dragging = false;
         newState.trackClicked = false;
       }
-      this.props['on' + this.state.dragging + 'DragStop'](this.state[this.state.dragging.toLowerCase() + 'Value']);
 
+      this._handlePropCallback(this.state.dragging);
       this.setState(newState);
 
       e.preventDefault();


### PR DESCRIPTION
I noticed the callback functions provided to the props `onLowerDragStop` and `onUpperDragStop` were executed multiple times while it was being dragged. Ideally this would truly only be called once after the drag was stopped and the mouse up ( or equivalent ) event was fired but that would be harder to implement. For the time being I implemented a solution with debounce.

A perfect example of this can be found in the Insight & Target Segment Balance filter...It will send off multiple execute calls to the backend while your dragging. 