### PR TITLE
Add animateLeftDistance prop to Drawer component

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,3 +1,4 @@
+const _isNumber = require('lodash/isNumber');
 const Radium = require('radium');
 const React = require('react');
 const Velocity = require('velocity-animate');
@@ -8,6 +9,7 @@ const StyleConstants = require('../constants/Style');
 
 const Drawer = React.createClass({
   propTypes: {
+    animateLeftDistance: React.PropTypes.number,
     buttonPrimaryColor: React.PropTypes.string,
     contentStyle: React.PropTypes.oneOfType([
       React.PropTypes.array,
@@ -42,6 +44,10 @@ const Drawer = React.createClass({
   },
 
   _getAnimationDistance () {
+    if (_isNumber(this.props.animateLeftDistance)) {
+      return this.props.animateLeftDistance + '%';
+    }
+
     const greaterThan1200ComponentWidth = 960;
     const maxResolutionBreakPoint = 1200;
     const minResoultionBreakPoint = 750;


### PR DESCRIPTION
### Issue

Nesting Drawer components has an issue where children Drawer components don't animate to the correct left position because of their parent container.

### Solution

This PR adds a new prop `animateLeftDistance` - (type: number) - (default: null) - Read as a percentage, this prop is the distance from the left of the containing div that the drawer will animate to when opened.

If supplied, the component will used the prop value over calculating a left distance on the fly.

I messed around with positioning trying to avoid adding this prop but this seems to be the only universal fix that prevents weird drawer positioning.

#### Before
![screen shot 2016-06-09 at 2 57 54 pm](https://cloud.githubusercontent.com/assets/6463914/15946243/4037e7a0-2e53-11e6-8b7c-acf2a06f75dd.png)

#### After
![screen shot 2016-06-09 at 2 58 32 pm](https://cloud.githubusercontent.com/assets/6463914/15946247/4707cc12-2e53-11e6-974c-9fb6bf7c0215.png)
