### PR TITLE
Button style updates

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -37,7 +37,8 @@ const Button = React.createClass({
 
     return (
       <div {...this.props} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
-        {this.props.icon && !this.props.isActive ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
+        {(this.props.icon && !this.props.isActive && !this.props.children) ? <Icon size={20} style={styles.iconOnly} type={this.props.icon} /> : null}
+        {this.props.icon && !this.props.isActive && this.props.children ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
         {this.props.isActive ? (
           <div>
             <Spin direction='counterclockwise'>
@@ -65,7 +66,8 @@ const Button = React.createClass({
         cursor: 'pointer',
         transition: 'all .2s ease-in',
         minWidth: 16,
-        height: 13
+        height: 13,
+        position: 'relative'
       }, this.props.style),
       primary: {
         backgroundColor: this.props.primaryColor,
@@ -168,6 +170,12 @@ const Button = React.createClass({
         borderColor: StyleConstants.Colors.FOG,
         color: StyleConstants.Colors.FOG,
         fill: StyleConstants.Colors.FOG
+      },
+      iconOnly: {
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)'
       },
       icon: {
         marginBottom: -4,

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -38,7 +38,7 @@ const Button = React.createClass({
     return (
       <div {...this.props} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
         {(this.props.icon && !this.props.isActive && !this.props.children) ? <Icon size={20} style={styles.iconOnly} type={this.props.icon} /> : null}
-        {this.props.icon && !this.props.isActive && this.props.children ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
+        {(this.props.icon && !this.props.isActive && this.props.children) ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
         {this.props.isActive ? (
           <div>
             <Spin direction='counterclockwise'>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -37,8 +37,7 @@ const Button = React.createClass({
 
     return (
       <div {...this.props} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
-        {(this.props.icon && !this.props.isActive && !this.props.children) ? <Icon size={20} style={styles.iconOnly} type={this.props.icon} /> : null}
-        {(this.props.icon && !this.props.isActive && this.props.children) ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
+        {(this.props.icon && !this.props.isActive) ? <Icon size={20} style={this.props.children ? styles.icon : styles.iconOnly} type={this.props.icon} /> : null}
         {this.props.isActive ? (
           <div>
             <Spin direction='counterclockwise'>

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -48,12 +48,12 @@ const ButtonGroup = React.createClass({
               onClick={button.onClick}
               primaryColor={this.props.primaryColor}
               style={Object.assign({},
-                button.style,
                 styles.component,
                 styles[this.props.type],
                 isFirstChild && styles.firstChild,
                 isLastChild && styles.lastChild,
-                isOnlyChild && styles.onlyChild)}
+                isOnlyChild && styles.onlyChild,
+                button.style)}
               type={this.props.type}
             >
               {button.text}

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -48,6 +48,7 @@ const ButtonGroup = React.createClass({
               onClick={button.onClick}
               primaryColor={this.props.primaryColor}
               style={Object.assign({},
+                button.style,
                 styles.component,
                 styles[this.props.type],
                 isFirstChild && styles.firstChild,


### PR DESCRIPTION
Hopefully this will be the last update to buttons for a while. There are some inconsistencies in the reset.css we're using in app.js, the docs, and our production apps. These updates will allow us to manage those inconsistencies and make the buttons more universal.

1. Icon only buttons to use transform for placement rather than relying on negative margins.
2. Allow individual buttons in button groups to be styled. (Like for overriding global box-border styles).

## Before
![screen shot 2016-05-06 at 11 50 23 am](https://cloud.githubusercontent.com/assets/1916697/15081583/cf9983c4-1380-11e6-9093-6a2738d02f0e.png)

## After
![screen shot 2016-05-06 at 11 50 35 am](https://cloud.githubusercontent.com/assets/1916697/15081581/cc9ef212-1380-11e6-9c0a-664fa52d8183.png)
