### PR TITLE
Move breakpoint resolutions to style constants

### DIFF
--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -1,6 +1,6 @@
 const React = require('react');
 
-const defaultBreakpoints = { large: 1200, medium: 750, small: 320 };
+const { BreakPoints } = require('../../constants/Style');
 const defaultSpan = { large: 12, medium: 12, small: 12 };
 const defaultOffset = { large: 0, medium: 0, small: 0 };
 
@@ -42,7 +42,7 @@ const Column = React.createClass({
   },
 
   _getWindowSize () {
-    const breakpoints = Object.assign({}, defaultBreakpoints, this.props.breakpoints);
+    const breakpoints = Object.assign({}, BreakPoints, this.props.breakpoints);
     const width = window.innerWidth;
     let windowSize = 'small';
 

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -1,4 +1,10 @@
 module.exports = {
+  BreakPoints: {
+    large: 1200,
+    medium: 750,
+    small: 320
+  },
+
   Colors: {
     // GRAYSCALE
     ASH: '#ACB0B3',

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -129,5 +129,19 @@ module.exports = {
     const b = parseInt(color.slice(5, 7), 16);
 
     return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + opacity + ')';
+  },
+
+  getWindowSize () {
+    const breakPoints = this.BreakPoints;
+    const width = window.innerWidth;
+    let windowSize = 'small';
+
+    if (width >= breakPoints.large) {
+      windowSize = 'large';
+    } else if (width >= breakPoints.medium) {
+      windowSize = 'medium';
+    }
+
+    return windowSize;
   }
 };


### PR DESCRIPTION
I'm starting to see a need to hide/show/change text and other elements based upon resolution as the grid system is only a start to making things responsive.  

This PR will make our lives a bit easier by doing the following.

- Moves the default break point resolutions to the `Style` constants file for easy reuse/access
- Adds a `getWindowSize` function to the `Style` constants file that returns a string telling you what break point the screen resolution currently is in. (ported from @jmophoto's `_getScreenResolution` function the `Column` component)
- Updates the `Column` component to use the break points now contained within the `Style` constants file.

NOTE:  I didn't replace @jmophoto's `_getScreenResolution` function in the `Column` component with the one from the `Style` constants because he is merging in a break point prop to allow for custom functionality for the `Column` component.
