### PR TITLE
fix flex spelling for SimpleSelect component

### DIFF
--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -63,7 +63,7 @@ const SimpleSelect = React.createClass({
         boxShadow: StyleConstants.ShadowHigh,
         boxSizing: 'border-box',
         color: StyleConstants.Colors.BLACK,
-        display: 'felx',
+        display: 'flex',
         flexDirection: 'column',
         fill: StyleConstants.Colors.BLACK,
         fontFamily: StyleConstants.FontFamily,

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -37,7 +37,7 @@ const SimpleSelect = React.createClass({
                   style={Object.assign({}, styles.item, this.props.itemStyles)}
                 >
                   {item.icon ? (
-                    <Icon size={this.props.iconSize || 20} styles={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
+                    <Icon size={this.props.iconSize || 20} style={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
                   ) : null}
                   {item.text}
                 </div>
@@ -72,7 +72,9 @@ const SimpleSelect = React.createClass({
         position: 'absolute',
         zIndex: 10
       },
-
+      icon: {
+        paddingRight: StyleConstants.Spacing.SMALL
+      },
       item: {
         boxSizing: 'border-box',
         height: 40,


### PR DESCRIPTION
- Fixes flex spelling for component styling

![screen shot 2016-08-02 at 1 31 48 pm](https://cloud.githubusercontent.com/assets/6463914/17342264/a16c71f8-58b5-11e6-8844-f9cf22c6218e.png)

- Fixes icon styling.  There was a typo and a missing icon style.

#### Before
![screen shot 2016-08-02 at 2 15 48 pm](https://cloud.githubusercontent.com/assets/6463914/17343625/e630647e-58bb-11e6-857c-30285bb6d60c.png)

#### After
![screen shot 2016-08-02 at 2 16 01 pm](https://cloud.githubusercontent.com/assets/6463914/17343628/e9e264fa-58bb-11e6-9e71-8e0c2fe2251f.png)
