### PR TITLE
Remove illeagal attributes causing react warnings

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -38,7 +38,7 @@ const Button = React.createClass({
     const styles = this.styles();
 
     return (
-      <div {...this.props} onClick={this.props.type === 'disabled' ? null : this.props.onClick} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
+      <div onClick={this.props.type === 'disabled' ? null : this.props.onClick} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
         <div style={styles.children}>
           {(this.props.icon && !this.props.isActive) ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
           {this.props.isActive ? (

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -35,7 +35,7 @@ const ButtonGroup = React.createClass({
     const styles = this.styles();
 
     return (
-      <div {...this.props}>
+      <div>
         {this.props.buttons.map((button, i) => {
           const isFirstChild = i === 0;
           const isLastChild = i === this.props.buttons.length - 1;

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1330,7 +1330,6 @@ const Icon = React.createClass({
       <svg
         {...this.props}
         className='mx-icon'
-        fit={true}
         preserveAspectRatio='xMidYMid meet'
         style={styles.component}
         viewBox='0 0 512 512'


### PR DESCRIPTION
Remove {...this.props} on buttonGroup and button containing divs and the fit attribute on the svg.

Checking https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg, I don't see that `fit` is a valid attribute on an svg.

I tested these changes in Serenity and everything appears to be functioning correctly.

