### PR TITLE
Defualt cursor for disabled Buttons

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -66,7 +66,7 @@ const Button = React.createClass({
         padding: '4px 14px',
         fontSize: StyleConstants.FontSizes.MEDIUM,
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
-        cursor: 'pointer',
+        cursor: this.props.type === 'disabled' ? 'default' : 'pointer',
         transition: 'all .2s ease-in',
         minWidth: 16,
         position: 'relative'


### PR DESCRIPTION
This would set the cursor to be default if the button is disabled. Since we're disabling `onClick` events, we don't want to confuse the user by having a pointer of hover for disabled buttons.