### PR TITLE
Change the Column span prop so it behaves more like Bootstrap

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -452,19 +452,23 @@ const Demo = React.createClass({
               >
                 <div style={styles.responsiveDiv}>1</div>
               </Column>
+            </Row>
+            <Row>
               <Column span={{ large: 4, medium: 3, small: 10 }} >
                 <div style={styles.responsiveDiv}>2</div>
               </Column>
               <Column
-                span={{ large: 4, medium: 9 }}
+                span={{ large: 4, medium: 6, small: 0 }}
               >
                 <div style={styles.responsiveDiv}>3</div>
               </Column>
               <Column
-                span={{ large: 4 }}
+                span={{ large: 4, medium: 9, small: 2 }}
               >
                 <div style={styles.responsiveDiv}>4</div>
               </Column>
+            </Row>
+            <Row>
               <Column
                 order={{ medium: -1 }}
                 span={{ large: 3, medium: 6, small: 9 }}
@@ -473,10 +477,12 @@ const Demo = React.createClass({
               </Column>
               <Column
                 order={{ medium: -2 }}
-                span={{ large: 3, medium: 6, small: 9 }}
+                span={{ large: 9, medium: 6, small: 3 }}
               >
                 <div style={styles.responsiveDiv}>6</div>
               </Column>
+            </Row>
+            <Row>
               <Column
                 span={{ large: 6 }}
               >
@@ -485,18 +491,20 @@ const Demo = React.createClass({
               <Column
                 span={{ large: 6, medium: 9 }}
               >
-                <Row>
-                  <Column
-                    span={{ large: 6, medium: 6, small: 6 }}
-                  >
-                    <div style={styles.responsiveDiv}>8</div>
-                  </Column>
-                  <Column
-                    span={{ large: 6, medium: 6, small: 6 }}
-                  >
-                    <div style={styles.responsiveDiv}>9</div>
-                  </Column>
-                </Row>
+                <Container>
+                  <Row>
+                    <Column
+                      span={{ large: 6, medium: 6, small: 6 }}
+                    >
+                      <div style={styles.responsiveDiv}>nested-8</div>
+                    </Column>
+                    <Column
+                      span={{ large: 6, medium: 6, small: 6 }}
+                    >
+                      <div style={styles.responsiveDiv}>nested-9</div>
+                    </Column>
+                  </Row>
+                </Container>
               </Column>
             </Row>
           </Container>

--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -15,32 +15,30 @@ const Column = React.createClass({
   getDefaultProps () {
     return {
       offset: {},
-      span: { large: 12, medium: 12, small: 12 }
+      span: { large: 12 }
     };
   },
 
   getColumnWidths () {
     const colWidths = [];
-    const small = this.props.span.small || 0;
-    const medium = this.props.span.medium || 0;
-    const large = this.props.span.large || 0;
+    const { large, medium, small } = this.props.span;
 
     // Column widths
     if (small === 0) {
       colWidths.push('hidden-sm');
-    } else {
+    } else if (small) {
       colWidths.push('col-sm-' + small);
     }
 
     if (medium === 0) {
       colWidths.push('hidden-md');
-    } else if (medium !== small) {
+    } else if (medium && medium !== small) {
       colWidths.push('col-md-' + medium);
     }
 
     if (large === 0) {
       colWidths.push('hidden-lg');
-    } else if (large !== medium) {
+    } else if (large && large !== medium) {
       colWidths.push('col-lg-' + large);
     }
 


### PR DESCRIPTION
This fixes a problem where the spans were defaulted to 0 when only one
or two of the spans were provided as props which caused the hidden-*
class to be applied causing surprising behavior.

Before:
`<Column span={ large:6, medium:6, small:6 }>`

After:
`<Column span={small:6}>`
This will result in a span of `{ large:6, medium:6, small:6 }`