### PR TITLE
SimpleSelect Component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -866,7 +866,7 @@ const Demo = React.createClass({
                 { text: 'Menu Item 3' }
               ]}
               onScrimClick={this._handleSimpleSelectClick}
-              showItems={this.state.showSimpleSelectItems}
+              showMenu={this.state.showSimpleSelectItems}
             />
           </div>
         </div>

--- a/demo/app.js
+++ b/demo/app.js
@@ -856,7 +856,9 @@ const Demo = React.createClass({
               icon='gear'
               onClick={this._handleSimpleSelectClick}
               type='base'
-            >This is a menu Button</Button>
+            >
+              This is a menu Button
+            </Button>
             <SimpleSelect
               items={[
                 { text: 'Menu Item 1' },

--- a/demo/app.js
+++ b/demo/app.js
@@ -859,10 +859,14 @@ const Demo = React.createClass({
           <SimpleSelect
             align='right'
             items={[
-              { text: 'Menu Item 1' },
+              {
+                icon: 'add',
+                text: 'Menu Item 1'
+              },
               { text: 'Menu Item 2' },
               { text: 'Menu Item 3' }
             ]}
+            onScrimClick={this._handleSimpleSelectClick}
             showItems={this.state.showSimpleSelectItems}
           />
         </div>

--- a/demo/app.js
+++ b/demo/app.js
@@ -23,6 +23,7 @@ const {
   Select,
   SelectFullScreen,
   SimpleInput,
+  SimpleSelect,
   TimeBasedLineChart,
   ToggleSwitch,
   TypeAhead
@@ -561,6 +562,7 @@ const Demo = React.createClass({
       showDrawer: false,
       showDrawerButtonType: 'primary',
       showModal: false,
+      showSimpleSelectItems: false,
       showSmallModal: false,
       uploadedFile: null,
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
@@ -694,6 +696,12 @@ const Demo = React.createClass({
   _handleSpinnerWithTextClick () {
     this.setState({
       spinnerWithTextIsActive: !this.state.spinnerWithTextIsActive
+    });
+  },
+
+  _handleSimpleSelectClick () {
+    this.setState({
+      showSimpleSelectItems: !this.state.showSimpleSelectItems
     });
   },
 
@@ -841,6 +849,21 @@ const Demo = React.createClass({
               { icon: 'add' }
             ]}
             type='base'
+          />
+          <br /><br />
+          <Button
+            icon='gear'
+            onClick={this._handleSimpleSelectClick}
+            type='base'
+          >This is a menu Button</Button>
+          <SimpleSelect
+            align='right'
+            items={[
+              { text: 'Menu Item 1' },
+              { text: 'Menu Item 2' },
+              { text: 'Menu Item 3' }
+            ]}
+            showItems={this.state.showSimpleSelectItems}
           />
         </div>
         {this.state.showModal ? (

--- a/demo/app.js
+++ b/demo/app.js
@@ -562,7 +562,7 @@ const Demo = React.createClass({
       showDrawer: false,
       showDrawerButtonType: 'primary',
       showModal: false,
-      showSimpleSelectItems: false,
+      showMenu: false,
       showSmallModal: false,
       uploadedFile: null,
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
@@ -701,7 +701,7 @@ const Demo = React.createClass({
 
   _handleSimpleSelectClick () {
     this.setState({
-      showSimpleSelectItems: !this.state.showSimpleSelectItems
+      showMenu: !this.state.showMenu
     });
   },
 
@@ -859,15 +859,16 @@ const Demo = React.createClass({
             >
               This is a menu Button
             </Button>
-            <SimpleSelect
-              items={[
-                { text: 'Menu Item 1' },
-                { text: 'Menu Item 2' },
-                { text: 'Menu Item 3' }
-              ]}
-              onScrimClick={this._handleSimpleSelectClick}
-              showMenu={this.state.showSimpleSelectItems}
-            />
+            {this.state.showMenu ? (
+              <SimpleSelect
+                items={[
+                  { text: 'Menu Item 1' },
+                  { text: 'Menu Item 2' },
+                  { text: 'Menu Item 3' }
+                ]}
+                onScrimClick={this._handleSimpleSelectClick}
+              />
+            ) : null}
           </div>
         </div>
         {this.state.showModal ? (

--- a/demo/app.js
+++ b/demo/app.js
@@ -851,24 +851,22 @@ const Demo = React.createClass({
             type='base'
           />
           <br /><br />
-          <Button
-            icon='gear'
-            onClick={this._handleSimpleSelectClick}
-            type='base'
-          >This is a menu Button</Button>
-          <SimpleSelect
-            align='right'
-            items={[
-              {
-                icon: 'add',
-                text: 'Menu Item 1'
-              },
-              { text: 'Menu Item 2' },
-              { text: 'Menu Item 3' }
-            ]}
-            onScrimClick={this._handleSimpleSelectClick}
-            showItems={this.state.showSimpleSelectItems}
-          />
+          <div style={{ margin: '0 auto', width: 177 }}>
+            <Button
+              icon='gear'
+              onClick={this._handleSimpleSelectClick}
+              type='base'
+            >This is a menu Button</Button>
+            <SimpleSelect
+              items={[
+                { text: 'Menu Item 1' },
+                { text: 'Menu Item 2' },
+                { text: 'Menu Item 3' }
+              ]}
+              onScrimClick={this._handleSimpleSelectClick}
+              showItems={this.state.showSimpleSelectItems}
+            />
+          </div>
         </div>
         {this.state.showModal ? (
           <Modal

--- a/src/Index.js
+++ b/src/Index.js
@@ -18,6 +18,7 @@ module.exports = {
   Select: require('./components/Select'),
   SelectFullScreen: require('./components/SelectFullScreen'),
   SimpleInput: require('./components/SimpleInput'),
+  SimpleSelect: require('./components/SimpleSelect'),
   Spin: require('./components/Spin'),
   TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -1,0 +1,117 @@
+const React = require('react');
+const Radium = require('radium');
+
+const Icon = require('./Icon');
+
+const StyleConstants = require('../constants/Style');
+
+const SimpleSelect = React.createClass({
+  propTypes: {
+    align: React.PropTypes.string,
+    items: React.PropTypes.array,
+    itemStyles: React.PropTypes.object,
+    onItemSelect: React.PropTypes.func,
+    primaryColor: React.PropTypes.string,
+    styles: React.PropTypes.object
+  },
+
+  getDefaultProps () {
+    return {
+      align: 'left',
+      closeOnDateSelect: false,
+      items: [],
+      onItemSelect () {},
+      primaryColor: StyleConstants.Colors.PRIMARY
+    };
+  },
+
+  getInitialState () {
+    return {
+      showItems: true
+    };
+  },
+
+  _handleItemSelect (item) {
+    this.props.onItemSelect(item);
+    this._handleScrimClick();
+  },
+
+  _handleScrimClick () {
+    this.setState({
+      showItems: false
+    });
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div>
+      {this.state.showItems ? (
+        <div style={styles.wrapper}>
+          <div style={Object.assign({}, styles.component)}>
+              {this.props.items.map((item, i) => {
+                return (
+                  <div
+                    key={i}
+                    onClick={this._handleItemSelect.bind(null, item)}
+                    style={Object.assign({}, styles.item, this.props.itemStyles)}
+                  >
+                    {item.text}
+                  </div>
+                );
+              })}
+          </div>
+          <div onClick={this._handleScrimClick} style={styles.scrim} />
+        </div>
+      ) : null }
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: Object.assign({
+        backgroundColor: StyleConstants.Colors.WHITE,
+        borderRadius: 3,
+        boxShadow: StyleConstants.ShadowHigh,
+        boxSizing: 'border-box',
+        color: StyleConstants.Colors.BLACK,
+        display: this.state.showItems ? 'inline-block' : 'none',
+        fontFamily: StyleConstants.FontFamily,
+        fontSize: StyleConstants.FontSizes.MEDIUM,
+        position: 'absolute',
+        transform: this.props.align === 'left' ? 'translateX(calc(-100% - 30px))' : 'translateX(calc(100% - 120px))',
+        width: 150,
+        zIndex: 10
+      }, this.props.style),
+
+      wrapper: {
+        margin: '0 auto',
+        position: 'relative',
+        width: 0
+      },
+
+      item: {
+        padding: '14px 20px',
+        textAlign: 'left',
+
+        ':hover': {
+          backgroundColor: StyleConstants.Colors.FOG,
+          cursor: 'pointer'
+        }
+      },
+
+      scrim: {
+        bottom: 0,
+        left: 0,
+        position: 'fixed',
+        right: 0,
+        top: 0,
+        zIndex: 9
+      }
+    };
+  }
+});
+
+module.exports = Radium(SimpleSelect);

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -7,7 +7,6 @@ const StyleConstants = require('../constants/Style');
 
 const SimpleSelect = React.createClass({
   propTypes: {
-    brandColor: React.PropTypes.string,
     componentStyles: React.PropTypes.object,
     containerStyles: React.PropTypes.object,
     iconSize: React.PropTypes.number,
@@ -22,7 +21,6 @@ const SimpleSelect = React.createClass({
 
   getDefaultProps () {
     return {
-      brandColor: StyleConstants.Colors.PRIMARY,
       closeOnDateSelect: false,
       items: [],
       onItemSelect () {},

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -14,7 +14,7 @@ const SimpleSelect = React.createClass({
     menuStyles: React.PropTypes.object,
     onScrimClick: React.PropTypes.func,
     showMenu: React.PropTypes.bool,
-    styles: React.PropTypes.object
+    style: React.PropTypes.object
   },
 
   getDefaultProps () {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -13,7 +13,7 @@ const SimpleSelect = React.createClass({
     iconStyles: React.PropTypes.object,
     items: React.PropTypes.array.isRequired,
     itemStyles: React.PropTypes.object,
-    onItemSelect: React.PropTypes.func,
+    onItemClick: React.PropTypes.func,
     onScrimClick: React.PropTypes.func,
     showItems: React.PropTypes.bool,
     styles: React.PropTypes.object
@@ -23,14 +23,14 @@ const SimpleSelect = React.createClass({
     return {
       closeOnDateSelect: false,
       items: [],
-      onItemSelect () {},
+      onItemClick () {},
       onScrimClick () {},
       showItems: false
     };
   },
 
   _handleItemSelect (item) {
-    this.props.onItemSelect(item);
+    this.props.onItemClick(item);
   },
 
   render () {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -49,7 +49,7 @@ const SimpleSelect = React.createClass({
                     style={Object.assign({}, styles.item, this.props.itemStyles)}
                   >
                     {item.icon ? (
-                      <Icon size={this.props.iconSize} styles={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
+                      <Icon size={this.props.iconSize || 20} styles={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
                     ) : null}
                     {item.text}
                   </div>

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -14,7 +14,7 @@ const SimpleSelect = React.createClass({
     items: React.PropTypes.array.isRequired,
     itemStyles: React.PropTypes.object,
     onScrimClick: React.PropTypes.func,
-    showItems: React.PropTypes.bool,
+    showMenu: React.PropTypes.bool,
     styles: React.PropTypes.object
   },
 
@@ -23,7 +23,7 @@ const SimpleSelect = React.createClass({
       closeOnDateSelect: false,
       items: [],
       onScrimClick () {},
-      showItems: false
+      showMenu: false
     };
   },
 
@@ -32,7 +32,7 @@ const SimpleSelect = React.createClass({
 
     return (
       <div style={Object.assign({}, styles.container, this.props.containerStyles)}>
-      {this.props.showItems ? (
+      {this.props.showMenu ? (
         <div>
           <div style={Object.assign({}, styles.component, this.props.componentStyles)}>
               {this.props.items.map((item, i) => {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -7,22 +7,26 @@ const StyleConstants = require('../constants/Style');
 
 const SimpleSelect = React.createClass({
   propTypes: {
+    brandColor: React.PropTypes.string,
+    componentStyles: React.PropTypes.object,
+    containerStyles: React.PropTypes.object,
+    iconSize: React.PropTypes.number,
+    iconStyles: React.PropTypes.object,
     items: React.PropTypes.array,
     itemStyles: React.PropTypes.object,
     onItemSelect: React.PropTypes.func,
     onScrimClick: React.PropTypes.func,
-    primaryColor: React.PropTypes.string,
     showItems: React.PropTypes.bool,
     styles: React.PropTypes.object
   },
 
   getDefaultProps () {
     return {
+      brandColor: StyleConstants.Colors.PRIMARY,
       closeOnDateSelect: false,
       items: [],
       onItemSelect () {},
       onScrimClick () {},
-      primaryColor: StyleConstants.Colors.PRIMARY,
       showItems: false
     };
   },
@@ -35,19 +39,19 @@ const SimpleSelect = React.createClass({
     const styles = this.styles();
 
     return (
-      <div>
+      <div style={Object.assign({}, styles.container, this.props.containerStyles)}>
       {this.props.showItems ? (
         <div>
-          <div style={Object.assign({}, styles.component)}>
+          <div style={Object.assign({}, styles.component, this.props.componentStyles)}>
               {this.props.items.map((item, i) => {
                 return (
                   <div
                     key={i}
-                    onClick={this._handleItemSelect.bind(null, item)}
+                    onClick={item.onClick}
                     style={Object.assign({}, styles.item, this.props.itemStyles)}
                   >
                     {item.icon ? (
-                      <Icon type={item.icon} />
+                      <Icon size={this.props.iconSize} styles={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
                     ) : null}
                     {item.text}
                   </div>
@@ -64,20 +68,29 @@ const SimpleSelect = React.createClass({
   styles () {
     return {
       component: Object.assign({
+        alignSelf: 'stretch',
         backgroundColor: StyleConstants.Colors.WHITE,
         borderRadius: 3,
         boxShadow: StyleConstants.ShadowHigh,
         boxSizing: 'border-box',
         color: StyleConstants.Colors.BLACK,
+        display: 'felx',
+        flexDirection: 'column',
         fill: StyleConstants.Colors.BLACK,
         fontFamily: StyleConstants.FontFamily,
         fontSize: StyleConstants.FontSizes.MEDIUM,
         position: 'absolute',
-        width: 150,
         zIndex: 10
       }, this.props.style),
 
+      container: {
+        marginTop: 10,
+        position: 'relative'
+      },
+
       item: {
+        boxSizing: 'border-box',
+        height: 40,
         padding: '14px 20px',
         textAlign: 'left',
 

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -7,12 +7,11 @@ const StyleConstants = require('../constants/Style');
 
 const SimpleSelect = React.createClass({
   propTypes: {
-    componentStyles: React.PropTypes.object,
-    containerStyles: React.PropTypes.object,
     iconSize: React.PropTypes.number,
     iconStyles: React.PropTypes.object,
     items: React.PropTypes.array.isRequired,
     itemStyles: React.PropTypes.object,
+    menuStyles: React.PropTypes.object,
     onScrimClick: React.PropTypes.func,
     showMenu: React.PropTypes.bool,
     styles: React.PropTypes.object
@@ -31,10 +30,10 @@ const SimpleSelect = React.createClass({
     const styles = this.styles();
 
     return (
-      <div style={Object.assign({}, styles.container, this.props.containerStyles)}>
+      <div style={styles.component}>
       {this.props.showMenu ? (
         <div>
-          <div style={Object.assign({}, styles.component, this.props.componentStyles)}>
+          <div style={Object.assign({}, styles.menu, this.props.menuStyles)}>
               {this.props.items.map((item, i) => {
                 return (
                   <div
@@ -60,6 +59,11 @@ const SimpleSelect = React.createClass({
   styles () {
     return {
       component: Object.assign({
+        marginTop: 10,
+        position: 'relative'
+      }, this.props.style),
+
+      menu: {
         alignSelf: 'stretch',
         backgroundColor: StyleConstants.Colors.WHITE,
         borderRadius: 3,
@@ -73,11 +77,6 @@ const SimpleSelect = React.createClass({
         fontSize: StyleConstants.FontSizes.MEDIUM,
         position: 'absolute',
         zIndex: 10
-      }, this.props.style),
-
-      container: {
-        marginTop: 10,
-        position: 'relative'
       },
 
       item: {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -7,39 +7,28 @@ const StyleConstants = require('../constants/Style');
 
 const SimpleSelect = React.createClass({
   propTypes: {
-    align: React.PropTypes.string,
     items: React.PropTypes.array,
     itemStyles: React.PropTypes.object,
     onItemSelect: React.PropTypes.func,
+    onScrimClick: React.PropTypes.func,
     primaryColor: React.PropTypes.string,
+    showItems: React.PropTypes.bool,
     styles: React.PropTypes.object
   },
 
   getDefaultProps () {
     return {
-      align: 'left',
       closeOnDateSelect: false,
       items: [],
       onItemSelect () {},
-      primaryColor: StyleConstants.Colors.PRIMARY
-    };
-  },
-
-  getInitialState () {
-    return {
-      showItems: true
+      onScrimClick () {},
+      primaryColor: StyleConstants.Colors.PRIMARY,
+      showItems: false
     };
   },
 
   _handleItemSelect (item) {
     this.props.onItemSelect(item);
-    this._handleScrimClick();
-  },
-
-  _handleScrimClick () {
-    this.setState({
-      showItems: false
-    });
   },
 
   render () {
@@ -47,8 +36,8 @@ const SimpleSelect = React.createClass({
 
     return (
       <div>
-      {this.state.showItems ? (
-        <div style={styles.wrapper}>
+      {this.props.showItems ? (
+        <div>
           <div style={Object.assign({}, styles.component)}>
               {this.props.items.map((item, i) => {
                 return (
@@ -57,12 +46,15 @@ const SimpleSelect = React.createClass({
                     onClick={this._handleItemSelect.bind(null, item)}
                     style={Object.assign({}, styles.item, this.props.itemStyles)}
                   >
+                    {item.icon ? (
+                      <Icon type={item.icon} />
+                    ) : null}
                     {item.text}
                   </div>
                 );
               })}
           </div>
-          <div onClick={this._handleScrimClick} style={styles.scrim} />
+          <div onClick={this.props.onScrimClick} style={styles.scrim} />
         </div>
       ) : null }
       </div>
@@ -77,20 +69,13 @@ const SimpleSelect = React.createClass({
         boxShadow: StyleConstants.ShadowHigh,
         boxSizing: 'border-box',
         color: StyleConstants.Colors.BLACK,
-        display: this.state.showItems ? 'inline-block' : 'none',
+        fill: StyleConstants.Colors.BLACK,
         fontFamily: StyleConstants.FontFamily,
         fontSize: StyleConstants.FontSizes.MEDIUM,
         position: 'absolute',
-        transform: this.props.align === 'left' ? 'translateX(calc(-100% - 30px))' : 'translateX(calc(100% - 120px))',
         width: 150,
         zIndex: 10
       }, this.props.style),
-
-      wrapper: {
-        margin: '0 auto',
-        position: 'relative',
-        width: 0
-      },
 
       item: {
         padding: '14px 20px',

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -19,7 +19,6 @@ const SimpleSelect = React.createClass({
 
   getDefaultProps () {
     return {
-      closeOnDateSelect: false,
       items: [],
       onScrimClick () {},
       showMenu: false

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -11,7 +11,7 @@ const SimpleSelect = React.createClass({
     containerStyles: React.PropTypes.object,
     iconSize: React.PropTypes.number,
     iconStyles: React.PropTypes.object,
-    items: React.PropTypes.array,
+    items: React.PropTypes.array.isRequired,
     itemStyles: React.PropTypes.object,
     onItemSelect: React.PropTypes.func,
     onScrimClick: React.PropTypes.func,

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -13,15 +13,13 @@ const SimpleSelect = React.createClass({
     itemStyles: React.PropTypes.object,
     menuStyles: React.PropTypes.object,
     onScrimClick: React.PropTypes.func,
-    showMenu: React.PropTypes.bool,
     style: React.PropTypes.object
   },
 
   getDefaultProps () {
     return {
       items: [],
-      onScrimClick () {},
-      showMenu: false
+      onScrimClick () {}
     };
   },
 
@@ -30,27 +28,23 @@ const SimpleSelect = React.createClass({
 
     return (
       <div style={styles.component}>
-      {this.props.showMenu ? (
-        <div>
-          <div style={Object.assign({}, styles.menu, this.props.menuStyles)}>
-              {this.props.items.map((item, i) => {
-                return (
-                  <div
-                    key={i}
-                    onClick={item.onClick}
-                    style={Object.assign({}, styles.item, this.props.itemStyles)}
-                  >
-                    {item.icon ? (
-                      <Icon size={this.props.iconSize || 20} styles={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
-                    ) : null}
-                    {item.text}
-                  </div>
-                );
-              })}
-          </div>
-          <div onClick={this.props.onScrimClick} style={styles.scrim} />
+        <div style={Object.assign({}, styles.menu, this.props.menuStyles)}>
+            {this.props.items.map((item, i) => {
+              return (
+                <div
+                  key={i}
+                  onClick={item.onClick}
+                  style={Object.assign({}, styles.item, this.props.itemStyles)}
+                >
+                  {item.icon ? (
+                    <Icon size={this.props.iconSize || 20} styles={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
+                  ) : null}
+                  {item.text}
+                </div>
+              );
+            })}
         </div>
-      ) : null }
+        <div onClick={this.props.onScrimClick} style={styles.scrim} />
       </div>
     );
   },
@@ -58,7 +52,7 @@ const SimpleSelect = React.createClass({
   styles () {
     return {
       component: Object.assign({
-        marginTop: 10,
+        height: 0,
         position: 'relative'
       }, this.props.style),
 
@@ -74,6 +68,7 @@ const SimpleSelect = React.createClass({
         fill: StyleConstants.Colors.BLACK,
         fontFamily: StyleConstants.FontFamily,
         fontSize: StyleConstants.FontSizes.MEDIUM,
+        marginTop: 10,
         position: 'absolute',
         zIndex: 10
       },

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -13,7 +13,6 @@ const SimpleSelect = React.createClass({
     iconStyles: React.PropTypes.object,
     items: React.PropTypes.array.isRequired,
     itemStyles: React.PropTypes.object,
-    onItemClick: React.PropTypes.func,
     onScrimClick: React.PropTypes.func,
     showItems: React.PropTypes.bool,
     styles: React.PropTypes.object
@@ -23,14 +22,9 @@ const SimpleSelect = React.createClass({
     return {
       closeOnDateSelect: false,
       items: [],
-      onItemClick () {},
       onScrimClick () {},
       showItems: false
     };
-  },
-
-  _handleItemSelect (item) {
-    this.props.onItemClick(item);
   },
 
   render () {


### PR DESCRIPTION
Closes #185

This adds the SimpleSelect component. This is just the dropdown and scrim and not the icon/button/whatever that triggers the menu.

## Example
```
<div style={{ margin: '0 auto', width: 177 }}>
  <Button
    icon='gear'
    onClick={this._handleSimpleSelectClick}
    type='base'
  >
    This is a menu Button
  </Button>
  <SimpleSelect
    items={[
      { text: 'Menu Item 1' },
      { text: 'Menu Item 2' },
      { text: 'Menu Item 3' }
    ]}
    onScrimClick={this._handleSimpleSelectClick}
    showItems={this.state.showSimpleSelectItems}
  />
</div>
```
![screen shot 2016-06-01 at 11 11 45 am](https://cloud.githubusercontent.com/assets/1916697/15719001/371b9a54-27eb-11e6-991c-6b6307787a9c.png)

## Props
`iconSize` _number_ **optional**
Default: 20
The icon size used for icons in menu items if used

`iconStyles` _object_ **optional**
Styles for the icons in menu items if used

`items` _array_ **required**
An array of objects that specify `icon`, `text`, and/or `onClick` of the item.

`itemStyles` _object_ **optional**
Styles of the item in the list

`menuStyles` _object_ **optional**
Styles for the menu

`onScrimClick` _function_ **optional**
`onClick` handler for the menu scrim

`showMenu` _boolean_ **optional**
Default: false
Boolean value that dictates whether or not the menu is shown

`style` _object_ **optional**
Styles for the container around the component