### PR TITLE
Date range picker tweaks

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -83,76 +83,31 @@ const DateRangePicker = React.createClass({
     }
   },
 
+  _endDateIsBeforeStartDate (startDate, endDate) {
+    return moment.unix(endDate).isBefore(moment.unix(startDate));
+  },
+
   _handleDateSelect (date) {
-    const selectedStartDate = this.props.selectedStartDate;
-    const selectedEndDate = this.props.selectedEndDate;
-    let updatedDates = [null, null];
+    let endDate;
+    let startDate;
+    const existingRangeComplete = this.props.selectedStartDate && this.props.selectedEndDate;
+    const existingRangeEmpty = !this.props.selectedStartDate && !this.props.selectedEndDate;
 
-    updatedDates = this._deselectDate(date, selectedStartDate, selectedEndDate);
-    updatedDates = updatedDates || this._startAndEndDate(date, selectedStartDate, selectedEndDate);
-    updatedDates = updatedDates || this._noEndDate(date, selectedStartDate, selectedEndDate);
-    updatedDates = updatedDates || this._noStartDate(date, selectedStartDate, selectedEndDate);
-    updatedDates = updatedDates || this._noStartOrEndDate(date, selectedStartDate, selectedEndDate);
-
-    this.props.onDateSelect(updatedDates[0], updatedDates[1]);
-  },
-
-  _startAndEndDate (selected, start, end) {
-    let updatedDates;
-
-    if (start && end) {
-      if (selected < start && selected < end) {
-        updatedDates = [selected, end];
-      } else if ((selected > start && selected < end) || selected > end) {
-        updatedDates = [start, selected];
-      }
+    if (existingRangeComplete || existingRangeEmpty) {
+      startDate = date;
+      endDate = null;
+    } else {
+      startDate = this.props.selectedStartDate;
+      endDate = date;
     }
 
-    return updatedDates;
-  },
+    const modifiedRangeCompleteButDatesInversed = startDate && endDate && this._endDateIsBeforeStartDate(startDate, endDate);
 
-  _noEndDate (selected, start, end) {
-    let updatedDates;
-
-    if (start && !end) {
-      if (selected > start) {
-        updatedDates = [start, selected];
-      } else {
-        updatedDates = [selected, start];
-      }
+    if (modifiedRangeCompleteButDatesInversed) {
+      this.props.onDateSelect(endDate, startDate);
+    } else {
+      this.props.onDateSelect(startDate, endDate);
     }
-
-    return updatedDates;
-  },
-
-  _noStartDate (selected, start, end) {
-    let updatedDates;
-
-    if (!start && end) {
-      if (selected < end) {
-        updatedDates = [selected, end];
-      } else {
-        updatedDates = [end, selected];
-      }
-    }
-
-    return updatedDates;
-  },
-
-  _noStartOrEndDate (selected, start, end) {
-    return (!start && !end) ? [selected, end] : null;
-  },
-
-  _deselectDate (selected, start, end) {
-    let updatedDates;
-
-    if (selected === start) {
-      updatedDates = [null, end];
-    } else if (selected === end) {
-      updatedDates = [start, null];
-    }
-
-    return updatedDates;
   },
 
   _handleDefaultRangeSelection (range) {

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -312,9 +312,9 @@ const DateRangePicker = React.createClass({
               />
             </div>
             <div style={styles.calendarWeek}>
-              {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day) => {
+              {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => {
                 return (
-                  <div key={day} style={styles.calendarWeekDay}>
+                  <div key={day + i} style={styles.calendarWeekDay}>
                     {day}
                   </div>
                 );


### PR DESCRIPTION
### Issue

After using the `DateRangePicker` internally, we decided that it's current functionality didn't match intended behavior exactly.

The picker was working fine but in order to deselect a range you had the select the start and end date from the calendar.  This caused confusion and made it difficult to work with if a range crossed multiple months.

### Solution

The picker now clears the current range if the user clicks a date in the calendar and a complete range was already in place.  This does away with the confusion and prevents us from having to had the ability to clear the range via external means such as a button.

I also fixed a duplicate key warning that was caused by my last set of changes where we set the key for the days label header to use the day rather than an index.  Tuesday and Thursday are both represented by a `T` so we were getting a duplicate key warning.  We now use the index and day for the key.

#### New Behavior
![daterangepicker](https://cloud.githubusercontent.com/assets/6463914/16275500/7b36a06c-3867-11e6-9aca-503d3b605541.gif)
