### PR TITLE
Calendar: Set current date to minimum date if no selected date

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -68,7 +68,7 @@ const Calendar = React.createClass({
       const isCurrentMonth = startDate.isSame(moment.unix(this.state.currentDate), 'month');
       const isSelectedDay = startDate.isSame(moment.unix(this.props.selectedDate), 'day');
       const isToday = startDate.isSame(moment(), 'day');
-      const disabledDay = this.props.minimumDate ? startDate.isBefore(moment.unix(this.props.minimumDate)) : null;
+      const disabledDay = this.props.minimumDate ? startDate.isBefore(moment.unix(this.props.minimumDate), 'day') : null;
 
       const day = (
         <div

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -26,7 +26,7 @@ const Calendar = React.createClass({
 
   getInitialState () {
     return {
-      currentDate: this.props.selectedDate || moment().unix()
+      currentDate: this.props.selectedDate || this.props.minimumDate || moment().unix()
     };
   },
 


### PR DESCRIPTION
the current date is set to the selected date or today in the calendar. This adds the minimum date to that list. 

This allows for the calendar to be advanced to the minimum date.

This also adds `day` to the check for minimum date, otherwise if you send a timestamp of today at 4, the minimum date would not be selectable. 