### PR TITLE
Fixes typo to allow for custom color prop

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -195,7 +195,7 @@ const Calendar = React.createClass({
         width: 35,
 
         ':hover': {
-          border: '1px solid' + this.props.primaryColor
+          border: '1px solid ' + this.props.primaryColor
         }
       },
       calendarDayDisabled: {


### PR DESCRIPTION
Setting a custom primaryColor prop wasn't working when hovering over dates. This fixes the issue. @jmophoto 