### PR TITLE
Date time responsive

### DIFF
--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -3,6 +3,7 @@ const moment = require('moment-timezone/builds/moment-timezone-with-data.min');
 
 const Calendar = require('./Calendar');
 const Column = require('./grid/Column');
+const Container = require('./grid/Container');
 const Icon = require('./Icon');
 const Row = require('./grid/Row');
 
@@ -147,100 +148,94 @@ const DatePicker = React.createClass({
 
   render () {
     const styles = this.styles();
+    const inputSize = this.props.children ? 5 : 6;
 
     return (
-      <Row style={styles.component}>
-        <Column
-          span={{ large: 5, medium: 5, small: 12 }}
-        >
-          <div
-            onBlur={this._handleDateBlur}
-            onClick={this._handleDateClick}
-            onFocus={this._handleDateFocus}
-            ref='dateSelect'
-            style={Object.assign({}, styles.selectWrapper, this.state.showCalendar ? styles.activeSelectWrapper : null)}
-            tabIndex={0}
-          >
-            {this.props.showIcons ? (
+      <Container fluid={true}>
+        <Row>
+          <Column span={{ large: inputSize, medium: inputSize, small: 12 }}>
+            <div
+              onBlur={this._handleDateBlur}
+              onClick={this._handleDateClick}
+              onFocus={this._handleDateFocus}
+              ref='dateSelect'
+              style={Object.assign({}, styles.selectWrapper, this.state.showCalendar ? styles.activeSelectWrapper : null)}
+              tabIndex={0}
+            >
+              {this.props.showIcons ? (
+                <Icon
+                  size={20}
+                  style={styles.selectedIcon}
+                  type={this.props.dateIcon}
+                />
+              ) : null}
+              <div style={styles.selectedText}>
+                {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.dateFormat) : this.props.datePlaceholder}
+              </div>
               <Icon
                 size={20}
-                style={styles.selectedIcon}
-                type={this.props.dateIcon}
+                style={styles.selectedDateCaret}
+                type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
+              />
+            {this.state.showCalendar ? (
+              <Calendar
+                {...this.props}
+                onDateSelect={this._handleDateSelect}
+                style={styles.calendar}
               />
             ) : null}
-            <div style={styles.selectedText}>
-              {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.dateFormat) : this.props.datePlaceholder}
             </div>
-            <Icon
-              size={20}
-              style={styles.selectedDateCaret}
-              type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
-            />
-          {this.state.showCalendar ? (
-            <Calendar
-              {...this.props}
-              onDateSelect={this._handleDateSelect}
-              style={styles.calendar}
-            />
-          ) : null}
-          </div>
-        </Column>
-        {this.props.children ? (
-          <Column
-            span={{ large: 1, medium: 1, small: 12 }}
-            style={styles.children}
-          >
-              {this.props.children}
           </Column>
-        ) : null}
-        <Column
-          span={{ large: 6, medium: 6, small: 12 }}
-        >
-          <div
-            onBlur={this._handleTimeBlur}
-            onFocus={this._handleTimeFocus}
-            style={Object.assign({}, styles.selectWrapper, this.state.editTime ? styles.activeSelectWrapper : null)}
-            tabIndex={0}
-          >
-            {this.props.showIcons ? (
-              <Icon
-                size={20}
-                style={styles.selectedIcon}
-                type={this.props.timeIcon}
-              />
-            ) : null}
-            {this.state.editTime ? (
-              <input
-                autoFocus={true}
-                defaultValue={this.state.editTime ? moment.unix(this.props.selectedDate).format('HH:mm') : null}
-                name='time'
-                onBlur={this._handleTimeSelect}
-                ref='timeInput'
-                style={styles.timeInput}
-                type='time'
-              />
-            ) : (
-              <div style={styles.timeDisplay}>
-                {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.timeFormat) : this.props.timePlaceholder}
+          {this.props.children ? (
+            <Column span={{ large: 1, medium: 1, small: 12 }}>
+              <div style={styles.children}>
+                {this.props.children}
               </div>
-            )}
-            {this.props.timezoneFormat ? (
-              <div style={styles.timezone}>
-                {this._getTimezone(this.props.selectedDate)}
-              </div>
-            ) : null}
-          </div>
-        </Column>
-      </Row>
+            </Column>
+          ) : null}
+          <Column span={{ large: 6, medium: 6, small: 12 }}>
+            <div
+              onBlur={this._handleTimeBlur}
+              onFocus={this._handleTimeFocus}
+              style={Object.assign({}, styles.selectWrapper, this.state.editTime ? styles.activeSelectWrapper : null)}
+              tabIndex={0}
+            >
+              {this.props.showIcons ? (
+                <Icon
+                  size={20}
+                  style={styles.selectedIcon}
+                  type={this.props.timeIcon}
+                />
+              ) : null}
+              {this.state.editTime ? (
+                <input
+                  autoFocus={true}
+                  defaultValue={this.state.editTime ? moment.unix(this.props.selectedDate).format('HH:mm') : null}
+                  name='time'
+                  onBlur={this._handleTimeSelect}
+                  ref='timeInput'
+                  style={styles.timeInput}
+                  type='time'
+                />
+              ) : (
+                <div style={styles.timeDisplay}>
+                  {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.timeFormat) : this.props.timePlaceholder}
+                </div>
+              )}
+              {this.props.timezoneFormat ? (
+                <div style={styles.timezone}>
+                  {this._getTimezone(this.props.selectedDate)}
+                </div>
+              ) : null}
+            </div>
+          </Column>
+        </Row>
+      </Container>
     );
   },
 
   styles () {
     return Object.assign({}, {
-      component: {
-        alignItems: 'center',
-        display: 'flex'
-      },
       children: {
         textAlign: 'center'
       },

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -153,7 +153,7 @@ const DatePicker = React.createClass({
     return (
       <Container fluid={true}>
         <Row>
-          <Column span={spans.dateColumn}>
+          <Column span={spans.date}>
             <div
               onBlur={this._handleDateBlur}
               onClick={this._handleDateClick}
@@ -187,13 +187,13 @@ const DatePicker = React.createClass({
             </div>
           </Column>
           {this.props.children ? (
-            <Column span={spans.childrenColumn}>
+            <Column span={spans.children}>
               <div style={styles.children}>
                 {this.props.children}
               </div>
             </Column>
           ) : null}
-          <Column span={spans.timeColumn}>
+          <Column span={spans.time}>
             <div
               onBlur={this._handleTimeBlur}
               onFocus={this._handleTimeFocus}
@@ -235,25 +235,25 @@ const DatePicker = React.createClass({
   },
 
   spans () {
-    return Object.assign({}, {
-      dateColumn: {
+    return {
+      date: {
         large: this.props.children ? 5 : 6,
         medium: this.props.children ? 5 : 6,
         small: 12
       },
 
-      childrenColumn: {
+      children: {
         large: 1,
         medium: 1,
         small: 12
       },
 
-      timeColumn: {
+      time: {
         large: 6,
         medium: 6,
         small: 12
       }
-    });
+    };
   },
 
   styles () {

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -231,7 +231,6 @@ const DatePicker = React.createClass({
           </Column>
         </Row>
       </Container>
-
     );
   },
 

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -2,7 +2,9 @@ const React = require('react');
 const moment = require('moment-timezone/builds/moment-timezone-with-data.min');
 
 const Calendar = require('./Calendar');
+const Column = require('./grid/Column');
 const Icon = require('./Icon');
+const Row = require('./grid/Row');
 
 const StyleConstants = require('../constants/Style');
 
@@ -147,76 +149,89 @@ const DatePicker = React.createClass({
     const styles = this.styles();
 
     return (
-      <div style={styles.component}>
-        <div
-          onBlur={this._handleDateBlur}
-          onClick={this._handleDateClick}
-          onFocus={this._handleDateFocus}
-          ref='dateSelect'
-          style={Object.assign({}, styles.selectWrapper, this.state.showCalendar ? styles.activeSelectWrapper : null)}
-          tabIndex={0}
+      <Row style={styles.component}>
+        <Column
+          span={{ large: 5, medium: 5, small: 12 }}
         >
-          {this.props.showIcons ? (
+          <div
+            onBlur={this._handleDateBlur}
+            onClick={this._handleDateClick}
+            onFocus={this._handleDateFocus}
+            ref='dateSelect'
+            style={Object.assign({}, styles.selectWrapper, this.state.showCalendar ? styles.activeSelectWrapper : null)}
+            tabIndex={0}
+          >
+            {this.props.showIcons ? (
+              <Icon
+                size={20}
+                style={styles.selectedIcon}
+                type={this.props.dateIcon}
+              />
+            ) : null}
+            <div style={styles.selectedText}>
+              {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.dateFormat) : this.props.datePlaceholder}
+            </div>
             <Icon
               size={20}
-              style={styles.selectedIcon}
-              type={this.props.dateIcon}
+              style={styles.selectedDateCaret}
+              type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
+            />
+          {this.state.showCalendar ? (
+            <Calendar
+              {...this.props}
+              onDateSelect={this._handleDateSelect}
+              style={styles.calendar}
             />
           ) : null}
-          <div style={styles.selectedText}>
-            {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.dateFormat) : this.props.datePlaceholder}
           </div>
-          <Icon
-            size={20}
-            style={styles.selectedDateCaret}
-            type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
-          />
-        {this.state.showCalendar ? (
-          <Calendar
-            {...this.props}
-            onDateSelect={this._handleDateSelect}
-            style={styles.calendar}
-          />
+        </Column>
+        {this.props.children ? (
+          <Column
+            span={{ large: 1, medium: 1, small: 12 }}
+            style={styles.children}
+          >
+              {this.props.children}
+          </Column>
         ) : null}
-        </div>
-        <div>
-          {this.props.children}
-        </div>
-        <div
-          onBlur={this._handleTimeBlur}
-          onFocus={this._handleTimeFocus}
-          style={Object.assign({}, styles.selectWrapper, this.state.editTime ? styles.activeSelectWrapper : null)}
-          tabIndex={0}
+        <Column
+          span={{ large: 6, medium: 6, small: 12 }}
         >
-          {this.props.showIcons ? (
-            <Icon
-              size={20}
-              style={styles.selectedIcon}
-              type={this.props.timeIcon}
-            />
-          ) : null}
-          {this.state.editTime ? (
-            <input
-              autoFocus={true}
-              defaultValue={this.state.editTime ? moment.unix(this.props.selectedDate).format('HH:mm') : null}
-              name='time'
-              onBlur={this._handleTimeSelect}
-              ref='timeInput'
-              style={styles.timeInput}
-              type='time'
-            />
-          ) : (
-            <div style={styles.timeDisplay}>
-              {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.timeFormat) : this.props.timePlaceholder}
-            </div>
-          )}
-          {this.props.timezoneFormat ? (
-            <div style={styles.timezone}>
-              {this._getTimezone(this.props.selectedDate)}
-            </div>
-          ) : null}
-        </div>
-      </div>
+          <div
+            onBlur={this._handleTimeBlur}
+            onFocus={this._handleTimeFocus}
+            style={Object.assign({}, styles.selectWrapper, this.state.editTime ? styles.activeSelectWrapper : null)}
+            tabIndex={0}
+          >
+            {this.props.showIcons ? (
+              <Icon
+                size={20}
+                style={styles.selectedIcon}
+                type={this.props.timeIcon}
+              />
+            ) : null}
+            {this.state.editTime ? (
+              <input
+                autoFocus={true}
+                defaultValue={this.state.editTime ? moment.unix(this.props.selectedDate).format('HH:mm') : null}
+                name='time'
+                onBlur={this._handleTimeSelect}
+                ref='timeInput'
+                style={styles.timeInput}
+                type='time'
+              />
+            ) : (
+              <div style={styles.timeDisplay}>
+                {this.props.selectedDate ? moment.unix(this.props.selectedDate).format(this.props.timeFormat) : this.props.timePlaceholder}
+              </div>
+            )}
+            {this.props.timezoneFormat ? (
+              <div style={styles.timezone}>
+                {this._getTimezone(this.props.selectedDate)}
+              </div>
+            ) : null}
+          </div>
+        </Column>
+      </Row>
     );
   },
 
@@ -224,8 +239,10 @@ const DatePicker = React.createClass({
     return Object.assign({}, {
       component: {
         alignItems: 'center',
-        display: 'flex',
-        width: '100%'
+        display: 'flex'
+      },
+      children: {
+        textAlign: 'center'
       },
 
       // Select styles

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -148,12 +148,12 @@ const DatePicker = React.createClass({
 
   render () {
     const styles = this.styles();
-    const inputSize = this.props.children ? 5 : 6;
+    const spans = this.spans();
 
     return (
       <Container fluid={true}>
         <Row>
-          <Column span={{ large: inputSize, medium: inputSize, small: 12 }}>
+          <Column span={spans.dateColumn}>
             <div
               onBlur={this._handleDateBlur}
               onClick={this._handleDateClick}
@@ -187,13 +187,13 @@ const DatePicker = React.createClass({
             </div>
           </Column>
           {this.props.children ? (
-            <Column span={{ large: 1, medium: 1, small: 12 }}>
+            <Column span={spans.childrenColumn}>
               <div style={styles.children}>
                 {this.props.children}
               </div>
             </Column>
           ) : null}
-          <Column span={{ large: 6, medium: 6, small: 12 }}>
+          <Column span={spans.timeColumn}>
             <div
               onBlur={this._handleTimeBlur}
               onFocus={this._handleTimeFocus}
@@ -232,6 +232,28 @@ const DatePicker = React.createClass({
         </Row>
       </Container>
     );
+  },
+
+  spans () {
+    return Object.assign({}, {
+      dateColumn: {
+        large: this.props.children ? 5 : 6,
+        medium: this.props.children ? 5 : 6,
+        small: 12
+      },
+
+      childrenColumn: {
+        large: 1,
+        medium: 1,
+        small: 12
+      },
+
+      timeColumn: {
+        large: 6,
+        medium: 6,
+        small: 12
+      }
+    });
   },
 
   styles () {


### PR DESCRIPTION
Addresses part of https://github.com/mxenabled/mx-react-components/issues/363
This adds the grid system to the DateTimePicker component to make it responsive. The only changes needed were to the inputs as the calendar on the date portion is already small enough for the smallest viewport. There are upcoming change to the grid system that should be deployed before this PR is reviewed. 

#### Large
![screen shot 2016-07-06 at 3 12 25 pm](https://cloud.githubusercontent.com/assets/1916697/16634705/251fddda-438c-11e6-82e5-ed86ff30ee06.png)

#### Medium
![screen shot 2016-07-06 at 3 12 35 pm](https://cloud.githubusercontent.com/assets/1916697/16634707/2a72e390-438c-11e6-84a5-62b16b14c18a.png)

#### Small
![screen shot 2016-07-06 at 3 13 47 pm](https://cloud.githubusercontent.com/assets/1916697/16634745/4f07cc52-438c-11e6-98b6-5f753f4caae6.png)
