### PR TITLE
Make Drawer component wrapper div fixed positioned

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -162,9 +162,10 @@ const Drawer = React.createClass({
       componentWrapper: {
         bottom: 0,
         left: 0,
-        position: 'absolute',
+        position: 'fixed',
         right: 0,
-        top: 0
+        top: 0,
+        zIndex: 999
       },
       content: {
         backgroundColor: StyleConstants.Colors.WHITE,


### PR DESCRIPTION
### Issue

The drawer could be scrolled off screen due to being positioned absolute.

### Solution

The makes the component wrapper div of the Drawer component fixed positioned.  It also adds a z-index of 999.  The z-index number was chosen based upon the Drawer component's scrim being at z-index 1000 and it's contents at 1001.

#### Screen shot
![screen shot 2016-07-11 at 10 07 35 am](https://cloud.githubusercontent.com/assets/6463914/16737714/d59b58b2-474f-11e6-9042-6c5cb5d903ed.png)
