### PR TITLE
Add border to Drawer component

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -132,6 +132,8 @@ const Drawer = React.createClass({
   styles () {
     return {
       component: {
+        border: '1px solid ' + StyleConstants.Colors.FOG,
+        boxSizing: 'border-box',
         zIndex: 1001,
         top: 0,
         bottom: 0,


### PR DESCRIPTION
#### Issue

The edges of the drawer component were being lost/washed out in the case where the surrounding content was a similar color.

#### Solution

After a discussion with product, it was decided to add a border to the drawer component.  This PR does just that.  It also add box sizing to ensure that the border on the right side of the drawer is not cut off by the edge of it's containing element.

NOTE: It was hard to see the border in the screen shot so I've changed the border color to CHARCOAL in the after image to better illustrate the change.  The actual border color in the PR is FOG.  It is also important to note that this border can be over written via the style prop for the component.

#### Before

![screen shot 2016-05-20 at 3 15 59 pm](https://cloud.githubusercontent.com/assets/6463914/15442458/926ff69e-1e9e-11e6-9e12-4dbcd47e042c.png)


#### After

![screen shot 2016-05-20 at 3 17 26 pm](https://cloud.githubusercontent.com/assets/6463914/15442460/9856c542-1e9e-11e6-9f2a-3284c0da1109.png)
