### PR TITLE
Column: fix offset

### DIFF
--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -14,7 +14,7 @@ const Column = React.createClass({
 
   getDefaultProps () {
     return {
-      offset: { large: 0, medium: 0, small: 0 },
+      offset: {},
       span: { large: 12, medium: 12, small: 12 }
     };
   },
@@ -49,20 +49,20 @@ const Column = React.createClass({
 
   getColumnOffsets () {
     const offsets = [];
-    const small = this.props.offset.small || 0;
-    const medium = this.props.offset.medium || 0;
-    const large = this.props.offset.large || 0;
+    const small = this.props.offset.small;
+    const medium = this.props.offset.medium;
+    const large = this.props.offset.large;
 
     // Column offsets
-    if (small !== 0) {
+    if (small >= 0) {
       offsets.push('col-sm-offset-' + small);
     }
 
-    if (medium !== 0 && medium !== small) {
+    if (medium >= 0 && medium !== small) {
       offsets.push('col-md-offset-' + medium);
     }
 
-    if (large !== 0 && large !== medium) {
+    if (large >= 0 && large !== medium) {
       offsets.push('col-lg-offset-' + large);
     }
 


### PR DESCRIPTION
There was an issue resetting the column offset for medium and large if small was set.

`offset: { small: 2 }`
Sets the offset of small, medium and large to 2, as expected.

`offset: { small: 2, medium: 0}`
Expected to set small to two and medium and large to 0, but didn't.

This was because of the check for `=== 0` in medium and large.

- Remove defaults for offset
- Remove `|| 0` from constants
- Check if prop exists with `>=` since just checking the prop would return false with `0`

This was tested in the Budget action bar where the offset is used.

@cerinman 

