### PR TITLE
Row component: Spread props to component div

### DIFF
--- a/src/components/grid/Row.js
+++ b/src/components/grid/Row.js
@@ -9,7 +9,7 @@ const Row = React.createClass({
     const styles = this.styles();
 
     return (
-      <div style={styles.component}>
+      <div {...this.props} style={styles.component}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
I have a need to add an onClick handler to a grid row internally.  This PR makes that possible.  If we don't want to spread props then I can change this to just add an onClick prop.