### PR TITLE
Preventing Opening Animation From Running on Every Render

### DIFF
--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -97,7 +97,10 @@ const DonutChart = React.createClass({
     if (!_isEqual(prevProps.data, this.props.data)) {
       this._animateChart();
     }
-    this._animateActiveArc(prevProps.activeIndex, this.props.activeIndex);
+
+    if (!_isEqual(prevProps.activeIndex, this.props.activeIndex)) {
+      this._animateActiveArc(prevProps.activeIndex, this.props.activeIndex);
+    }
   },
 
   _setupD3Functions (props) {

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -94,7 +94,9 @@ const DonutChart = React.createClass({
   },
 
   componentDidUpdate (prevProps) {
-    this._animateChart();
+    if (!_isEqual(prevProps.data, this.props.data)) {
+      this._animateChart();
+    }
     this._animateActiveArc(prevProps.activeIndex, this.props.activeIndex);
   },
 


### PR DESCRIPTION
<h2>The Run Down:

Issue: https://github.com/mxenabled/mx-react-components/issues/385


Moving the animation to componentDidMount caused the opening animation to run on every hover, click, etc. This protects against that.

--

<h3>Broken:
![ezgif com-video-to-gif 5](https://cloud.githubusercontent.com/assets/1081167/17379897/958925e4-5981-11e6-9e4a-45111273fff9.gif)

--

<h3>Fixed:
![ezgif com-video-to-gif 6](https://cloud.githubusercontent.com/assets/1081167/17379920/b78bbdc8-5981-11e6-94de-43769b9a56f3.gif)