### PR TITLE
Fixing Chart Animation with New Props

### DIFF
--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -80,22 +80,22 @@ const DonutChart = React.createClass({
   },
 
   componentWillReceiveProps (newProps) {
-    if (!_isEqual(this.props.data, newProps.data)) {
-      this._setupD3Functions(newProps);
-      this._animateChart();
-    }
+    this._setupD3Functions(newProps);
 
     if (newProps.activeIndex !== this.props.activeIndex) {
       this.setState({
         activeIndex: newProps.activeIndex
       });
-
-      this._animateActiveArc(this.props.activeIndex, newProps.activeIndex);
     }
   },
 
   shouldComponentUpdate (nextProps, nextState) {
     return !_isEqual(this.props, nextProps) || !_isEqual(this.state, nextState);
+  },
+
+  componentDidUpdate (prevProps) {
+    this._animateChart();
+    this._animateActiveArc(prevProps.activeIndex, this.props.activeIndex);
   },
 
   _setupD3Functions (props) {


### PR DESCRIPTION

<h2>The Run Down:

Issue: https://github.com/mxenabled/mx-react-components/issues/385

`componentWillReceiveProps` is called after shouldComponentUpdate, but before render. It is also not called on the initial render -- which is why only subsequent animations were busted.

The animation functions needed to be called **after** render.

`componentDidUpdate` is called after render and putting the animation calls there fixed the issue. It is also not called on the initial render -- which means it doesn't break the initial animation.

Notice in the broken version only some of the arcs animate, while in the fixed version all of the arcs animate every time. 

**Bonus** this fixes both roll and bounce animations!

--

<h3>Broken:
![ezgif com-video-to-gif 4](https://cloud.githubusercontent.com/assets/1081167/17349604/9e331ac4-58dc-11e6-876f-1538acad0454.gif)

--

<h3>Fixed:
![ezgif com-video-to-gif 4](https://cloud.githubusercontent.com/assets/1081167/17349658/fb67c942-58dc-11e6-84e3-028bb5a273bc.gif)

--

Gigantic Shout Out to :cookie::cookie::eggplant:@cerinman & @phantomxc:eggplant::cookie::cookie: for helping me in my moments of despair. I was completely stumped without their help.

