### PR TITLE
Fix fontFamily for Drawer header

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -190,7 +190,7 @@ const Drawer = React.createClass({
         borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
         color: StyleConstants.Colors.ASH,
         display: 'flex',
-        fontFamily: StyleConstants.Fonts.NORMAL,
+        fontFamily: StyleConstants.Fonts.REGULAR,
         fontSize: StyleConstants.FontSizes.LARGE,
         justifyContent: 'center',
         padding: '7px 7px',


### PR DESCRIPTION
When I updated the Drawer component last, I accidentally used a bad key name for getting the regular font for the Drawer component header. I used `NORMAL` but it should have been `REGULAR`.  

See `Style` constants file for reference here. https://github.com/mxenabled/mx-react-components/blob/master/src/constants/Style.js#L41 