### PR TITLE
Simple Input: add icon prop

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -2,12 +2,10 @@ const React = require('react');
 const Radium = require('radium');
 
 const Input = require('./SimpleInput');
-const Icon = require('./Icon');
-
-const StyleConstants = require('../constants/Style');
 
 const SearchInput = React.createClass({
   propTypes: {
+    baseColor: React.PropTypes.string,
     onBlur: React.PropTypes.func,
     onChange: React.PropTypes.func,
     placeholder: React.PropTypes.string,
@@ -28,21 +26,15 @@ const SearchInput = React.createClass({
 
     return (
       <div style={Object.assign({}, styles.component, this.props.style)}>
-        <div style={styles.searchBar}>
-          <Icon
-            size={20}
-            style={styles.searchIcon}
-            type={'search'}
-          />
-          <Input
-            onBlur={this.props.onBlur}
-            onChange={this.props.onChange}
-            placeholder={this.props.placeholder}
-            style={styles.searchInput}
-            type='text'
-            value={this.props.searchKeyword}
-          />
-        </div>
+        <Input
+          baseColor={this.props.baseColor}
+          icon='search'
+          onBlur={this.props.onBlur}
+          onChange={this.props.onChange}
+          placeholder={this.props.placeholder}
+          type='text'
+          value={this.props.searchKeyword}
+        />
       </div>
     );
   },
@@ -52,27 +44,6 @@ const SearchInput = React.createClass({
       component: {
         display: 'inline-block',
         width: '100%'
-      },
-      searchBar: {
-        position: 'relative',
-        marginBottom: 10
-      },
-      searchIcon: {
-        left: 10,
-        position: 'absolute',
-        top: '50%',
-        transform: 'translateY(-50%)'
-      },
-      searchInput: {
-        boxSizing: 'border-box',
-        lineHeight: StyleConstants.FontSizes.LARGE + 'px',
-        padding: '12px 10px 12px 40px',
-        outline: 'none',
-        boxShadow: 'none',
-
-        ':focus': {
-          backgroundColor: StyleConstants.Colors.WHITE
-        }
       }
     };
   }

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -1,5 +1,4 @@
 const React = require('react');
-const Radium = require('radium');
 
 const Input = require('./SimpleInput');
 
@@ -49,4 +48,4 @@ const SearchInput = React.createClass({
   }
 });
 
-module.exports = Radium(SearchInput);
+module.exports = SearchInput;

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -34,7 +34,7 @@ const Input = React.createClass({
 
   componentDidMount () {
     if (this.props.style) {
-      console.warn('The style prop is depricated and will be removed in a future release. Please used styles.');
+      console.warn('The style prop is deprecated and will be removed in a future release. Please used styles.');
     }
   },
 

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -1,5 +1,4 @@
 const React = require('react');
-const Radium = require('radium');
 const _merge = require('lodash/merge');
 
 const Icon = require('./Icon');
@@ -110,4 +109,4 @@ const Input = React.createClass({
   }
 });
 
-module.exports = Radium(Input);
+module.exports = Input;

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -1,56 +1,112 @@
 const React = require('react');
 const Radium = require('radium');
+const _merge = require('lodash/merge');
 
+const Icon = require('./Icon');
 const StyleConstants = require('../constants/Style');
 
 const Input = React.createClass({
   propTypes: {
+    baseColor: React.PropTypes.string,
+    icon: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     style: React.PropTypes.oneOfType([
       React.PropTypes.array,
       React.PropTypes.object
     ]),
+    styles: React.PropTypes.object,
     type: React.PropTypes.string,
     valid: React.PropTypes.bool
   },
 
   getDefaultProps () {
     return {
+      baseColor: StyleConstants.Colors.PRIMARY,
       type: 'text',
       valid: true
     };
+  },
+
+  getInitialState () {
+    return {
+      focus: false
+    };
+  },
+
+  componentDidMount () {
+    if (this.props.style) {
+      console.warn('The style prop is depricated and will be removed in a future release. Please used styles.');
+    }
+  },
+
+  _onFocus () {
+    this.refs.input.focus();
+
+    this.setState({
+      focus: true
+    });
+  },
+
+  _onBlur () {
+    this.refs.input.blur();
+
+    this.setState({
+      focus: false
+    });
   },
 
   render () {
     const styles = this.styles();
 
     return (
-      <input
-        {...this.props}
-        style={Object.assign({}, styles.wrapper, this.props.style)}
-        type={this.props.type}
-      />
+      <div
+        onBlur={this._onBlur}
+        onFocus={this._onFocus}
+        style={Object.assign({}, styles.wrapper, this.state.focus ? styles.activeWrapper : null)}
+        tabIndex={0}
+      >
+        {this.props.icon ? (
+          <Icon size={20} style={styles.icon} type={this.props.icon} />
+        ) : null}
+        <input
+          {...this.props}
+          ref='input'
+          style={styles.input}
+          type={this.props.type}
+        />
+      </div>
     );
   },
 
   styles () {
-    return {
-      wrapper: {
+    return _merge({}, {
+      wrapper: Object.assign({}, {
+        padding: StyleConstants.Spacing.SMALL,
+        boxSizing: 'border-box',
         backgroundColor: StyleConstants.Colors.WHITE,
         border: this.props.valid ? '1px solid ' + StyleConstants.Colors.FOG : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
         borderRadius: 3,
-        padding: 10,
+        display: 'flex',
+        alignItems: 'center',
         width: '100%',
-        WebkitAppearance: 'none',
-
-        ':focus': {
-          backgroundColor: StyleConstants.Colors.WHITE,
-          border: '1px solid ' + StyleConstants.Colors.PRIMARY,
-          outline: 'none',
-          boxShadow: 'none'
-        }
+        outline: 'none',
+        boxShadow: 'none'
+      }, this.props.style),
+      activeWrapper: {
+        border: '1px solid ' + this.props.baseColor
+      },
+      icon: {
+        paddingRight: StyleConstants.Spacing.XSMALL,
+        fill: this.props.baseColor
+      },
+      input: {
+        flex: '1 0 0%',
+        backgroundColor: StyleConstants.Colors.WHITE,
+        border: 'none',
+        outline: 'none',
+        boxShadow: 'none'
       }
-    };
+    }, this.props.styles);
   }
 });
 


### PR DESCRIPTION
This adds an icon prop to the simple input component following the pattern of the date/time inputs and buttons.

- add baseColor prop for active border and icon
- add icon prop
- add styles prop that gets merged with the component style
- set baseColor to default to PRIMARY
- use onBlur and onFocus to set active border color
- remove radium

This should be backwards compatible with a warning when a `style` prop is used.

Also updates the SearchInput component to use the icon prop.

Input with Icon and SearchInput
![screen shot 2016-07-05 at 11 21 24 am](https://cloud.githubusercontent.com/assets/488916/16594824/6c6a6f7c-42a9-11e6-8e6d-5ea86f1da478.png)

Deprecation warning
![screen shot 2016-07-05 at 11 21 35 am](https://cloud.githubusercontent.com/assets/488916/16594829/6c6e5c72-42a9-11e6-9383-ac87b187e9d9.png)

Testing internal uses
![screen shot 2016-07-05 at 11 37 57 am](https://cloud.githubusercontent.com/assets/488916/16594826/6c6cddb6-42a9-11e6-9a4b-7b357578badf.png)
![screen shot 2016-07-05 at 11 48 06 am](https://cloud.githubusercontent.com/assets/488916/16594827/6c6dae94-42a9-11e6-80dd-1e4c1d224952.png)
![screen shot 2016-07-05 at 11 58 39 am](https://cloud.githubusercontent.com/assets/488916/16594825/6c6c3d34-42a9-11e6-867a-8c02e959d107.png)
