### PR TITLE
Tooltip Component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -25,8 +25,10 @@ const {
   SelectFullScreen,
   SimpleInput,
   SimpleSelect,
+  Styles,
   TimeBasedLineChart,
   ToggleSwitch,
+  Tooltip,
   TypeAhead
 } = require('../src/Index');
 
@@ -858,6 +860,9 @@ const Demo = React.createClass({
             ]}
             type='base'
           />
+          <br /><br />
+          <Tooltip placement='right' style={{ fill: Styles.Colors.PRIMARY }}>Text for the tool tip</Tooltip>
+
           <br /><br />
           <div style={{ margin: '0 auto', width: 177 }}>
             <Button

--- a/demo/app.js
+++ b/demo/app.js
@@ -861,7 +861,7 @@ const Demo = React.createClass({
             type='base'
           />
           <br /><br />
-          <Tooltip placement='right'>Text for the tool tip</Tooltip>
+          <Tooltip placement='bottom' style={{ fill: Styles.Colors.PRIMARY }}>Text for the tool tip</Tooltip>
 
           <br /><br />
           <div style={{ margin: '0 auto', width: 177 }}>

--- a/demo/app.js
+++ b/demo/app.js
@@ -861,7 +861,7 @@ const Demo = React.createClass({
             type='base'
           />
           <br /><br />
-          <Tooltip placement='right' style={{ fill: Styles.Colors.PRIMARY }}>Text for the tool tip</Tooltip>
+          <Tooltip placement='right'>Text for the tool tip</Tooltip>
 
           <br /><br />
           <div style={{ margin: '0 auto', width: 177 }}>

--- a/src/Index.js
+++ b/src/Index.js
@@ -23,6 +23,7 @@ module.exports = {
   Spin: require('./components/Spin'),
   TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),
+  Tooltip: require('./components/Tooltip'),
   TypeAhead: require('./components/TypeAhead'),
 
   Styles: require('./constants/Style')

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,0 +1,129 @@
+const React = require('react');
+
+const Icon = require('./Icon');
+
+const StyleConstants = require('../constants/Style');
+
+const Tooltip = React.createClass({
+  propTypes: {
+    icon: React.PropTypes.string,
+    iconSize: React.PropTypes.number,
+    placement: React.PropTypes.oneOf(['left', 'top', 'right', 'bottom']),
+    style: React.PropTypes.object,
+    tooltipStyle: React.PropTypes.object
+  },
+
+  getDefaultProps () {
+    return {
+      icon: 'info',
+      iconSize: 20,
+      placement: 'top',
+      tooltipStyle: {}
+    };
+  },
+
+  getInitialState () {
+    return {
+      showTooltip: false
+    };
+  },
+
+  _handleInfoMouseEnter () {
+    this.setState({
+      showTooltip: true
+    });
+  },
+
+  _handleInfoMouseLeave () {
+    this.setState({
+      showTooltip: false
+    });
+  },
+
+  _getPosition () {
+    const offSet = this.props.iconSize + 5;
+    const width = this.props.tooltipStyle.width || 200;
+
+    switch (this.props.placement) {
+      case 'left':
+        return {
+          bottom: 0,
+          margin: 'auto',
+          right: offSet,
+          top: 0
+        };
+      case 'right':
+        return {
+          bottom: 0,
+          left: offSet,
+          margin: 'auto',
+          top: 0
+        };
+      case 'top':
+        return {
+          bottom: offSet,
+          left: '50%',
+          marginLeft: -(this.props.iconSize / 2 + width / 2)
+        };
+      case 'bottom':
+        return {
+          top: offSet,
+          left: '50%',
+          marginLeft: -(this.props.iconSize / 2 + width / 2)
+        };
+      default:
+        return null;
+    }
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div style={styles.component}>
+        {this.state.showTooltip ? (
+          <div style={styles.tooltip}>
+            {this.props.children}
+          </div>
+        ) : null}
+        <Icon
+          onMouseEnter={this._handleInfoMouseEnter}
+          onMouseLeave={this._handleInfoMouseLeave}
+          size={this.props.iconSize}
+          type={this.props.icon}
+        />
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: Object.assign({}, {
+        display: 'inline-block',
+        position: 'relative'
+      }, this.props.style),
+      tooltip: Object.assign({},
+        {
+          alignItems: 'center',
+          backgroundColor: StyleConstants.Colors.WHITE,
+          borderRadius: 3,
+          boxShadow: StyleConstants.ShadowHigh,
+          display: 'flex',
+          fontSize: StyleConstants.FontSizes.MEDIUM,
+          justifyContent: 'center',
+          lineHeight: '1.3em',
+          minHeight: '100%',
+          padding: 10,
+          position: 'absolute',
+          textAlign: 'center',
+          whiteSpace: 'normal',
+          width: this.props.tooltipStyle.width || 200,
+          zIndex: '10'
+        },
+        this._getPosition(),
+        this.props.tooltipStyle)
+    };
+  }
+});
+
+module.exports = Tooltip;

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -100,6 +100,7 @@ const Tooltip = React.createClass({
     return {
       component: Object.assign({}, {
         display: 'inline-block',
+        fill: StyleConstants.Colors.ASH,
         position: 'relative'
       }, this.props.style),
       tooltip: Object.assign({},


### PR DESCRIPTION
This adds a tooltip component with the following props:

- `children` (node): Text or JSX to be displayed inside the tooltip
- `icon` (string): Icon to be displayed to indicate a tooltip. Defaults to `info`
- `iconSize` (number): Size of the icon to be displayed: Defaults to `20`
- `placement` (string): Used to quickly position tooltip. Must be `top`, `right`, `bottom` or `left`
- `style` (object): Used to override component styles. Can pass `fill` in to set the icon color
- `tooltipStyle` (object): Used to override the tooltip styling. Can be used for custom positioning.

Top:
![screen shot 2016-06-02 at 5 12 10 pm](https://cloud.githubusercontent.com/assets/488916/15764204/49a2c39a-28e6-11e6-9a18-653b2b01576d.png)

Right:
![screen shot 2016-06-02 at 5 11 36 pm](https://cloud.githubusercontent.com/assets/488916/15764207/50662960-28e6-11e6-8c57-35a75fee72fd.png)

Bottom:
![screen shot 2016-06-02 at 5 13 08 pm](https://cloud.githubusercontent.com/assets/488916/15764210/55901f5e-28e6-11e6-8ec0-5e460a6e5e31.png)

Left:
![screen shot 2016-06-02 at 5 11 54 pm](https://cloud.githubusercontent.com/assets/488916/15764213/5ba3088e-28e6-11e6-8d4f-b422f817ba4a.png)

@derek-boman 

