### PR TITLE
Fix typo in DisplayInput

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -146,7 +146,7 @@ const DisplayInput = React.createClass({
       },
 
       labelText: {
-        aligntItems: 'center',
+        alignItems: 'center',
         color: StyleConstants.Colors.CHARCOAL,
         display: 'flex',
         fontSize: StyleConstants.FontSizes.SMALL,


### PR DESCRIPTION
There's no `T` in `alignItems`. 