### PR TITLE
Fix left margin on button icon

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -41,7 +41,7 @@ const Button = React.createClass({
           {(this.props.icon && !this.props.isActive) ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
           {this.props.isActive ? (
             <Spin direction='counterclockwise'>
-              <Icon size={20} style={styles.spinner} type='spinner' />
+              <Icon size={20} type='spinner' />
             </Spin>
           ) : null }
           <div style={styles.buttonText}>
@@ -178,6 +178,7 @@ const Button = React.createClass({
         fill: StyleConstants.Colors.FOG
       },
       icon: {
+        marginLeft: this.props.children ? -4 : 0,
         marginRight: this.props.children ? 5 : 0
       },
       buttonText: {


### PR DESCRIPTION
Found that the left margin on a button with an icon was too wide. This adds a negative margin on the icon only if there is props.children

Before:
![screen shot 2016-05-09 at 2 39 36 pm](https://cloud.githubusercontent.com/assets/488916/15127457/04c13716-15f4-11e6-8d3b-cf75f8885b96.png)

After:
![screen shot 2016-05-09 at 2 39 26 pm](https://cloud.githubusercontent.com/assets/488916/15127461/0c6bee84-15f4-11e6-99c1-b5756a941754.png)

