### PR TITLE
Drawer: Adds style props for header and content

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -760,8 +760,8 @@ const Demo = React.createClass({
         {this.state.showDrawer ? (
           <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
             <Drawer
+              headerStyle={{ backgroundColor: '#fff' }}
               navConfig={navConfig}
-              navStyle={{ backgroundColor: '#fff' }}
               onClose={this._onHideDrawer}
               title='This is the drawer component'
             >

--- a/demo/app.js
+++ b/demo/app.js
@@ -761,6 +761,7 @@ const Demo = React.createClass({
           <div style={{ textAlign: 'center', width: '80%', margin: 'auto' }}>
             <Drawer
               navConfig={navConfig}
+              navStyle={{ backgroundColor: '#fff' }}
               onClose={this._onHideDrawer}
               title='This is the drawer component'
             >

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -9,6 +9,10 @@ const StyleConstants = require('../constants/Style');
 const Drawer = React.createClass({
   propTypes: {
     buttonPrimaryColor: React.PropTypes.string,
+    contentStyle: React.PropTypes.oneOfType([
+      React.PropTypes.array,
+      React.PropTypes.object
+    ]),
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
     navConfig: React.PropTypes.shape({
@@ -16,6 +20,10 @@ const Drawer = React.createClass({
       onNextClick: React.PropTypes.func.isRequired,
       onPreviousClick: React.PropTypes.func.isRequired
     }),
+    navStyle: React.PropTypes.oneOfType([
+      React.PropTypes.array,
+      React.PropTypes.object
+    ]),
     onClose: React.PropTypes.func.isRequired,
     title: React.PropTypes.string
   },
@@ -99,7 +107,7 @@ const Drawer = React.createClass({
       <div style={styles.componentWrapper}>
         <div onClick={this._handleCloseClick} style={styles.scrim}></div>
         <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
-          <header style={styles.header}>
+          <header style={Object.assign({}, styles.header, this.props.navStyle)}>
             <span style={styles.backArrow}>
               <Button
                 icon='arrow-left'
@@ -113,7 +121,7 @@ const Drawer = React.createClass({
             </span>
             {this._renderNav()}
           </header>
-          <div style={styles.content}>
+          <div style={Object.assign({}, styles.content, this.props.contentStyle)}>
             {this.props.children}
           </div>
         </div>
@@ -205,6 +213,8 @@ const Drawer = React.createClass({
       },
       navLabel: {
         padding: '7px 14px',
+        position: 'relative',
+        bottom: 5,
 
         '@media (max-width: 750px)': {
           display: 'none',

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -15,15 +15,15 @@ const Drawer = React.createClass({
     ]),
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
+    headerStyle: React.PropTypes.oneOfType([
+      React.PropTypes.array,
+      React.PropTypes.object
+    ]),
     navConfig: React.PropTypes.shape({
       label: React.PropTypes.string.isRequired,
       onNextClick: React.PropTypes.func.isRequired,
       onPreviousClick: React.PropTypes.func.isRequired
     }),
-    navStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
     onClose: React.PropTypes.func.isRequired,
     title: React.PropTypes.string
   },
@@ -107,7 +107,7 @@ const Drawer = React.createClass({
       <div style={styles.componentWrapper}>
         <div onClick={this._handleCloseClick} style={styles.scrim}></div>
         <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
-          <header style={Object.assign({}, styles.header, this.props.navStyle)}>
+          <header style={Object.assign({}, styles.header, this.props.headerStyle)}>
             <span style={styles.backArrow}>
               <Button
                 icon='arrow-left'


### PR DESCRIPTION
This PR adds the ability to style header and content sections of the `Drawer` component. It also aligns the label in the navigation with the next and previous carets.

Before
<img width="957" alt="screen shot 2016-05-12 at 10 50 56 am" src="https://cloud.githubusercontent.com/assets/9920303/15225385/76642fe2-183b-11e6-93df-46a3a9011fa0.png">

After
<img width="953" alt="screen shot 2016-05-12 at 11 04 50 am" src="https://cloud.githubusercontent.com/assets/9920303/15225388/7aec83a2-183b-11e6-8e59-3f59ab736203.png">




