### PR TITLE
DatePicker Clean-Up

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -1073,7 +1073,7 @@ const Demo = React.createClass({
 
         <br /><br />
         <DatePicker
-          closeOnDateSelect={false}
+          closeOnDateSelect={true}
           defaultDate={this.state.selectedDatePickerDate}
           onDateSelect={this._handleDateSelect}
         />

--- a/demo/app.js
+++ b/demo/app.js
@@ -545,7 +545,7 @@ const Demo = React.createClass({
       },
       lineChartData: [],
       pageIndicatorIndex: 0,
-      selectedDatePickerDate: moment().unix(),
+      selectedDatePickerDate: null,
       showDrawer: false,
       showDrawerButtonType: 'primary',
       showModal: false,
@@ -1075,7 +1075,6 @@ const Demo = React.createClass({
         <DatePicker
           closeOnDateSelect={false}
           defaultDate={this.state.selectedDatePickerDate}
-          minimumDate={this.state.selectedDatePickerDate}
           onDateSelect={this._handleDateSelect}
         />
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -1073,11 +1073,13 @@ const Demo = React.createClass({
 
         <br /><br />
         <DatePicker
-          closeOnDateSelect={true}
+          closeOnDateSelect={false}
           defaultDate={this.state.selectedDatePickerDate}
+          minimumDate={this.state.selectedDatePickerDate}
           onDateSelect={this._handleDateSelect}
-          showDayBorders={false}
         />
+
+        <br /><br />
         <SimpleInput
           placeholder='Type something'
           valid={true}

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -255,7 +255,7 @@ const DatePicker = React.createClass({
         textAlign: 'center'
       },
       calendayHeaderNav: {
-        width: 30
+        width: 35
       },
 
       //Calendar week
@@ -271,7 +271,7 @@ const DatePicker = React.createClass({
       },
       calendarWeekDay: {
         textAlign: 'center',
-        width: 30
+        width: 35
       },
 
       //Calenday table

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -34,7 +34,7 @@ const DatePicker = React.createClass({
   getInitialState () {
     return {
       currentDate: this.props.selectedDate || this.props.defaultDate || moment().unix(),
-      showCalendar: true
+      showCalendar: false
     };
   },
 
@@ -163,8 +163,8 @@ const DatePicker = React.createClass({
             </div>
             <Icon
               onClick={this._handleNextClick}
-              style={styles.calendayHeaderNav}
               size={20}
+              style={styles.calendayHeaderNav}
               type='caret-right'
             />
           </div>

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -22,7 +22,6 @@ const DatePicker = React.createClass({
   getDefaultProps () {
     return {
       closeOnDateSelect: false,
-      defaultDate: moment.unix(),
       format: 'MMM D, YYYY',
       locale: 'en',
       onDateSelect () {},
@@ -33,13 +32,13 @@ const DatePicker = React.createClass({
 
   getInitialState () {
     return {
-      currentDate: this.props.defaultDate,
+      currentDate: this.props.defaultDate || moment().unix(),
       showCalendar: false
     };
   },
 
   componentWillReceiveProps (newProps) {
-    if (newProps.defaultDate !== this.props.defaultDate) {
+    if (newProps.defaultDate && newProps.defaultDate !== this.props.defaultDate) {
       this.setState({
         currentDate: newProps.defaultDate
       });

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -137,6 +137,7 @@ const DatePicker = React.createClass({
       <div style={styles.component}>
         <div onClick={this._toggleCalendar} style={styles.selectedDateWrapper}>
           <Icon
+            size={20}
             style={styles.selectedDateIcon}
             type='calendar'
           />
@@ -144,6 +145,7 @@ const DatePicker = React.createClass({
             {(this.props.selectedDate || this.props.defaultDate) ? moment.unix(this.props.selectedDate || this.props.defaultDate).format(this.props.format) : this.props.placeholderText}
           </div>
           <Icon
+            size={20}
             style={styles.selectedDateCaret}
             type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
           />
@@ -152,6 +154,7 @@ const DatePicker = React.createClass({
           <div style={styles.calendarHeader}>
             <Icon
               onClick={this._handlePreviousClick}
+              size={20}
               type='caret-left'
             />
             <div>
@@ -159,6 +162,7 @@ const DatePicker = React.createClass({
             </div>
             <Icon
               onClick={this._handleNextClick}
+              size={20}
               type='caret-right'
             />
           </div>
@@ -206,7 +210,7 @@ const DatePicker = React.createClass({
         justifyContent: 'space-between',
         cursor: 'pointer',
         position: 'relative',
-        padding: 7
+        padding: '10px 15px'
       },
       selectedDateIcon: {
         marginRight: 5,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -16,6 +16,7 @@ const DatePicker = React.createClass({
     onDateSelect: React.PropTypes.func,
     placeholderText: React.PropTypes.string,
     primaryColor: React.PropTypes.string,
+    selectedDate: React.PropTypes.number,
     style: React.PropTypes.object
   },
 
@@ -32,13 +33,26 @@ const DatePicker = React.createClass({
 
   getInitialState () {
     return {
-      currentDate: this.props.defaultDate || moment().unix(),
+      currentDate: this.props.selectedDate || this.props.defaultDate || moment().unix(),
       showCalendar: false
     };
   },
 
+  componentDidMount () {
+    if (this.props.defaultDate) {
+      console.warn('WARNING: defaultDate has been replaced with selectedDate and will be removed in a future release. Check usage of ' + this.constructor.displayName + '.');
+    }
+  },
+
   componentWillReceiveProps (newProps) {
+    if (newProps.selectedDate && newProps.selectedDate !== this.props.selectedDate) {
+      this.setState({
+        currentDate: newProps.selectedDate
+      });
+    }
+
     if (newProps.defaultDate && newProps.defaultDate !== this.props.defaultDate) {
+      console.warn('WARNING: defaultDate has been replaced with selectedDate and will be removed in a future release. Check usage of ' + this.constructor.displayName + '.');
       this.setState({
         currentDate: newProps.defaultDate
       });
@@ -89,7 +103,7 @@ const DatePicker = React.createClass({
 
     while (moment(startDate).isBefore(endDate)) {
       const isCurrentMonth = startDate.isSame(moment.unix(this.state.currentDate), 'month');
-      const isSelectedDay = startDate.isSame(moment.unix(this.props.defaultDate), 'day');
+      const isSelectedDay = startDate.isSame(moment.unix(this.props.selectedDate || this.props.defaultDate), 'day');
       const isToday = startDate.isSame(moment(), 'day');
       const disabledDay = this.props.minimumDate ? startDate.isBefore(moment.unix(this.props.minimumDate)) : null;
 
@@ -127,7 +141,7 @@ const DatePicker = React.createClass({
             type='calendar'
           />
           <div style={styles.selectedDateText}>
-            {this.props.defaultDate ? moment.unix(this.props.defaultDate).format(this.props.format) : this.props.placeholderText}
+            {(this.props.selectedDate || this.props.defaultDate) ? moment.unix(this.props.selectedDate || this.props.defaultDate).format(this.props.format) : this.props.placeholderText}
           </div>
           <Icon
             style={styles.selectedDateCaret}
@@ -200,7 +214,7 @@ const DatePicker = React.createClass({
       },
       selectedDateText: {
         flex: '1',
-        color: this.props.defaultDate ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH
+        color: (this.props.selectedDate || this.props.defaultDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH
       },
       selectedDateCaret: {
         fill: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.ASH

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -34,7 +34,7 @@ const DatePicker = React.createClass({
   getInitialState () {
     return {
       currentDate: this.props.selectedDate || this.props.defaultDate || moment().unix(),
-      showCalendar: false
+      showCalendar: true
     };
   },
 
@@ -155,6 +155,7 @@ const DatePicker = React.createClass({
             <Icon
               onClick={this._handlePreviousClick}
               size={20}
+              style={styles.calendayHeaderNav}
               type='caret-left'
             />
             <div>
@@ -162,6 +163,7 @@ const DatePicker = React.createClass({
             </div>
             <Icon
               onClick={this._handleNextClick}
+              style={styles.calendayHeaderNav}
               size={20}
               type='caret-right'
             />
@@ -169,7 +171,7 @@ const DatePicker = React.createClass({
           <div style={styles.calendarWeek}>
             {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => {
               return (
-                <div key={i}>
+                <div key={i} style={styles.calendarWeekDay}>
                   {day}
                 </div>
               );
@@ -189,36 +191,36 @@ const DatePicker = React.createClass({
   styles () {
     return {
       component: Object.assign({
-        boxSizing: 'border-box',
         backgroundColor: StyleConstants.Colors.WHITE,
+        borderColor: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.FOG,
+        borderRadius: 3,
+        borderStyle: 'solid',
+        borderWidth: 1,
+        boxSizing: 'border-box',
         color: StyleConstants.Colors.BLACK,
         display: 'inline-block',
         fontFamily: StyleConstants.FontFamily,
         fontSize: StyleConstants.FontSizes.MEDIUM,
         position: 'relative',
-        width: '100%',
-        borderColor: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.FOG,
-        borderRadius: 3,
-        borderStyle: 'solid',
-        borderWidth: 1
+        width: '100%'
       }, this.props.style),
 
       // Selected Date styles
       selectedDateWrapper: {
-        display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-between',
         cursor: 'pointer',
-        position: 'relative',
-        padding: '10px 15px'
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '10px 15px',
+        position: 'relative'
       },
       selectedDateIcon: {
-        marginRight: 5,
-        fill: this.props.primaryColor
+        fill: this.props.primaryColor,
+        marginRight: 5
       },
       selectedDateText: {
-        flex: '1',
-        color: (this.props.selectedDate || this.props.defaultDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH
+        color: (this.props.selectedDate || this.props.defaultDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH,
+        flex: 1
       },
       selectedDateCaret: {
         fill: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.ASH
@@ -242,47 +244,54 @@ const DatePicker = React.createClass({
 
       //Calendar Header
       calendarHeader: {
-        display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-between',
         color: StyleConstants.Colors.CHARCOAL,
+        display: 'flex',
         fontSize: StyleConstants.FontSizes.LARGE,
-        marginBottom: 15,
         height: 30,
+        justifyContent: 'space-between',
+        marginBottom: 15,
         position: 'relative',
         textAlign: 'center'
+      },
+      calendayHeaderNav: {
+        width: 30
       },
 
       //Calendar week
       calendarWeek: {
-        display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-around',
         color: StyleConstants.Colors.ASH,
+        display: 'flex',
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
         fontSize: StyleConstants.FontSizes.SMALL,
         height: 30,
+        justifyContent: 'space-around',
         marginBottom: 2
+      },
+      calendarWeekDay: {
+        textAlign: 'center',
+        width: 30
       },
 
       //Calenday table
       calendarTable: {
+        alignItems: 'center',
         display: 'flex',
         flexWrap: 'wrap',
-        alignItems: 'center',
         justifyContent: 'space-around'
       },
       calendarDay: {
-        boxSizing: 'border-box',
-        display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
-        color: StyleConstants.Colors.FOG,
         borderRadius: 3,
-        height: 30,
-        width: 35,
-        maringBottom: 2,
+        boxSizing: 'border-box',
+        color: StyleConstants.Colors.FOG,
         cursor: 'pointer',
+        display: 'flex',
+        height: 30,
+        justifyContent: 'center',
+        maringBottom: 2,
+        width: 35,
 
         ':hover': {
           border: '1px solid' + this.props.primaryColor
@@ -298,8 +307,8 @@ const DatePicker = React.createClass({
       },
 
       today: {
-        color: StyleConstants.Colors.WHITE,
-        backgroundColor: StyleConstants.Colors.FOG
+        backgroundColor: StyleConstants.Colors.FOG,
+        color: StyleConstants.Colors.WHITE
       },
       currentMonth: {
         color: StyleConstants.Colors.CHARCOAL
@@ -310,12 +319,12 @@ const DatePicker = React.createClass({
       },
 
       scrim: {
-        position: 'fixed',
-        zIndex: 9,
-        top: 0,
-        right: 0,
         bottom: 0,
-        left: 0
+        left: 0,
+        position: 'fixed',
+        right: 0,
+        top: 0,
+        zIndex: 9
       }
     };
   }


### PR DESCRIPTION
This cleans up the DatePicker and fixes some styling when used without box sizing. This also changes all date props/state to a unix timestamp for consistency.

- Set currentDate to props.defaultDate or moment().unix()
- Add check for new defaultDate prop
- Remove inputValue and selectedDate states
- On click, sets current date to unix timestamp and calls onDateSelect prop 
- Move _renderDayTiles to inside the main render
- Clean up renderCalendarTable to use unix timestamps
- Clean up styling of days
- Use flex for centering

Follows up on https://github.com/mxenabled/mx-react-components/issues/280

![screen shot 2016-05-12 at 2 33 24 pm](https://cloud.githubusercontent.com/assets/488916/15229686/6ae42686-184f-11e6-9e98-28c12ab94c0c.png)
![screen shot 2016-05-12 at 2 33 30 pm](https://cloud.githubusercontent.com/assets/488916/15229688/6ae75932-184f-11e6-8095-bfc4e5bd75fc.png)
![screen shot 2016-05-12 at 2 33 37 pm](https://cloud.githubusercontent.com/assets/488916/15229687/6ae52392-184f-11e6-8d4d-857489b518e5.png)
