### PR TITLE
Display input tweaks/fixes

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -166,7 +166,7 @@ const DisplayInput = React.createClass({
 
       status: {
         paddingBottom: StyleConstants.Spacing.XSMALL,
-        paddingLeft: StyleConstants.Spacing.SMALL,
+        paddingLeft: isLargeOrMediumWindowSize ? StyleConstants.Spacing.SMALL : StyleConstants.Spacing.XSMALL,
         paddingRight: StyleConstants.Spacing.SMALL,
         paddingTop: StyleConstants.Spacing.XSMALL
       },

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -65,7 +65,7 @@ const DisplayInput = React.createClass({
             ) : null }
 
             <Column relative={!hasChildren} span={inputColumn}>
-              {this.props.children ? (
+              {hasChildren ? (
                 <div style={styles.children}>
                   {this.props.children}
                 </div>
@@ -136,19 +136,13 @@ const DisplayInput = React.createClass({
       inputWrapper: {
         alignItems: 'center',
         display: 'flex',
-        paddingBottom: StyleConstants.Spacing.SMALL,
-        paddingLeft: StyleConstants.Spacing.SMALL,
-        paddingRight: StyleConstants.Spacing.SMALL,
-        paddingTop: StyleConstants.Spacing.SMALL
+        padding: StyleConstants.Spacing.SMALL
       },
 
       children: {
         alignItems: 'center',
         display: 'flex',
-        paddingBottom: StyleConstants.Spacing.SMALL,
-        paddingLeft: StyleConstants.Spacing.SMALL,
-        paddingRight: StyleConstants.Spacing.SMALL,
-        paddingTop: StyleConstants.Spacing.SMALL
+        padding: StyleConstants.Spacing.SMALL
       },
 
       labelText: {

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -125,9 +125,7 @@ const DisplayInput = React.createClass({
         border: '1px solid transparent',
         fontSize: StyleConstants.FontSizes.LARGE,
         height: isLargeOrMediumWindowSize ? '100%' : '75%',
-        paddingBottom: isLargeOrMediumWindowSize ? 10 : 0,
-        paddingTop: 0,
-        paddingLeft: textIndent,
+        paddingBottom: isLargeOrMediumWindowSize ? 20 : 0,
         textAlign: 'left',
         width: '100%',
 
@@ -140,16 +138,19 @@ const DisplayInput = React.createClass({
       inputWrapper: {
         alignItems: 'center',
         display: 'flex',
-        height: isLargeOrMediumWindowSize ? 43 : 70
+        paddingBottom: StyleConstants.Spacing.SMALL,
+        paddingLeft: StyleConstants.Spacing.SMALL,
+        paddingRight: StyleConstants.Spacing.SMALL,
+        paddingTop: StyleConstants.Spacing.SMALL
       },
 
       children: {
         alignItems: 'center',
         display: 'flex',
-        height: isLargeOrMediumWindowSize ? 43 : 70,
-        paddingBottom: isLargeOrMediumWindowSize ? 10 : 0,
-        paddingTop: 0,
-        paddingLeft: textIndent,
+        paddingBottom: StyleConstants.Spacing.SMALL,
+        paddingLeft: StyleConstants.Spacing.SMALL,
+        paddingRight: StyleConstants.Spacing.SMALL,
+        paddingTop: StyleConstants.Spacing.SMALL,
         width: '100%'
       },
 

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -54,7 +54,7 @@ const DisplayInput = React.createClass({
         <div style={styles.wrapper}>
           <Row>
             {this.props.label ? (
-              <Column span={labelColumn} style={styles.label}>
+              <Column span={labelColumn}>
                 <div key='label' style={styles.label}>
                   <div style={Object.assign({}, styles.labelText, this.props.labelStyle)}>
                     {this.props.label}
@@ -188,8 +188,10 @@ const DisplayInput = React.createClass({
       wrapper: Object.assign({
         borderBottom: this.props.valid ? '1px solid ' + StyleConstants.Colors.FOG : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
         height: isLargeOrMediumWindowSize ? 43 : 70,
+        paddingBottom: StyleConstants.Spacing.XSMALL,
         paddingLeft: -10,
         paddingRight: -10,
+        paddingTop: StyleConstants.Spacing.XSMALL,
         transition: 'all .2s ease-in',
         WebkitAppearance: 'none',
         whiteSpace: 'nowrap',

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -91,22 +91,21 @@ const DisplayInput = React.createClass({
           </Row>
         </div>
 
-        {this.props.status ? (
-          <Row>
+        <Row>
+          {this.props.status ? (
             <Column offset={twoWidthColumn} span={statusColumn} >
               <div style={styles.status}>
                 <div style={styles[this.props.status.type]}>{this.props.status.message}</div>
               </div>
             </Column>
-          </Row>
-        ) : null}
+          ) : null}
+        </Row>
       </Container>
     );
   },
 
   styles () {
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize();
-    const textIndent = isLargeOrMediumWindowSize ? 20 : 10;
 
     return {
       error: {
@@ -124,8 +123,6 @@ const DisplayInput = React.createClass({
         backgroundColor: 'transparent',
         border: '1px solid transparent',
         fontSize: StyleConstants.FontSizes.LARGE,
-        height: isLargeOrMediumWindowSize ? '100%' : '75%',
-        paddingBottom: isLargeOrMediumWindowSize ? 20 : 0,
         textAlign: 'left',
         width: '100%',
 
@@ -150,32 +147,27 @@ const DisplayInput = React.createClass({
         paddingBottom: StyleConstants.Spacing.SMALL,
         paddingLeft: StyleConstants.Spacing.SMALL,
         paddingRight: StyleConstants.Spacing.SMALL,
-        paddingTop: StyleConstants.Spacing.SMALL,
-        width: '100%'
+        paddingTop: StyleConstants.Spacing.SMALL
       },
 
       labelText: {
         aligntItems: 'center',
         color: StyleConstants.Colors.CHARCOAL,
         display: 'flex',
-        height: isLargeOrMediumWindowSize ? '100%' : '25%',
         fontSize: StyleConstants.FontSizes.SMALL,
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
-        paddingBottom: StyleConstants.Spacing.MEDIUM,
+        paddingBottom: isLargeOrMediumWindowSize ? StyleConstants.Spacing.MEDIUM : StyleConstants.Spacing.XSMALL,
         paddingLeft: StyleConstants.Spacing.SMALL,
         paddingRight: StyleConstants.Spacing.SMALL,
-        paddingTop: StyleConstants.Spacing.MEDIUM,
-        textAlign: 'left',
-        width: '100%'
+        paddingTop: isLargeOrMediumWindowSize ? StyleConstants.Spacing.MEDIUM : StyleConstants.Spacing.XSMALL,
+        textAlign: 'left'
       },
 
       status: {
-        height: 10,
-        paddingLeft: textIndent,
-        paddingRight: StyleConstants.Spacing.SMALL,
         paddingBottom: StyleConstants.Spacing.XSMALL,
-        paddingTop: StyleConstants.Spacing.XSMALL,
-        width: '50%'
+        paddingLeft: StyleConstants.Spacing.SMALL,
+        paddingRight: StyleConstants.Spacing.SMALL,
+        paddingTop: StyleConstants.Spacing.XSMALL
       },
 
       success: {
@@ -184,10 +176,10 @@ const DisplayInput = React.createClass({
 
       wrapper: Object.assign({
         borderBottom: this.props.valid ? '1px solid ' + StyleConstants.Colors.FOG : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
-        height: isLargeOrMediumWindowSize ? 43 : 70,
+        boxSizing: 'border-box',
         paddingBottom: StyleConstants.Spacing.XSMALL,
-        paddingLeft: -10,
-        paddingRight: -10,
+        marginLeft: isLargeOrMediumWindowSize ? 0 : -10,
+        marginRight: isLargeOrMediumWindowSize ? 0 : -10,
         paddingTop: StyleConstants.Spacing.XSMALL,
         transition: 'all .2s ease-in',
         WebkitAppearance: 'none',

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -37,6 +37,7 @@ const DisplayInput = React.createClass({
 
   render () {
     // Methods
+    const hasChildren = !!this.props.children;
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize();
     const showHint = this.props.showHint && !this.props.status && isLargeOrMediumWindowSize;
 
@@ -63,7 +64,7 @@ const DisplayInput = React.createClass({
               </Column>
             ) : null }
 
-            <Column relative={!!this.props.children} span={inputColumn}>
+            <Column relative={!hasChildren} span={inputColumn}>
               {this.props.children ? (
                 <div style={styles.children}>
                   {this.props.children}

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -55,7 +55,7 @@ const DisplayInput = React.createClass({
           <Row>
             {this.props.label ? (
               <Column span={labelColumn}>
-                <div key='label' style={styles.label}>
+                <div>
                   <div style={Object.assign({}, styles.labelText, this.props.labelStyle)}>
                     {this.props.label}
                   </div>
@@ -153,12 +153,6 @@ const DisplayInput = React.createClass({
         width: '100%'
       },
 
-      label: {
-        ':focus': {
-          color: this.props.primaryColor
-        }
-      },
-
       labelText: {
         aligntItems: 'center',
         color: StyleConstants.Colors.CHARCOAL,
@@ -166,8 +160,10 @@ const DisplayInput = React.createClass({
         height: isLargeOrMediumWindowSize ? '100%' : '25%',
         fontSize: StyleConstants.FontSizes.SMALL,
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
-        padding: isLargeOrMediumWindowSize ? 15 : 0,
-        paddingLeft: textIndent,
+        paddingBottom: StyleConstants.Spacing.MEDIUM,
+        paddingLeft: StyleConstants.Spacing.SMALL,
+        paddingRight: StyleConstants.Spacing.SMALL,
+        paddingTop: StyleConstants.Spacing.MEDIUM,
         textAlign: 'left',
         width: '100%'
       },

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -63,14 +63,22 @@ const DisplayInput = React.createClass({
               </Column>
             ) : null }
 
-            <Column span={inputColumn}>
-              <input
-                {...this.props}
-                key='input'
-                label={this.props.label}
-                style={styles.input}
-                type='text'
-              />
+            <Column relative={!!this.props.children} span={inputColumn}>
+              {this.props.children ? (
+                <div style={styles.children}>
+                  {this.props.children}
+                </div>
+              ) : (
+                <div style={styles.inputWrapper}>
+                  <input
+                    {...this.props}
+                    key='input'
+                    label={this.props.label}
+                    style={styles.input}
+                    type='text'
+                  />
+                </div>
+              )}
             </Column>
 
             {showHint ? (
@@ -83,14 +91,16 @@ const DisplayInput = React.createClass({
           </Row>
         </div>
 
-        <Row>
-          <Column span={twoWidthColumn} />
-          <Column span={statusColumn} >
-            <div style={styles.status}>
-              {this.props.status ? (<div style={styles[this.props.status.type]}>{this.props.status.message}</div>) : null}
-            </div>
-          </Column>
-        </Row>
+        {this.props.status ? (
+          <Row>
+            <Column span={twoWidthColumn} />
+            <Column span={statusColumn} >
+              <div style={styles.status}>
+                <div style={styles[this.props.status.type]}>{this.props.status.message}</div>
+              </div>
+            </Column>
+          </Row>
+        ) : null}
       </Container>
     );
   },
@@ -128,6 +138,22 @@ const DisplayInput = React.createClass({
         }
       },
 
+      inputWrapper: {
+        alignItems: 'center',
+        display: 'flex',
+        height: isLargeOrMediumWindowSize ? 43 : 70
+      },
+
+      children: {
+        alignItems: 'center',
+        display: 'flex',
+        height: isLargeOrMediumWindowSize ? 43 : 70,
+        paddingBottom: isLargeOrMediumWindowSize ? 10 : 0,
+        paddingTop: 0,
+        paddingLeft: textIndent,
+        width: '100%'
+      },
+
       label: {
         ':focus': {
           color: this.props.primaryColor
@@ -135,7 +161,9 @@ const DisplayInput = React.createClass({
       },
 
       labelText: {
-        color: StyleConstants.Colors.BLACK,
+        aligntItems: 'center',
+        color: StyleConstants.Colors.CHARCOAL,
+        display: 'flex',
         height: isLargeOrMediumWindowSize ? '100%' : '25%',
         fontSize: StyleConstants.FontSizes.SMALL,
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
@@ -148,7 +176,9 @@ const DisplayInput = React.createClass({
       status: {
         height: 10,
         paddingLeft: textIndent,
-        paddingTop: 10,
+        paddingRight: StyleConstants.Spacing.SMALL,
+        paddingBottom: StyleConstants.Spacing.XSMALL,
+        paddingTop: StyleConstants.Spacing.XSMALL,
         width: '50%'
       },
 
@@ -159,6 +189,8 @@ const DisplayInput = React.createClass({
       wrapper: Object.assign({
         borderBottom: this.props.valid ? '1px solid ' + StyleConstants.Colors.FOG : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
         height: isLargeOrMediumWindowSize ? 43 : 70,
+        paddingLeft: -10,
+        paddingRight: -10,
         transition: 'all .2s ease-in',
         WebkitAppearance: 'none',
         whiteSpace: 'nowrap',

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -93,8 +93,7 @@ const DisplayInput = React.createClass({
 
         {this.props.status ? (
           <Row>
-            <Column span={twoWidthColumn} />
-            <Column span={statusColumn} >
+            <Column offset={twoWidthColumn} span={statusColumn} >
               <div style={styles.status}>
                 <div style={styles[this.props.status.type]}>{this.props.status.message}</div>
               </div>

--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -9,12 +9,14 @@ const defaultShape = {
 const Column = React.createClass({
   propTypes: {
     offset: React.PropTypes.shape(defaultShape),
+    relative: React.PropTypes.bool,
     span: React.PropTypes.shape(defaultShape)
   },
 
   getDefaultProps () {
     return {
       offset: {},
+      relative: true,
       span: { large: 12 }
     };
   },
@@ -77,7 +79,7 @@ const Column = React.createClass({
     className = className.concat(this.getColumnOffsets());
 
     return (
-      <div className={className.join(' ')} style={{ boxSizing: 'border-box' }}>
+      <div className={className.join(' ')} style={{ boxSizing: 'border-box', position: this.props.relative ? 'relative' : 'static' }}>
         {this.props.children}
       </div>
     );

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -20,9 +20,6 @@ module.exports = {
     LIME: '#2EBE51',
     STRAWBERRY: '#E22727',
 
-    // BLACK
-    BLACK: '#000000',
-
     // CHART COLORS
     BASE_ARC: '#F5F5F5',
     YELLOW: '#f6a01e',


### PR DESCRIPTION
https://github.com/mxenabled/mx-react-components/issues/373

This PR makes some changes and fixes to the DisplayInput component.  The last set of changes made it responsive by implementing the grid system but @vintagepenguin and I noticed some issues and inconsistencies with the component internally after the upgrade.

The following was done after discussion with @vintagepenguin @derek-boman and @paniclater.

- Allow children used in the `DisplayInput` to be used in place of the input.  This allows us to use the `DisplayInput` for things like account selects and category selects on forms.  Currently we use a separate internal component for these things but no one has time to maintain two sets of styles to keep things looking consistent.
- Adds a consistent padding/margin to match product designs to the various parts of the component
- Uses the `StyleConstants.Spacing` numbers for the above padding/margins
- Only renders the status column if it exists.  Before we were rendering the column with empty content so it was taking up space and made the `DisplayInput` look weird.
- Drops empty column used for spacing and instead uses offset to achieve same goal.
- Uses `flex` and `alignItems` to correctly align the label and input/children.
- Corrects the label color to be `charcoal`.  It was black but we don't use black for anything.  I also removed the color black from the `StyleConstants`.
- Adds a `relative` prop to the `Column` component.  Bootstrap adds a position relative to columns which works in almost all cases.  The issue we were running into internally was that using the display input to wrap a select component that needed to show it's options outside it's parent wrapper was impossible.  By adding this prop we allow ourselves to set that position to `static` were needed.  The prop defaults to true the position will continue to be relative unless we set it false.  All of our testing has shown that having the position set to `static` does no harm to the `DisplayInput` in question or it's surrounding neighbors.
- Drops the fixed height of the `DisplayInput`.  Having a fixed height was causing positioning issues and it was decided after discussing the issue with @derek-boman that it would be better to drop the fixed height and let the padding position things as intended rather than trying to do one off padding/margin styles to try and align things.  We'll need to keep this in mind when using the `DisplayInput` to wrap things like selectors if we want those `DisplayInputs` to maintain the same height as those that use the input.

#### Screen Shots

![screen shot 2016-07-29 at 8 49 06 am](https://cloud.githubusercontent.com/assets/6463914/17252389/ca5e56fc-5569-11e6-80e5-dc36df02c570.png)
![screen shot 2016-07-29 at 8 49 19 am](https://cloud.githubusercontent.com/assets/6463914/17252388/ca5f609c-5569-11e6-9b1b-d458809a7f9d.png)
![screen shot 2016-07-29 at 8 49 27 am](https://cloud.githubusercontent.com/assets/6463914/17252391/ca65605a-5569-11e6-92da-f40048de5dd0.png)
![screen shot 2016-07-29 at 8 50 04 am](https://cloud.githubusercontent.com/assets/6463914/17252390/ca6180a2-5569-11e6-934e-2942bca2206e.png)
![screen shot 2016-07-29 at 8 50 23 am](https://cloud.githubusercontent.com/assets/6463914/17252386/ca5aecc4-5569-11e6-80ce-c5af7ce38dd1.png)
![screen shot 2016-07-29 at 8 51 38 am](https://cloud.githubusercontent.com/assets/6463914/17252387/ca5bcb44-5569-11e6-8c2b-c9b48a75ad16.png)
