### PR TITLE
Progress Bar: limit width to 100%

### DIFF
--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -41,7 +41,7 @@ const ProgressBar = React.createClass({
         backgroundColor: this.props.progressColor,
         borderRadius: this.props.height / 4,
         height: this.props.height,
-        width: this.props.percentage + '%'
+        width: this.props.percentage > 100 ? '100%' : this.props.percentage + '%'
       }
     }, this.props.styles);
   }


### PR DESCRIPTION
This limits the width of the progress bar to 100% when a percentage over 100 is passed in.

