### PR TITLE
Drawer header color change

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -186,7 +186,7 @@ const Drawer = React.createClass({
       },
       header: {
         alignItems: 'center',
-        backgroundColor: StyleConstants.Colors.PORCELAIN,
+        backgroundColor: StyleConstants.Colors.WHITE,
         borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
         color: StyleConstants.Colors.ASH,
         display: 'flex',


### PR DESCRIPTION
Change default drawer header from Porcelain to White to prevent need for local overrides.