### PR TITLE
Column: change to window.innerWidth for column

### DIFF
--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -47,7 +47,7 @@ const Column = React.createClass({
   },
 
   _getScreenWidth () {
-    const width = document.documentElement.clientWidth || document.body.clientWidth;
+    const width = window.innerWidth;
     let screenWidth = 'Small';
 
     if (width >= this.props.breakpointLarge) {


### PR DESCRIPTION
Internally, we are using this in an iFrame, which made getting the width by calling `document.documentElement.clientWidth` unhelpful. I change it to `window.innerWidth`. Testing this, it returns the correct value stand-alone and also from the iFrame.

