### PR TITLE
DisplayInput border color

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -56,7 +56,7 @@ const DisplayInput = React.createClass({
   styles () {
     return {
       wrapper: Object.assign({
-        borderBottom: this.props.valid ? '1px solid ' + StyleConstants.Colors.ASH : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
+        borderBottom: this.props.valid ? '1px solid ' + StyleConstants.Colors.FOG : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
         height: 43,
         paddingLeft: this.props.label ? 130 : 0,
         paddingRight: this.props.hint || this.props.status ? 100 : 0,


### PR DESCRIPTION
The bottom border color on the DisplayInput component wasn't quite what our product team had speced out. This updates the border color and now the input field doesn't look as harsh on a white background. @cerinman 

## Before
![screen shot 2016-06-09 at 1 37 17 pm](https://cloud.githubusercontent.com/assets/1916697/15943752/bcd54fde-2e47-11e6-8d73-c78ede67afa2.png)

## After
![screen shot 2016-06-09 at 1 37 30 pm](https://cloud.githubusercontent.com/assets/1916697/15943748/b956c3a6-2e47-11e6-91be-8e9dd0a2f3f2.png)
