### PR TITLE
Add ability to hide scrim for drawer via showScrim prop

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -27,6 +27,7 @@ const Drawer = React.createClass({
       onPreviousClick: React.PropTypes.func.isRequired
     }),
     onClose: React.PropTypes.func.isRequired,
+    showScrim: React.PropTypes.bool,
     title: React.PropTypes.string
   },
 
@@ -35,6 +36,7 @@ const Drawer = React.createClass({
       buttonPrimaryColor: StyleConstants.Colors.PRIMARY,
       duration: 500,
       easing: [0.28, 0.14, 0.34, 1.04],
+      showScrim: true,
       title: ''
     };
   },
@@ -111,7 +113,7 @@ const Drawer = React.createClass({
 
     return (
       <div style={styles.componentWrapper}>
-        <div onClick={this._handleCloseClick} style={styles.scrim}></div>
+        <div onClick={this._handleCloseClick} style={styles.scrim} />
         <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
           <header style={Object.assign({}, styles.header, this.props.headerStyle)}>
             <span style={styles.backArrow}>
@@ -176,7 +178,7 @@ const Drawer = React.createClass({
         bottom: 0,
         left: 0,
         textAlign: 'center',
-        backgroundColor: StyleConstants.Colors.SCRIM
+        backgroundColor: this.props.showScrim ? StyleConstants.Colors.SCRIM : 'transparent'
       },
       icons: {
         color: StyleConstants.Colors.ASH


### PR DESCRIPTION
### Issue

Now that we can nest Drawer components, we don't want the nested Drawers to show their scrim.

### Solution

This adds another new prop to the Drawer component

`showScrim` - Type(`Bool`) - Default(`true`) - If set to false, sets the color of the scrim to transparent so that you can still see the content below.

#### Before
![screen shot 2016-06-10 at 9 53 32 am](https://cloud.githubusercontent.com/assets/6463914/15970467/ebebed14-2ef1-11e6-8f48-fd89c45399b9.png)

#### After
![screen shot 2016-06-10 at 9 53 53 am](https://cloud.githubusercontent.com/assets/6463914/15970472/f1ac8614-2ef1-11e6-9bc8-3913cfec3806.png)
