### PR TITLE
DonutChart: Return Event on click and name transitions

### DIFF
--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -41,7 +41,7 @@ const DonutChart = React.createClass({
       activeIndex: -1,
       activeOffset: 0,
       animateOnHover: false,
-      animationDuration: 5000,
+      animationDuration: 500,
       arcWidth: 10,
       baseArcColor: StyleConstants.Colors.BASE_ARC,
       colors: [StyleConstants.Colors.PRIMARY].concat(d3.scale.category20().range()),

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -41,7 +41,7 @@ const DonutChart = React.createClass({
       activeIndex: -1,
       activeOffset: 0,
       animateOnHover: false,
-      animationDuration: 500,
+      animationDuration: 5000,
       arcWidth: 10,
       baseArcColor: StyleConstants.Colors.BASE_ARC,
       colors: [StyleConstants.Colors.PRIMARY].concat(d3.scale.category20().range()),
@@ -147,17 +147,17 @@ const DonutChart = React.createClass({
     const nextArcData = this.state.values[nextActiveIndex];
 
     if (currentArcData) {
-      d3.select(this.refs['arc-' + this.props.id + currentActiveIndex]).transition().duration(200).attr('d', this.state.standardArc(currentArcData));
+      d3.select(this.refs['arc-' + this.props.id + currentActiveIndex]).transition('currentArc').duration(200).attr('d', this.state.standardArc(currentArcData));
     }
 
     if (nextArcData) {
-      d3.select(this.refs['arc-' + this.props.id + nextActiveIndex]).transition().duration(200).attr('d', this.state.hoveredArc(nextArcData));
+      d3.select(this.refs['arc-' + this.props.id + nextActiveIndex]).transition('nextArc').duration(200).attr('d', this.state.hoveredArc(nextArcData));
     }
   },
 
   _bounceAnimate () {
     d3.selectAll('.arc-' + this.props.id)
-      .transition()
+      .transition('bounce')
       .ease(t => {
         // See Penner's Equation and D3 docs on custom easing function
         // for details on variable names.
@@ -209,7 +209,7 @@ const DonutChart = React.createClass({
 
   _rollAnimate () {
     d3.selectAll('.arc-' + this.props.id)
-      .transition()
+      .transition('roll')
       .duration(this.props.animationDuration)
       .attrTween('transform', function () {
         return d3.interpolateString('rotate(0)', 'rotate(360)');
@@ -222,7 +222,7 @@ const DonutChart = React.createClass({
 
   _handleMouseEnter (point) {
     if (this.props.animateOnHover && this.state.activeIndex !== point.index) {
-      d3.select(this.refs[point.ref]).transition().duration(200).attr('d', this.state.hoveredArc(point.arc));
+      d3.select(this.refs[point.ref]).transition('mouseEnter').duration(200).attr('d', this.state.hoveredArc(point.arc));
     }
 
     this.props.onMouseEnter(this.props.data[point.index], point.index);
@@ -234,7 +234,7 @@ const DonutChart = React.createClass({
 
   _handleMouseLeave (point) {
     if (this.props.animateOnHover) {
-      d3.select(this.refs[point.ref]).transition().duration(200).attr('d', this.state.standardArc(point.arc));
+      d3.select(this.refs[point.ref]).transition('mouseLeave').duration(200).attr('d', this.state.standardArc(point.arc));
     }
 
     this.props.onMouseLeave();

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -216,8 +216,8 @@ const DonutChart = React.createClass({
       });
   },
 
-  _handleClick (index) {
-    this.props.onClick(this.props.data[index]);
+  _handleClick (index, event) {
+    this.props.onClick(this.props.data[index], event);
   },
 
   _handleMouseEnter (point) {


### PR DESCRIPTION
This adds the click event to the on click so it can be passed back to the parent component. This allows for an `e.stopPropogation` to be called.

Also names the different D3 transitions so they are not interrupted when more than one is called.

Before:
![donut_before](https://cloud.githubusercontent.com/assets/488916/15477157/715794e2-20d0-11e6-8caf-89cc6a9cc5e2.gif)

After:
![donut_after](https://cloud.githubusercontent.com/assets/488916/15477160/75de18a6-20d0-11e6-8fb8-9d938066cdc9.gif)
