### PR TITLE
Fix for width issue on DisplayInput

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -60,7 +60,6 @@ const DisplayInput = React.createClass({
         transition: 'all .2s ease-in',
         WebkitAppearance: 'none',
         whiteSpace: 'nowrap',
-        width: '100%',
 
         ':focus': {
           borderBottom: this.props.valid ? '1px solid ' + this.props.primaryColor : '1px solid ' + StyleConstants.Colors.STRAWBERRY,


### PR DESCRIPTION
The display input's width was set to 100% which after we removed box-sizing, messed things up. Removing the rule from the component fixes the issue.

## Before
![screen shot 2016-05-10 at 4 10 29 pm](https://cloud.githubusercontent.com/assets/1916697/15164144/28f67b24-16ca-11e6-8b3d-a2b392f734c6.png)

## After
![screen shot 2016-05-10 at 4 10 51 pm](https://cloud.githubusercontent.com/assets/1916697/15164149/2f0b12b8-16ca-11e6-94df-490c53ef68d4.png)
![screen shot 2016-05-10 at 4 11 11 pm](https://cloud.githubusercontent.com/assets/1916697/15164148/2efe938a-16ca-11e6-80e7-a0e6d13d2aa0.png)