### PR TITLE
Tommy/line chart dots

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -738,6 +738,7 @@ const Demo = React.createClass({
                 type: 'number'
               }
             ]}
+            limitLineCircles={true}
             rangeType={'day'}
             showBreakPoint={true}
             width={700}

--- a/demo/app.js
+++ b/demo/app.js
@@ -738,7 +738,6 @@ const Demo = React.createClass({
                 type: 'number'
               }
             ]}
-            limitLineCircles={true}
             rangeType={'day'}
             showBreakPoint={true}
             width={700}

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -293,19 +293,9 @@ const TimeBasedLineChart = React.createClass({
   // Helper Functions
   _getDataForLineCircles () {
     if (this.props.limitLineCircles) {
-      const data = [];
-
-      this.props.data.forEach((dataPoint, index) => {
-        const shouldIncludeDataPoint = index === 0 ||
-                                       index === this.props.data.length - 1 ||
-                                       dataPoint.x === this.props.breakPointDate;
-
-        if (shouldIncludeDataPoint) {
-          data.push(dataPoint);
-        }
+      return this.props.data.filter((dataPoint, index) => {
+        return index === 0 || index === this.props.data.length - 1 || dataPoint.x === this.props.breakPointDate;
       });
-
-      return data;
     }
 
     return this.props.data;

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -203,6 +203,7 @@ const TimeBasedLineChart = React.createClass({
     data: React.PropTypes.array.isRequired,
     height: React.PropTypes.number,
     hoveredDataPointDetails: React.PropTypes.array,
+    limitLineCircles: React.PropTypes.bool,
     lineColor: React.PropTypes.string,
     margin: React.PropTypes.object,
     rangeType: React.PropTypes.oneOf(['day', 'month']),
@@ -220,6 +221,7 @@ const TimeBasedLineChart = React.createClass({
       breakPointDate: moment().startOf('day').unix(),
       breakPointLabel: 'Today',
       height: 400,
+      limitLineCircles: false,
       lineColor: StyleConstants.Colors.PRIMARY,
       margin: styles.chartMargins,
       rangeType: 'day',
@@ -289,6 +291,26 @@ const TimeBasedLineChart = React.createClass({
   },
 
   // Helper Functions
+  _getDataForLineCircles () {
+    if (this.props.limitLineCircles) {
+      const data = [];
+
+      this.props.data.forEach((dataPoint, index) => {
+        const shouldIncludeDataPoint = index === 0 ||
+                                       index === this.props.data.length - 1 ||
+                                       dataPoint.x === this.props.breakPointDate;
+
+        if (shouldIncludeDataPoint) {
+          data.push(dataPoint);
+        }
+      });
+
+      return data;
+    }
+
+    return this.props.data;
+  },
+
   _getFormattedValue (value, type, format) {
     let formattedValue = '';
 
@@ -591,7 +613,7 @@ const TimeBasedLineChart = React.createClass({
               />
               <CirclesGroup
                 adjustedHeight={adjustedHeight}
-                data={data}
+                data={this._getDataForLineCircles()}
                 translation={this._getLineTranslation()}
                 xScaleValueFunction={this._getXScaleValue}
                 yScaleValueFunction={this._getYScaleValue}


### PR DESCRIPTION
Adds a new prop to the TimeBasedLineChart for limiting the circles on the line to the beginning, middle, and end of the line.

- `limitLineCircles` - (type: `bool`) - (default: `false`) - If set to true will limit the number of circles drawn on the line to just the beginning, middle, and end.

This was done to match a new design internally.

#### this.props.limitLineCircles === false
<img width="733" alt="screen shot 2016-06-16 at 12 30 01 pm" src="https://cloud.githubusercontent.com/assets/6463914/16128628/b10b37b4-33be-11e6-8e69-0ebb0c7c0c2f.png">

#### this.props.limitLineCircles === true
<img width="742" alt="screen shot 2016-06-16 at 12 30 22 pm" src="https://cloud.githubusercontent.com/assets/6463914/16128639/bdf2bcea-33be-11e6-99b9-5ac8af9b65f8.png">
