### PR TITLE
BarChat: Adds different colors to individual bars

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -1157,53 +1157,64 @@ const Demo = React.createClass({
           ) : null}
           <BarChart
             animateOnHover={true}
-            colorWhenClicked='#359BCF'
             data={[
               {
+                color: '#E3E6E7',
                 label: 'Jan',
                 value: 125.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Feb',
                 value: 545.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Mar',
                 value: 789.25
               },
               {
+                color: '#359BCF',
                 label: 'Apr',
                 value: 254.25
               },
               {
+                color: '#E3E6E7',
                 label: 'May',
                 value: 782.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Jun',
                 value: 1200.75
               },
               {
+                color: '#E3E6E7',
                 label: 'Jul',
                 value: 852.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Aug',
                 value: 965.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Sep',
                 value: 145.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Oct',
                 value: 987.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Nov',
                 value: 633.25
               },
               {
+                color: '#E3E6E7',
                 label: 'Dec',
                 value: 1248.25
               }

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -18,9 +18,7 @@ const SetIntervalMixin = {
 const Rect = React.createClass({
   propTypes: {
     animateOnHover: React.PropTypes.bool,
-    clickedRect: React.PropTypes.object,
     color: React.PropTypes.string,
-    colorWhenClicked: React.PropTypes.string,
     height: React.PropTypes.number.isRequired,
     hoverColor: React.PropTypes.string,
     label: React.PropTypes.string,
@@ -76,22 +74,12 @@ const Rect = React.createClass({
     });
   },
 
-  _getColor () {
-    if (this.props.clickedRect.label === this.props.label && this.props.clickedRect.value === this.props.value) {
-      return this.props.colorWhenClicked;
-    } else if (this.state.hovering && this.props.hoverColor) {
-      return this.props.hoverColor;
-    } else {
-      return this.props.color;
-    }
-  },
-
   render () {
     const animateHeight = d3.ease('back-out', 0.5);
     const height = this.props.height * animateHeight(Math.min(1, this.state.milliseconds / 1000));
     const y = this.props.height - height + this.props.y;
     const style = {
-      fill: this._getColor(),
+      fill: this.state.hovering && this.props.hoverColor ? this.props.hoverColor : this.props.color,
       cursor: 'pointer'
     };
 
@@ -114,8 +102,6 @@ const Rect = React.createClass({
 const BarChart = React.createClass({
   propTypes: {
     animateOnHover: React.PropTypes.bool,
-    color: React.PropTypes.string,
-    colorWhenClicked: React.PropTypes.string,
     data: React.PropTypes.array.isRequired,
     height: React.PropTypes.number,
     hoverColor: React.PropTypes.string,
@@ -127,8 +113,6 @@ const BarChart = React.createClass({
   getDefaultProps () {
     return {
       animateOnHover: false,
-      color: StyleConstants.Colors.ASH,
-      colorWhenClicked: StyleConstants.Colors.ASH,
       height: 300,
       hoverColor: StyleConstants.Colors.PRIMARY,
       onClick: () => {},
@@ -137,28 +121,8 @@ const BarChart = React.createClass({
     };
   },
 
-  getInitialState () {
-    return {
-      clickedRect: {
-        label: null,
-        value: null
-      }
-    };
-  },
-
-  shouldComponentUpdate (nextProps, nextState) {
-    return !_isEqual(nextProps, this.props) || !_isEqual(nextState, this.state);
-  },
-
-  _handleOnClick (value, label) {
-    this.props.onClick(value, label);
-
-    this.setState({
-      clickedRect: {
-        label,
-        value
-      }
-    });
+  shouldComponentUpdate (nextProps) {
+    return !_isEqual(nextProps, this.props);
   },
 
   _renderLabels (barWidth) {
@@ -207,14 +171,12 @@ const BarChart = React.createClass({
       return (
         <Rect
           animateOnHover={this.props.animateOnHover}
-          clickedRect={this.state.clickedRect}
-          color={this.props.color}
-          colorWhenClicked={this.props.colorWhenClicked}
+          color={this.props.data[index].color}
           height={height}
           hoverColor={this.props.hoverColor}
           key={index * point}
           label={this.props.data[index].label}
-          onClick={this._handleOnClick}
+          onClick={this.props.onClick}
           onHover={this.props.onHover}
           value={point}
           width={barWidth}


### PR DESCRIPTION
This PR allows users of the `BarChart` component to specify different colors for individual bars in the chart. Color for each dataset is passed as a property in the data `prop`:

 ```javascript
data: [
  {
    label: 'Jan',
    value: 123.34,
    color: '#359BCF'
  },
  {
    ...
  }
]
```
<img width="737" alt="screen shot 2016-05-27 at 11 01 29 pm" src="https://cloud.githubusercontent.com/assets/9920303/15625308/0a5b2406-245f-11e6-8fb8-cc414726b717.png">
