### PR TITLE
Add Radio Button Component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -18,6 +18,7 @@ const {
   Loader,
   Modal,
   PageIndicator,
+  RadioButton,
   RangeSelector,
   SearchInput,
   Select,
@@ -557,6 +558,7 @@ const Demo = React.createClass({
       },
       lineChartData: [],
       pageIndicatorIndex: 0,
+      radioChecked: false,
       selectedDatePickerDate: null,
       showDrawer: false,
       showDrawerButtonType: 'primary',
@@ -743,6 +745,12 @@ const Demo = React.createClass({
       barchartHoverValue,
       barchartX,
       barchartY
+    });
+  },
+
+  _handleRadioButtonClick () {
+    this.setState({
+      radioChecked: !this.state.radioChecked
     });
   },
 
@@ -1091,6 +1099,10 @@ const Demo = React.createClass({
         <div style={{ padding: '100px', position: 'relative' }}>
           <Loader isLoading={true} isRelative={true} />
         </div>
+
+        <br /><br />
+        <RadioButton checked={this.state.radioChecked} onClick={this._handleRadioButtonClick}>On</RadioButton>
+        <RadioButton checked={!this.state.radioChecked} onClick={this._handleRadioButtonClick}>Off</RadioButton>
 
         <br /><br />
         <DatePicker

--- a/src/Index.js
+++ b/src/Index.js
@@ -12,6 +12,7 @@ module.exports = {
   Loader: require('./components/Loader'),
   Modal: require('./components/Modal'),
   PageIndicator: require('./components/PageIndicator'),
+  RadioButton: require('./components/RadioButton'),
   RajaIcon: require('./components/RajaIcon'),
   RangeSelector: require('./components/RangeSelector'),
   SearchInput: require('./components/SearchInput'),

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -7,12 +7,14 @@ const RadioButton = React.createClass({
     activeButtonStyle: React.PropTypes.object,
     buttonStyle: React.PropTypes.object,
     checked: React.PropTypes.bool,
+    color: React.PropTypes.string,
     onClick: React.PropTypes.func,
     style: React.PropTypes.object
   },
 
   getDefaultProps () {
     return {
+      color: StyleConstants.Colors.PRIMARY,
       onClick: () => {}
     };
   },
@@ -52,7 +54,7 @@ const RadioButton = React.createClass({
         width: '60%',
         height: '60%',
         borderRadius: '100%',
-        backgroundColor: StyleConstants.Colors.PRIMARY
+        backgroundColor: this.props.color
       }, this.props.activeButtonStyle)
     };
   }

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -1,0 +1,61 @@
+const React = require('react');
+
+const StyleConstants = require('../constants/Style');
+
+const RadioButton = React.createClass({
+  propTypes: {
+    activeStyle: React.PropTypes.object,
+    checked: React.PropTypes.bool,
+    onClick: React.PropTypes.func,
+    style: React.PropTypes.object
+  },
+
+  getDefaultProps () {
+    return {
+      onClick: () => {}
+    };
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div onClick={this.props.onClick} style={styles.component}>
+        <div style={styles.radioButton}>
+          {this.props.checked ? <div style={styles.radioButtonActive}></div> : null}
+        </div>
+        <div style={styles.children}>{this.props.children}</div>
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: {
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        width: '100%'
+      },
+      radioButton: Object.assign({}, {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 15,
+        height: 15,
+        marginRight: 5,
+        border: '1px solid ' + StyleConstants.Colors.FOG,
+        borderRadius: '100%',
+        backgroundColor: StyleConstants.Colors.WHITE
+      }, this.props.style),
+      radioButtonActive: Object.assign({}, {
+        width: '60%',
+        height: '60%',
+        borderRadius: '100%',
+        backgroundColor: StyleConstants.Colors.PRIMARY
+      }, this.props.activeStyle)
+    };
+  }
+});
+
+module.exports = RadioButton;

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -4,7 +4,8 @@ const StyleConstants = require('../constants/Style');
 
 const RadioButton = React.createClass({
   propTypes: {
-    activeStyle: React.PropTypes.object,
+    activeButtonStyle: React.PropTypes.object,
+    buttonStyle: React.PropTypes.object,
     checked: React.PropTypes.bool,
     onClick: React.PropTypes.func,
     style: React.PropTypes.object
@@ -31,11 +32,11 @@ const RadioButton = React.createClass({
 
   styles () {
     return {
-      component: {
+      component: Object.assign({}, {
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center'
-      },
+      }, this.props.style),
       radioButton: Object.assign({}, {
         display: 'flex',
         alignItems: 'center',
@@ -46,13 +47,13 @@ const RadioButton = React.createClass({
         border: '1px solid ' + StyleConstants.Colors.FOG,
         borderRadius: '100%',
         backgroundColor: StyleConstants.Colors.WHITE
-      }, this.props.style),
+      }, this.props.buttonStyle),
       radioButtonActive: Object.assign({}, {
         width: '60%',
         height: '60%',
         borderRadius: '100%',
         backgroundColor: StyleConstants.Colors.PRIMARY
-      }, this.props.activeStyle)
+      }, this.props.activeButtonStyle)
     };
   }
 });

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -34,8 +34,7 @@ const RadioButton = React.createClass({
       component: {
         cursor: 'pointer',
         display: 'flex',
-        alignItems: 'center',
-        width: '100%'
+        alignItems: 'center'
       },
       radioButton: Object.assign({}, {
         display: 'flex',


### PR DESCRIPTION
This adds a radio button component.

Use:
```<RadioButton checked={true} onClick={this._handleClick}>Label</RadioButton>```

Props:
`activeStyle`: Object to override default styling of the active disc in the button
`checked`: Boolean to hide/show active disc in button
`onClick`: Callback when component is clicked
`style`: Object to override default styling of button

The component also accepts children and will display them in a div centered on the button. This can be used for labels, etc.

Default styling:
![screen shot 2016-05-31 at 3 12 49 pm](https://cloud.githubusercontent.com/assets/488916/15691337/4b8684f0-2745-11e6-8c56-96c5d5ad9881.png)

Style overriding to make it big and ugly:
![screen shot 2016-05-31 at 3 17 10 pm](https://cloud.githubusercontent.com/assets/488916/15691352/5fd05e40-2745-11e6-89a7-51932ad5b491.png)

