### PR TITLE
Typo in DatePicker

### DIFF
--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -290,7 +290,7 @@ const DatePicker = React.createClass({
         display: 'flex',
         height: 30,
         justifyContent: 'center',
-        maringBottom: 2,
+        marginBottom: 2,
         width: 35,
 
         ':hover': {


### PR DESCRIPTION
@jmophoto I didn't notice this typo in https://github.com/mxenabled/mx-react-components/pull/306. It's pretty noticeable when styling the DateRangePicker.