### PR TITLE
Make the close fn public for closing the Drawer externally

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -349,6 +349,10 @@ const Demo = React.createClass({
     });
   },
 
+  _handleCloseDrawerClick () {
+    this.refs.drawer.close();
+  },
+
   _onHideDrawer () {
     this.setState({
       showDrawer: false,
@@ -532,9 +536,15 @@ const Demo = React.createClass({
               headerStyle={{ backgroundColor: '#fff' }}
               navConfig={navConfig}
               onClose={this._onHideDrawer}
+              ref='drawer'
               title='This is the drawer component'
             >
               <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
+              <Button
+                onClick={this._handleCloseDrawerClick}
+              >
+                Close Drawer
+              </Button>
             </Drawer>
           </div>
         ) : null}

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -67,7 +67,12 @@ const Drawer = React.createClass({
     }
   },
 
-  _handleCloseClick () {
+  /**
+   * Animate the Drawer closed and then call the onClose callback.
+   *
+   * @returns {Promise} that is resolved when the animation finishes
+   */
+  close () {
     this._animateComponent({ left: '100%' })
     .then(() => {
       this.props.onClose();
@@ -113,13 +118,13 @@ const Drawer = React.createClass({
 
     return (
       <div style={styles.componentWrapper}>
-        <div onClick={this._handleCloseClick} style={styles.scrim} />
+        <div onClick={this.close} style={styles.scrim} />
         <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
           <header style={Object.assign({}, styles.header, this.props.headerStyle)}>
             <span style={styles.backArrow}>
               <Button
                 icon='arrow-left'
-                onClick={this._handleCloseClick}
+                onClick={this.close}
                 primaryColor={this.props.buttonPrimaryColor}
                 type={'base'}
               />


### PR DESCRIPTION
This will allow users to externally close a `Drawer` with the animation!

_Thanks to [this guide](https://facebook.github.io/react/tips/expose-component-functions.html) for the tip on how to do it._

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/4348/17705383/61b35ef6-6395-11e6-8d50-a4f3af6e69db.gif)
