### PR TITLE
Reposition the Drawer when the window is resized

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -2,6 +2,7 @@ const _isNumber = require('lodash/isNumber');
 const Radium = require('radium');
 const React = require('react');
 const Velocity = require('velocity-animate');
+const _throttle = require('lodash/throttle');
 
 const Button = require('../components/Button');
 
@@ -41,8 +42,17 @@ const Drawer = React.createClass({
     };
   },
 
+  componentWillMount () {
+    this._resizeThrottled = _throttle(this._resize, 100);
+  },
+
   componentDidMount () {
     this._animateComponent({ left: this._getAnimationDistance() });
+    window.addEventListener('resize', this._resizeThrottled);
+  },
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this._resizeThrottled);
   },
 
   _getAnimationDistance () {
@@ -74,14 +84,18 @@ const Drawer = React.createClass({
     });
   },
 
-  _animateComponent (transition) {
+  _animateComponent (transition, extraOptions) {
     const el = this._component;
-    const options = {
+    const options = Object.assign({
       duration: this.props.duration,
       easing: this.props.easing
-    };
+    }, extraOptions);
 
     return Velocity(el, transition, options);
+  },
+
+  _resize () {
+    this._animateComponent({ left: this._getAnimationDistance() }, { duration: 0 });
   },
 
   _renderNav () {


### PR DESCRIPTION
When the window was resized the Drawer would stay in the same position until closing and reopening. This fixes the problem by re-animating the Drawer, but with a duration of 0, which turned out to be the cleanest solution.

![ezgif com-video-to-gif 2](https://cloud.githubusercontent.com/assets/4348/17717969/7ea29656-63ce-11e6-87b5-b6aa46dad88c.gif)

Fixes #361 
Refs #363 