### PR TITLE
New Calendar component

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -8,6 +8,7 @@ const {
   BarChart,
   Button,
   ButtonGroup,
+  Calendar,
   Column,
   DatePicker,
   DatePickerFullScreen,
@@ -212,6 +213,7 @@ const Demo = React.createClass({
       lineChartData: [],
       pageIndicatorIndex: 0,
       radioChecked: false,
+      selectedCalendarDate: null,
       selectedDatePickerDate: null,
       showDrawer: false,
       showDrawerButtonType: 'primary',
@@ -273,6 +275,12 @@ const Demo = React.createClass({
   _handleWindowResize () {
     this.setState({
       windowWidth: document.documentElement.clientWidth || document.body.clientWidth
+    });
+  },
+
+  _handleCalendarDateSelect (selectedCalendarDate) {
+    this.setState({
+      selectedCalendarDate
     });
   },
 
@@ -872,6 +880,12 @@ const Demo = React.createClass({
         <br /><br />
         <RadioButton checked={this.state.radioChecked} onClick={this._handleRadioButtonClick}>On</RadioButton>
         <RadioButton checked={!this.state.radioChecked} onClick={this._handleRadioButtonClick}>Off</RadioButton>
+
+        <br /><br />
+        <Calendar
+          onDateSelect={this._handleCalendarDateSelect}
+          selectedDate={this.state.selectedCalendarDate}
+        />
 
         <br /><br />
         <DatePicker

--- a/src/Index.js
+++ b/src/Index.js
@@ -2,6 +2,7 @@ module.exports = {
   BarChart: require('./components/BarChart'),
   Button: require('./components/Button'),
   ButtonGroup: require('./components/ButtonGroup'),
+  Calendar: require('./components/Calendar'),
   Column: require('./components/grid/Column'),
   DatePicker: require('./components/DatePicker'),
   DatePickerFullScreen: require('./components/DatePickerFullScreen'),

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -6,15 +6,11 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const DatePicker = React.createClass({
+const Calendar = React.createClass({
   propTypes: {
-    closeOnDateSelect: React.PropTypes.bool,
-    defaultDate: React.PropTypes.number,
-    format: React.PropTypes.string,
     locale: React.PropTypes.string,
     minimumDate: React.PropTypes.number,
     onDateSelect: React.PropTypes.func,
-    placeholderText: React.PropTypes.string,
     primaryColor: React.PropTypes.string,
     selectedDate: React.PropTypes.number,
     style: React.PropTypes.object
@@ -22,26 +18,16 @@ const DatePicker = React.createClass({
 
   getDefaultProps () {
     return {
-      closeOnDateSelect: false,
-      format: 'MMM D, YYYY',
       locale: 'en',
       onDateSelect () {},
-      placeholderText: 'Select A Date',
       primaryColor: StyleConstants.Colors.PRIMARY
     };
   },
 
   getInitialState () {
     return {
-      currentDate: this.props.selectedDate || this.props.defaultDate || moment().unix(),
-      showCalendar: false
+      currentDate: this.props.selectedDate || moment().unix()
     };
-  },
-
-  componentDidMount () {
-    if (this.props.defaultDate) {
-      console.warn('WARNING: defaultDate has been replaced with selectedDate and will be removed in a future release. Check usage of ' + this.constructor.displayName + '.');
-    }
   },
 
   componentWillReceiveProps (newProps) {
@@ -50,20 +36,9 @@ const DatePicker = React.createClass({
         currentDate: newProps.selectedDate
       });
     }
-
-    if (newProps.defaultDate && newProps.defaultDate !== this.props.defaultDate) {
-      console.warn('WARNING: defaultDate has been replaced with selectedDate and will be removed in a future release. Check usage of ' + this.constructor.displayName + '.');
-      this.setState({
-        currentDate: newProps.defaultDate
-      });
-    }
   },
 
   _handleDateSelect (date) {
-    if (this.props.closeOnDateSelect) {
-      this._handleScrimClick();
-    }
-
     this.props.onDateSelect(date);
   },
 
@@ -83,18 +58,6 @@ const DatePicker = React.createClass({
     });
   },
 
-  _handleScrimClick () {
-    this.setState({
-      showCalendar: false
-    });
-  },
-
-  _toggleCalendar () {
-    this.setState({
-      showCalendar: !this.state.showCalendar
-    });
-  },
-
   _renderMonthTable () {
     const styles = this.styles();
     const days = [];
@@ -103,7 +66,7 @@ const DatePicker = React.createClass({
 
     while (moment(startDate).isBefore(endDate)) {
       const isCurrentMonth = startDate.isSame(moment.unix(this.state.currentDate), 'month');
-      const isSelectedDay = startDate.isSame(moment.unix(this.props.selectedDate || this.props.defaultDate), 'day');
+      const isSelectedDay = startDate.isSame(moment.unix(this.props.selectedDate), 'day');
       const isToday = startDate.isSame(moment(), 'day');
       const disabledDay = this.props.minimumDate ? startDate.isBefore(moment.unix(this.props.minimumDate)) : null;
 
@@ -135,55 +98,35 @@ const DatePicker = React.createClass({
 
     return (
       <div style={styles.component}>
-        <div onClick={this._toggleCalendar} style={styles.selectedDateWrapper}>
+        <div style={styles.calendarHeader}>
           <Icon
+            onClick={this._handlePreviousClick}
             size={20}
-            style={styles.selectedDateIcon}
-            type='calendar'
+            style={styles.calendayHeaderNav}
+            type='caret-left'
           />
-          <div style={styles.selectedDateText}>
-            {(this.props.selectedDate || this.props.defaultDate) ? moment.unix(this.props.selectedDate || this.props.defaultDate).format(this.props.format) : this.props.placeholderText}
+          <div>
+            {moment(this.state.currentDate, 'X').format('MMMM YYYY')}
           </div>
           <Icon
+            onClick={this._handleNextClick}
             size={20}
-            style={styles.selectedDateCaret}
-            type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
+            style={styles.calendayHeaderNav}
+            type='caret-right'
           />
         </div>
-        <div style={styles.calendarWrapper}>
-          <div style={styles.calendarHeader}>
-            <Icon
-              onClick={this._handlePreviousClick}
-              size={20}
-              style={styles.calendayHeaderNav}
-              type='caret-left'
-            />
-            <div>
-              {moment(this.state.currentDate, 'X').format('MMMM YYYY')}
-            </div>
-            <Icon
-              onClick={this._handleNextClick}
-              size={20}
-              style={styles.calendayHeaderNav}
-              type='caret-right'
-            />
-          </div>
-          <div style={styles.calendarWeek}>
-            {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => {
-              return (
-                <div key={i} style={styles.calendarWeekDay}>
-                  {day}
-                </div>
-              );
-            })}
-          </div>
-          <div style={styles.calendarTable}>
-            {this._renderMonthTable()}
-          </div>
+        <div style={styles.calendarWeek}>
+          {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => {
+            return (
+              <div key={i} style={styles.calendarWeekDay}>
+                {day}
+              </div>
+            );
+          })}
         </div>
-        {(this.state.showCalendar) ? (
-          <div onClick={this._handleScrimClick} style={styles.scrim} />
-        ) : null }
+        <div style={styles.calendarTable}>
+          {this._renderMonthTable()}
+        </div>
       </div>
     );
   },
@@ -192,55 +135,13 @@ const DatePicker = React.createClass({
     return {
       component: Object.assign({
         backgroundColor: StyleConstants.Colors.WHITE,
-        borderColor: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.FOG,
-        borderRadius: 3,
-        borderStyle: 'solid',
-        borderWidth: 1,
-        boxSizing: 'border-box',
-        color: StyleConstants.Colors.BLACK,
-        display: 'inline-block',
-        fontFamily: StyleConstants.FontFamily,
-        fontSize: StyleConstants.FontSizes.MEDIUM,
-        position: 'relative',
-        width: '100%'
-      }, this.props.style),
-
-      // Selected Date styles
-      selectedDateWrapper: {
-        alignItems: 'center',
-        cursor: 'pointer',
-        display: 'flex',
-        justifyContent: 'space-between',
-        padding: '10px 15px',
-        position: 'relative'
-      },
-      selectedDateIcon: {
-        fill: this.props.primaryColor,
-        marginRight: 5
-      },
-      selectedDateText: {
-        color: (this.props.selectedDate || this.props.defaultDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH,
-        flex: 1
-      },
-      selectedDateCaret: {
-        fill: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.ASH
-      },
-
-      //Calendar Styles
-      calendarWrapper: {
-        backgroundColor: StyleConstants.Colors.WHITE,
         border: '1px solid ' + StyleConstants.Colors.FOG,
         borderRadius: 3,
-        boxShadow: StyleConstants.ShadowHigh,
         boxSizing: 'border-box',
-        display: this.state.showCalendar ? 'block' : 'none',
         marginTop: 10,
         padding: 20,
-        position: 'absolute',
-        right: 0,
-        width: 287,
-        zIndex: 10
-      },
+        width: 287
+      }, this.props.style),
 
       //Calendar Header
       calendarHeader: {
@@ -316,18 +217,9 @@ const DatePicker = React.createClass({
       selectedDay: {
         backgroundColor: this.props.primaryColor,
         color: StyleConstants.Colors.WHITE
-      },
-
-      scrim: {
-        bottom: 0,
-        left: 0,
-        position: 'fixed',
-        right: 0,
-        top: 0,
-        zIndex: 9
       }
     };
   }
 });
 
-module.exports = Radium(DatePicker);
+module.exports = Radium(Calendar);

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -1,0 +1,177 @@
+const React = require('react');
+const Radium = require('radium');
+const moment = require('moment');
+
+const Calendar = require('./Calendar');
+const Icon = require('./Icon');
+
+const StyleConstants = require('../constants/Style');
+
+const DatePicker = React.createClass({
+  propTypes: {
+    closeOnDateSelect: React.PropTypes.bool,
+    defaultDate: React.PropTypes.number,
+    format: React.PropTypes.string,
+    locale: React.PropTypes.string,
+    minimumDate: React.PropTypes.number,
+    onDateSelect: React.PropTypes.func,
+    placeholderText: React.PropTypes.string,
+    primaryColor: React.PropTypes.string,
+    selectedDate: React.PropTypes.number,
+    style: React.PropTypes.object
+  },
+
+  getDefaultProps () {
+    return {
+      closeOnDateSelect: false,
+      format: 'MMM D, YYYY',
+      locale: 'en',
+      onDateSelect () {},
+      placeholderText: 'Select A Date',
+      primaryColor: StyleConstants.Colors.PRIMARY
+    };
+  },
+
+  getInitialState () {
+    return {
+      currentDate: this.props.selectedDate || this.props.defaultDate || moment().unix(),
+      showCalendar: false
+    };
+  },
+
+  componentDidMount () {
+    if (this.props.defaultDate) {
+      console.warn('WARNING: defaultDate has been replaced with selectedDate and will be removed in a future release. Check usage of ' + this.constructor.displayName + '.');
+    }
+  },
+
+  componentWillReceiveProps (newProps) {
+    if (newProps.selectedDate && newProps.selectedDate !== this.props.selectedDate) {
+      this.setState({
+        currentDate: newProps.selectedDate
+      });
+    }
+
+    if (newProps.defaultDate && newProps.defaultDate !== this.props.defaultDate) {
+      console.warn('WARNING: defaultDate has been replaced with selectedDate and will be removed in a future release. Check usage of ' + this.constructor.displayName + '.');
+      this.setState({
+        currentDate: newProps.defaultDate
+      });
+    }
+  },
+
+  _handleDateSelect (date) {
+    if (this.props.closeOnDateSelect) {
+      this._handleScrimClick();
+    }
+
+    this.props.onDateSelect(date);
+  },
+
+  _handleScrimClick () {
+    this.setState({
+      showCalendar: false
+    });
+  },
+
+  _toggleCalendar () {
+    this.setState({
+      showCalendar: !this.state.showCalendar
+    });
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div style={styles.component}>
+        <div onClick={this._toggleCalendar} style={styles.selectedDateWrapper}>
+          <Icon
+            size={20}
+            style={styles.selectedDateIcon}
+            type='calendar'
+          />
+          <div style={styles.selectedDateText}>
+            {(this.props.selectedDate || this.props.defaultDate) ? moment.unix(this.props.selectedDate || this.props.defaultDate).format(this.props.format) : this.props.placeholderText}
+          </div>
+          <Icon
+            size={20}
+            style={styles.selectedDateCaret}
+            type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
+          />
+        </div>
+        <div style={styles.calendarWrapper}>
+          <Calendar
+            onDateSelect={this._handleDateSelect}
+            selectedDate={this.state.currentDate}
+            style={styles.calendar}
+          />
+        </div>
+        {(this.state.showCalendar) ? (
+          <div onClick={this._handleScrimClick} style={styles.scrim} />
+        ) : null }
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      component: Object.assign({
+        backgroundColor: StyleConstants.Colors.WHITE,
+        borderColor: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.FOG,
+        borderRadius: 3,
+        borderStyle: 'solid',
+        borderWidth: 1,
+        boxSizing: 'border-box',
+        color: StyleConstants.Colors.BLACK,
+        display: 'inline-block',
+        fontFamily: StyleConstants.FontFamily,
+        fontSize: StyleConstants.FontSizes.MEDIUM,
+        position: 'relative',
+        width: '100%'
+      }, this.props.style),
+      calendar: {
+        boxShadow: StyleConstants.ShadowHigh
+      },
+      calendarWrapper: {
+        boxSizing: 'border-box',
+        display: this.state.showCalendar ? 'block' : 'none',
+        position: 'absolute',
+        right: 0,
+        width: 287,
+        zIndex: 10
+      },
+
+      // Selected Date styles
+      selectedDateWrapper: {
+        alignItems: 'center',
+        cursor: 'pointer',
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '10px 15px',
+        position: 'relative'
+      },
+      selectedDateIcon: {
+        fill: this.props.primaryColor,
+        marginRight: 5
+      },
+      selectedDateText: {
+        color: (this.props.selectedDate || this.props.defaultDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH,
+        flex: 1
+      },
+      selectedDateCaret: {
+        fill: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.ASH
+      },
+      scrim: {
+        bottom: 0,
+        left: 0,
+        position: 'fixed',
+        right: 0,
+        top: 0,
+        zIndex: 9
+      }
+    };
+  }
+});
+
+module.exports = Radium(DatePicker);


### PR DESCRIPTION
This PR extracts the calendar logic from the `DatePicker` component to it's own `Calendar` component.  I've done this because we now have duplicate code for the calendar in 5 locations between the open source and internally.  I don't want to maintain all that so here we go.

This PR does the following:

- Extracts the calendar code to it's own component as already noted above.
- Refactors the `DatePicker` component to use the new `Calendar` component.
- Sets up the Demo app to use the new `Calendar` component.

I'll update the `DatePickerFullScreen` and new `DateRangePicker` components in separate PRs after this one gets merged.  I didn't do that here because the `DatePickerFullScreen` component is way behind the curve for being up to date and the new `DateRangePicker` needs to be able to select ranges so I'll have to read through it's code a bit more before I implement the `Calendar` component there.

#### Screen

![screen shot 2016-06-13 at 5 10 35 pm](https://cloud.githubusercontent.com/assets/6463914/16026294/9cd1e7d8-318a-11e6-9031-71d75dcac991.png)
![screen shot 2016-06-13 at 5 11 04 pm](https://cloud.githubusercontent.com/assets/6463914/16026295/9cd5f3dc-318a-11e6-8f36-5e69125db6e0.png)
