### PR TITLE
Refactor of ToggleSwitch for animations, default icons and more style control

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -952,7 +952,7 @@ const Demo = React.createClass({
 
         <br /><br /><br /><br />
         <div>
-          <ToggleSwitch />
+          <ToggleSwitch showLabels={true} />
         </div>
 
         <br /><br />

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -1,89 +1,59 @@
 const React = require('react');
 const Radium = require('radium');
 const StyleConstants = require('../constants/Style');
+const Icon = require('./Icon');
 
 const ToggleSwitch = React.createClass({
   propTypes: {
-    activeColor: React.PropTypes.string,
-    children: React.PropTypes.node,
-    componentStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
-    defaultPosition: React.PropTypes.oneOf(['left', 'right']),
-    inactiveColor: React.PropTypes.string,
-    labelStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
+    checked: React.PropTypes.bool,
+    checkedByDefault: React.PropTypes.bool,
+    falseIcon: React.PropTypes.element,
     leftLabel: React.PropTypes.string,
     onToggle: React.PropTypes.func,
     rightLabel: React.PropTypes.string,
+    showIcons: React.PropTypes.bool,
     showLabels: React.PropTypes.bool,
-    toggleStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
-    trackStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ])
+    styles: React.PropTypes.object,
+    trueIcon: React.PropTypes.element
   },
 
   getDefaultProps () {
     return {
-      activeColor: StyleConstants.Colors.PRIMARY,
-      defaultPosition: 'left',
-      inactiveColor: StyleConstants.Colors.FOG,
-      leftLabel: 'On',
+      checkedByDefault: false,
+      leftLabel: 'Off',
       onToggle () {},
-      rightLabel: 'Off',
-      showLabels: true,
-      toggleStyle: {},
-      trackStyle: {}
+      rightLabel: 'On',
+      showLabels: false,
+      showIcons: true,
+      styles: {}
     };
   },
 
   getInitialState () {
+    let checked = false;
+
+    if ('checked' in this.props) {
+      checked = this.props.checked;
+    } else if ('checkedByDefault' in this.props) {
+      checked = this.props.checkedByDefault;
+    }
     return {
-      activePosition: this.props.defaultPosition
+      checked: !!checked
     };
   },
 
-  _handleLeftLabelClick () {
-    const activePosition = 'left';
-
-    this.setState({
-      activePosition
-    });
-
-    this.props.onToggle(activePosition);
-  },
-
-  _handleRightLabelClick () {
-    const activePosition = 'right';
-
-    this.setState({
-      activePosition
-    });
-
-    this.props.onToggle(activePosition);
-  },
-
   _handleToggle (event) {
-    const activePosition = this.state.activePosition === 'left' ? 'right' : 'left';
-
     this.setState({
-      activePosition
+      checked: !this.state.checked
+    }, () => {
+      this.props.onToggle(this.state.checked, event);
     });
-
-    this.props.onToggle(activePosition, event);
   },
 
   _renderLeftLabel (styles) {
     if (this.props.showLabels) {
       return (
-        <span className='left-label' onClick={this._handleLeftLabelClick} style={[styles.label, this.props.labelStyle, this.state.activePosition === 'left' && styles.activeLabel || styles.inactiveLabel]}>{this.props.leftLabel}</span>
+        <span className='left-label' onClick={this._handleToggle} style={[styles.label, !this.state.checked && styles.activeLabel || styles.inactiveLabel]}>{this.props.leftLabel}</span>
       );
     } else {
       return null;
@@ -93,73 +63,103 @@ const ToggleSwitch = React.createClass({
   _renderRightLabel (styles) {
     if (this.props.showLabels) {
       return (
-        <span className='right-label' onClick={this._handleRightLabelClick} style={[styles.label, this.props.labelStyle, this.state.activePosition === 'right' && styles.activeLabel || styles.inactiveLabel]}>{this.props.rightLabel}</span>
+        <span className='right-label' onClick={this._handleToggle} style={[styles.label, this.state.checked && styles.activeLabel || styles.inactiveLabel]}>{this.props.rightLabel}</span>
       );
     } else {
       return null;
     }
   },
 
-  _getChildren () {
-    // Let all the children of the toggle switch be aware of the activePosition
-    return React.Children.map(this.props.children, child => {
-      return React.cloneElement(child, { activePosition: this.state.activePosition });
-    });
+  _renderIcons (styles) {
+    if (!this.props.showIcons) {
+      return null;
+    }
+    let trueIcon = this.props.trueIcon ? this.props.trueIcon : <Icon className='true-icon' style={Object.assign({}, styles.icon, styles.trueIcon)} type='check-skinny' />;
+    let falseIcon = this.props.falseIcon ? this.props.falseIcon : <Icon className='false-icon' style={Object.assign({}, styles.icon, styles.falseIcon)} type='close-skinny' />;
+
+    return (
+      <span>
+        {trueIcon} {falseIcon}
+      </span>
+    );
   },
 
   render () {
-    const styles = {
-      activeLabel: {
-        color: this.props.activeColor
-      },
+    const styles = Object.assign({}, {
       component: {
         display: 'inline-block',
         fontFamily: StyleConstants.FontFamily,
         fontSize: '12px',
         position: 'relative'
       },
-      inactiveLabel: {
-        color: this.props.inactiveColor
+      icon: {
+        fill: StyleConstants.Colors.WHITE,
+        position: 'absolute',
+        top: '0px',
+        zIndex: 2
+      },
+      trueIcon: {
+        left: '0px'
+      },
+      falseIcon: {
+        right: '0px'
       },
       label: {
         cursor: 'pointer',
         fontWeight: 'bold'
       },
-      left: {
-        left: this.props.trackStyle.padding || '2px',
-        transition: 'all .1s'
+      inactiveLabel: {
+        color: StyleConstants.Colors.FOG
       },
-      right: {
-        right: this.props.trackStyle.padding || '2px',
-        transition: 'all .1s'
+      activeLabel: {
+        color: StyleConstants.Colors.PRIMARY
       },
       toggle: {
         backgroundColor: StyleConstants.Colors.WHITE,
         borderRadius: '100%',
-        height: this.props.toggleStyle.height || '20px',
+        height: '20px',
         position: 'absolute',
-        width: this.props.toggleStyle.width || '20px'
+        width: '20px',
+        transition: 'all 0.5s ease',
+        zIndex: 3
+      },
+      falseToggle: {
+        left: '2px'
+      },
+      trueToggle: {
+        left: '20px'
       },
       track: {
-        backgroundColor: StyleConstants.Colors.FOG,
-        borderRadius: this.props.trackStyle.height || '20px',
+        borderRadius: '20px',
         cursor: 'pointer',
         display: 'inline-block',
-        height: this.props.trackStyle.height || '20px',
+        height: '20px',
         margin: '0 10px',
-        padding: this.props.trackStyle.padding || '2px',
+        padding: '2px',
         position: 'relative',
+        transition: 'all 0.5s ease',
         verticalAlign: 'middle',
-        width: this.props.trackStyle.width || '38px'
+        width: '38px',
+        zIndex: 1
+      },
+      trueTrack: {
+        backgroundColor: StyleConstants.Colors.CHARCOAL
+      },
+      falseTrack: {
+        backgroundColor: StyleConstants.Colors.ASH
       }
-    };
+    }, this.props.styles);
 
     return (
-      <div className='toggle-switch-component' style={[styles.component, this.props.componentStyle]}>
+      <div className='toggle-switch-component' style={styles.component}>
         {this._renderLeftLabel(styles)}
-        <div className='toggle-switch-track' onClick={this._handleToggle} style={[styles.track, this.props.trackStyle]} >
-          <div className='toggle-switch-toggle' style={[styles.toggle, styles[this.state.activePosition], this.props.toggleStyle]}></div>
-          {this._getChildren()}
+        <div
+          className='toggle-switch-track'
+          onClick={this._handleToggle}
+          style={Object.assign({}, styles.track, styles[this.state.checked + 'Track'])}
+        >
+          <div className='toggle-switch-toggle' style={Object.assign({}, styles.toggle, styles[this.state.checked + 'Toggle'])}></div>
+          {this._renderIcons(styles)}
         </div>
         {this._renderRightLabel(styles)}
       </div>

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -18,7 +18,7 @@ const ToggleSwitch = React.createClass({
 
   getDefaultProps () {
     return {
-      checkedByDefault: false,
+      checked: false,
       leftLabel: 'Off',
       onToggle () {},
       rightLabel: 'On',
@@ -29,13 +29,8 @@ const ToggleSwitch = React.createClass({
   },
 
   getInitialState () {
-    let checked = false;
-
-    if ('checked' in this.props) {
-      checked = this.props.checked;
-    }
     return {
-      checked: !!checked
+      checked: this.props.checked
     };
   },
 
@@ -82,7 +77,26 @@ const ToggleSwitch = React.createClass({
   },
 
   render () {
-    const styles = Object.assign({}, {
+    const styles = this.styles();
+
+    return (
+      <div className='toggle-switch-component' style={styles.component}>
+        {this._renderLeftLabel(styles)}
+        <div
+          className='toggle-switch-track'
+          onClick={this._handleToggle}
+          style={Object.assign({}, styles.track, styles[this.state.checked + 'Track'])}
+        >
+          <div className='toggle-switch-toggle' style={Object.assign({}, styles.toggle, styles[this.state.checked + 'Toggle'])}></div>
+          {this._renderIcons(styles)}
+        </div>
+        {this._renderRightLabel(styles)}
+      </div>
+    );
+  },
+
+  styles () {
+    return Object.assign({}, {
       component: {
         display: 'inline-block',
         fontFamily: StyleConstants.FontFamily,
@@ -146,22 +160,8 @@ const ToggleSwitch = React.createClass({
         backgroundColor: StyleConstants.Colors.ASH
       }
     }, this.props.style);
-
-    return (
-      <div className='toggle-switch-component' style={styles.component}>
-        {this._renderLeftLabel(styles)}
-        <div
-          className='toggle-switch-track'
-          onClick={this._handleToggle}
-          style={Object.assign({}, styles.track, styles[this.state.checked + 'Track'])}
-        >
-          <div className='toggle-switch-toggle' style={Object.assign({}, styles.toggle, styles[this.state.checked + 'Toggle'])}></div>
-          {this._renderIcons(styles)}
-        </div>
-        {this._renderRightLabel(styles)}
-      </div>
-    );
   }
+
 });
 
 module.exports = Radium(ToggleSwitch);

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -6,14 +6,13 @@ const Icon = require('./Icon');
 const ToggleSwitch = React.createClass({
   propTypes: {
     checked: React.PropTypes.bool,
-    checkedByDefault: React.PropTypes.bool,
     falseIcon: React.PropTypes.element,
     leftLabel: React.PropTypes.string,
     onToggle: React.PropTypes.func,
     rightLabel: React.PropTypes.string,
     showIcons: React.PropTypes.bool,
     showLabels: React.PropTypes.bool,
-    styles: React.PropTypes.object,
+    style: React.PropTypes.object,
     trueIcon: React.PropTypes.element
   },
 
@@ -25,7 +24,7 @@ const ToggleSwitch = React.createClass({
       rightLabel: 'On',
       showLabels: false,
       showIcons: true,
-      styles: {}
+      style: {}
     };
   },
 
@@ -34,8 +33,6 @@ const ToggleSwitch = React.createClass({
 
     if ('checked' in this.props) {
       checked = this.props.checked;
-    } else if ('checkedByDefault' in this.props) {
-      checked = this.props.checkedByDefault;
     }
     return {
       checked: !!checked
@@ -74,8 +71,8 @@ const ToggleSwitch = React.createClass({
     if (!this.props.showIcons) {
       return null;
     }
-    const trueIcon = this.props.trueIcon ? this.props.trueIcon : <Icon className='true-icon' style={Object.assign({}, styles.icon, styles.trueIcon)} type='check-skinny' />;
-    const falseIcon = this.props.falseIcon ? this.props.falseIcon : <Icon className='false-icon' style={Object.assign({}, styles.icon, styles.falseIcon)} type='close-skinny' />;
+    const trueIcon = this.props.trueIcon || <Icon className='true-icon' style={Object.assign({}, styles.icon, styles.trueIcon)} type='check-skinny' />;
+    const falseIcon = this.props.falseIcon || <Icon className='false-icon' style={Object.assign({}, styles.icon, styles.falseIcon)} type='close-skinny' />;
 
     return (
       <span>
@@ -148,7 +145,7 @@ const ToggleSwitch = React.createClass({
       falseTrack: {
         backgroundColor: StyleConstants.Colors.ASH
       }
-    }, this.props.styles);
+    }, this.props.style);
 
     return (
       <div className='toggle-switch-component' style={styles.component}>

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -74,8 +74,8 @@ const ToggleSwitch = React.createClass({
     if (!this.props.showIcons) {
       return null;
     }
-    let trueIcon = this.props.trueIcon ? this.props.trueIcon : <Icon className='true-icon' style={Object.assign({}, styles.icon, styles.trueIcon)} type='check-skinny' />;
-    let falseIcon = this.props.falseIcon ? this.props.falseIcon : <Icon className='false-icon' style={Object.assign({}, styles.icon, styles.falseIcon)} type='close-skinny' />;
+    const trueIcon = this.props.trueIcon ? this.props.trueIcon : <Icon className='true-icon' style={Object.assign({}, styles.icon, styles.trueIcon)} type='check-skinny' />;
+    const falseIcon = this.props.falseIcon ? this.props.falseIcon : <Icon className='false-icon' style={Object.assign({}, styles.icon, styles.falseIcon)} type='close-skinny' />;
 
     return (
       <span>
@@ -95,14 +95,14 @@ const ToggleSwitch = React.createClass({
       icon: {
         fill: StyleConstants.Colors.WHITE,
         position: 'absolute',
-        top: '0px',
+        top: 0,
         zIndex: 2
       },
       trueIcon: {
-        left: '0px'
+        left: 0
       },
       falseIcon: {
-        right: '0px'
+        right: 0
       },
       label: {
         cursor: 'pointer',


### PR DESCRIPTION
- New styles property that allows you to just override any key in the style const in the render functions.
- Changed the concept of 'left' and 'right' to just a boolean being stored as this is a glorified checkbox. 
- Allow custom Icons to be passed in via props instead of children.
- Some default animations and style changes to match the renderings from product.

Before: 
![ezgif com-video-to-gif 4](https://cloud.githubusercontent.com/assets/758371/15329883/a52b8b38-1c17-11e6-9bed-12829d77b423.gif)

After:
![ezgif com-video-to-gif 5](https://cloud.githubusercontent.com/assets/758371/15329889/ab08e870-1c17-11e6-9fd1-cb9e874a6568.gif)

