### PR TITLE
Add Progress Bar

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -22,6 +22,7 @@ const {
   Loader,
   Modal,
   PageIndicator,
+  ProgressBar,
   RadioButton,
   RangeSelector,
   Row,
@@ -605,6 +606,9 @@ const Demo = React.createClass({
             ]}
             type='base'
           />
+          <br /><br />
+          <ProgressBar percentage={50} />
+
           <br /><br />
           <Tooltip placement='bottom' style={{ fill: Styles.Colors.PRIMARY }}>Text for the tool tip</Tooltip>
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -16,6 +16,7 @@ module.exports = {
   Loader: require('./components/Loader'),
   Modal: require('./components/Modal'),
   PageIndicator: require('./components/PageIndicator'),
+  ProgressBar: require('./components/ProgressBar'),
   RadioButton: require('./components/RadioButton'),
   RajaIcon: require('./components/RajaIcon'),
   Row: require('./components/grid/Row'),

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,0 +1,50 @@
+const React = require('react');
+const _merge = require('lodash/merge');
+
+const StyleConstants = require('../constants/Style');
+
+const ProgressBar = React.createClass({
+  propTypes: {
+    baseColor: React.PropTypes.string,
+    color: React.PropTypes.string,
+    height: React.PropTypes.number,
+    percentage: React.PropTypes.number,
+    styles: React.PropTypes.object
+  },
+
+  getDefaultProps () {
+    return {
+      baseColor: StyleConstants.Colors.FOG,
+      color: StyleConstants.Colors.PRIMARY,
+      height: 10
+    };
+  },
+
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div style={styles.component}>
+        <div style={styles.progress}>{this.props.children}</div>
+      </div>
+    );
+  },
+
+  styles () {
+    return _merge({}, {
+      component: {
+        backgroundColor: this.props.baseColor,
+        borderRadius: this.props.height / 4,
+        height: this.props.height
+      },
+      progress: {
+        backgroundColor: this.props.color,
+        borderRadius: this.props.height / 4,
+        height: this.props.height,
+        width: this.props.percentage + '%'
+      }
+    }, this.props.styles);
+  }
+});
+
+module.exports = ProgressBar;

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -6,17 +6,17 @@ const StyleConstants = require('../constants/Style');
 const ProgressBar = React.createClass({
   propTypes: {
     baseColor: React.PropTypes.string,
-    color: React.PropTypes.string,
     height: React.PropTypes.number,
     percentage: React.PropTypes.number,
+    progressColor: React.PropTypes.string,
     styles: React.PropTypes.object
   },
 
   getDefaultProps () {
     return {
       baseColor: StyleConstants.Colors.FOG,
-      color: StyleConstants.Colors.PRIMARY,
-      height: 10
+      height: 10,
+      progressColor: StyleConstants.Colors.PRIMARY
     };
   },
 
@@ -38,7 +38,7 @@ const ProgressBar = React.createClass({
         height: this.props.height
       },
       progress: {
-        backgroundColor: this.props.color,
+        backgroundColor: this.props.progressColor,
         borderRadius: this.props.height / 4,
         height: this.props.height,
         width: this.props.percentage + '%'


### PR DESCRIPTION
Add progress bar component.

#### Props ####
`baseColor`: string, default FOG, color for the full width bar
`height`: number, default 10, height of the bar
`percentage`: number, percentage of width for the progress bar. Shown in percentage value, so `50` for `50%`
`progressColor`: string, default PRIMARY, color of the progress bad
`styles`: object, styles to override either the component or the progress divs

The `height`, `baseColor` and `progressColor` props can also be overridden within the styles prop, but since they would be used most often, I have exposed them as helper props.

Also, I switched from Object.assign on the styles to lodash's `_merge`. This allows us to override/provide a new style without wiping out all of the others.

Default and custom colors and styles
```
<ProgressBar percentage={50} />
<ProgressBar baseColor={Styles.Colors.ASH} color={Styles.Colors.ORANGE} percentage={25} styles={{ component: { width: '75%' } }}/>
```
![screen shot 2016-06-20 at 1 10 41 pm](https://cloud.githubusercontent.com/assets/488916/16208023/784c20aa-36ed-11e6-9d6b-a624593492bd.png)

