### PR TITLE
Fix height on buttons and button group

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -37,15 +37,17 @@ const Button = React.createClass({
 
     return (
       <div {...this.props} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
-        {(this.props.icon && !this.props.isActive) ? <Icon size={20} style={this.props.children ? styles.icon : styles.iconOnly} type={this.props.icon} /> : null}
-        {this.props.isActive ? (
-          <div>
+        <div style={styles.children}>
+          {(this.props.icon && !this.props.isActive) ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
+          {this.props.isActive ? (
             <Spin direction='counterclockwise'>
               <Icon size={20} style={styles.spinner} type='spinner' />
             </Spin>
-              {this.props.actionText ? <div style={styles.actionText}> {this.props.actionText} </div> : null }
+          ) : null }
+          <div style={styles.buttonText}>
+            {this.props.isActive ? this.props.actionText : this.props.children}
           </div>
-        ) : this.props.children}
+        </div>
       </div>
     );
   },
@@ -57,17 +59,22 @@ const Button = React.createClass({
         borderStyle: 'solid',
         borderWidth: 1,
         borderColor: 'transparent',
+        boxSizing: 'border-box',
         display: 'inline-block',
-        padding: '7px 14px',
-        textAlign: 'center',
+        padding: '4px 14px',
         fontSize: StyleConstants.FontSizes.MEDIUM,
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
         cursor: 'pointer',
         transition: 'all .2s ease-in',
         minWidth: 16,
-        height: 13,
         position: 'relative'
       }, this.props.style),
+      children: {
+        justifyContent: 'center',
+        display: 'flex',
+        alignItems: 'center',
+        lineHeight: '20px'
+      },
       primary: {
         backgroundColor: this.props.primaryColor,
         borderColor: this.props.primaryColor,
@@ -170,27 +177,11 @@ const Button = React.createClass({
         color: StyleConstants.Colors.FOG,
         fill: StyleConstants.Colors.FOG
       },
-      iconOnly: {
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)'
-      },
       icon: {
-        marginBottom: -4,
-        marginLeft: -6,
-        marginRight: this.props.children ? 5 : -5,
-        marginTop: -4
+        marginRight: this.props.children ? 5 : 0
       },
-      spinner: {
-        marginBottom: -3,
-        marginLeft: -6,
-        marginRight: -5,
-        marginTop: -5
-      },
-      actionText: {
-        display: 'inline-block',
-        paddingLeft: 10
+      buttonText: {
+        marginLeft: (this.props.isActive && this.props.actionText) ? 10 : 0
       }
     };
   }

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -67,6 +67,7 @@ const ButtonGroup = React.createClass({
   styles () {
     return {
       component: Object.assign({
+        boxSizing: 'border-box',
         borderRadius: 0,
         borderWidth: 1,
         borderRightWidth: 0,


### PR DESCRIPTION
This replaces the icon and spinner margins with Flexbox to center the contents of the button. Also maintains a standard height with or without an icon/spinner. 

Tested in the demo app and in outside projects (Robinhood, Raja & Sabotage)

Demo:
![screen shot 2016-05-09 at 1 28 55 pm](https://cloud.githubusercontent.com/assets/488916/15125574/ca998ee8-15ea-11e6-8d0d-a2b2db09c30b.png)

Robinhood:
![screen shot 2016-05-09 at 12 12 14 pm](https://cloud.githubusercontent.com/assets/488916/15125539/a3c4f410-15ea-11e6-8067-087fd6a6903d.png)
![screen shot 2016-05-09 at 1 33 55 pm](https://cloud.githubusercontent.com/assets/488916/15125557/b6c906e6-15ea-11e6-95a1-ef010858e048.png)

Raja:
![screen shot 2016-05-09 at 1 22 04 pm](https://cloud.githubusercontent.com/assets/488916/15125563/bc7ce800-15ea-11e6-8c39-48372c9bd09a.png)
![screen shot 2016-05-09 at 1 22 30 pm](https://cloud.githubusercontent.com/assets/488916/15125564/bc8a2934-15ea-11e6-9dd8-7026063dbfcf.png)

Sabotage:
![screen shot 2016-05-09 at 12 36 36 pm](https://cloud.githubusercontent.com/assets/488916/15125569/c45c84f4-15ea-11e6-99a1-35c672207707.png)