### PR TITLE
Fix spelling for Prop in Tabs demo

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -763,7 +763,7 @@ const Demo = React.createClass({
 
         <div style={{ marginLeft: '30%', width: '100%' }}>
           <Tabs
-            activeTabStyle={{ paddingBottom: 25 }}
+            activeTabStyles={{ paddingBottom: 25 }}
             onTabSelect={this._handleTabSelect}
             selectedTab={this.state.selectedTab}
             showBottomBorder={false}

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -159,8 +159,8 @@ const Tabs = React.createClass({
         padding: 5,
         textTransform: 'uppercase',
 
-        ':hover': {
-          color: this._isLargeOrMediumWindowSize() ? StyleConstants.Colors.ASH : StyleConstants.Colors.CHARCOAL
+        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+          color: StyleConstants.Colors.ASH
         }
       },
       menuWrapper: {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -160,7 +160,7 @@ const Tabs = React.createClass({
         textTransform: 'uppercase',
 
         ':hover': {
-          color: StyleConstants.Colors.ASH
+          color: this._isLargeOrMediumWindowSize() ? StyleConstants.Colors.ASH : StyleConstants.Colors.CHARCOAL
         }
       },
       menuWrapper: {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -181,11 +181,7 @@ const Tabs = React.createClass({
         fontStyle: StyleConstants.Fonts.SEMIBOLD,
         letterSpacing: '.75',
         position: 'absolute',
-        textTransform: 'uppercase',
-
-        ':hover': {
-          color: StyleConstants.Colors.ASH
-        }
+        textTransform: 'uppercase'
       },
       activeTab: {
         borderBottom: '2px solid ' + this.props.brandColor


### PR DESCRIPTION
## WHY THE FRANK DOES THIS PR EXIST? 
When the prop `useTabsInMobile={true}` then the Hover state is applied. Hover, in mobile, is applied by clicking. So the color in mobile will change on click which is not something we, or other people, would probably want. 

### Color Not Changing onClick in Mobile Anymore 👍 
[![https://gyazo.com/a10eaa6579abc2c74f832c0d43877ada](https://i.gyazo.com/a10eaa6579abc2c74f832c0d43877ada.gif)](https://gyazo.com/a10eaa6579abc2c74f832c0d43877ada)

### Hover Still Workin' in Full Screen
[![https://gyazo.com/3f98179d9c388c4f7e8ca78acf6f3a0f](https://i.gyazo.com/3f98179d9c388c4f7e8ca78acf6f3a0f.gif)](https://gyazo.com/3f98179d9c388c4f7e8ca78acf6f3a0f)

* I forgot the `s` on `activeTabStyles` prop so the styles weren't getting displayed. I also made this mistake in the `gh-pages`. So I figured I'd fix it now. 