### PR TITLE
Modal: Add primaryColor prop to Buttons prop array

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -14,6 +14,7 @@ const Modal = React.createClass({
       icon: React.PropTypes.string,
       label: React.PropTypes.string,
       onClick: React.PropTypes.func,
+      primaryColor: React.PropTypes.string,
       style: React.PropTypes.object,
       type: React.PropTypes.oneOf(['primary', 'secondary'])
     })),
@@ -97,6 +98,7 @@ const Modal = React.createClass({
                   isActive={button.isActive}
                   key={button.type + i}
                   onClick={button.onClick}
+                  primaryColor={button.primaryColor}
                   style={Object.assign({}, styles.button, button.style)}
                   type={button.type}
                 >


### PR DESCRIPTION
Internally, the hover states and border colors are off for Modals because we updated the Buttons component to take in a `primaryColor` prop for setting that stuff but then never updated the Modal to use it.  This PR does just that.

