### PR TITLE
Allow for different Drawer sizes

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -356,6 +356,18 @@ const Demo = React.createClass({
     });
   },
 
+  _handleShowSmallDrawer () {
+    this.setState({
+      showSmallDrawer: true
+    });
+  },
+
+  _handleHideSmallDrawer () {
+    this.setState({
+      showSmallDrawer: false
+    });
+  },
+
   _handleSpinnerIconOnlyClick () {
     this.setState({
       spinnerIconOnlyIsActive: !this.state.spinnerIconOnlyIsActive
@@ -535,6 +547,18 @@ const Demo = React.createClass({
               title='This is the drawer component'
             >
               <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>Insert Custom Content Here</div>
+              <Button onClick={this._handleShowSmallDrawer}>
+                Toggle Small Drawer
+              </Button>
+              {this.state.showSmallDrawer ? (
+                <Drawer
+                  breakPoints={{ large: 750, medium: 500, small: 320 }}
+                  maxWidth={480}
+                  onClose={this._handleHideSmallDrawer}
+                  showScrim={false}
+                  title='Small Drawer'
+                />
+              ) : null}
             </Drawer>
           </div>
         ) : null}

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -50,15 +50,13 @@ const Drawer = React.createClass({
       return this.props.animateLeftDistance + '%';
     }
 
-    const greaterThan1200ComponentWidth = 960;
-    const maxResolutionBreakPoint = 1200;
-    const minResoultionBreakPoint = 750;
+    const maxDrawerWidth = 960;
     const windowWidth = window.innerWidth;
 
-    if (windowWidth >= maxResolutionBreakPoint) {
+    if (windowWidth >= StyleConstants.BreakPoints.large) {
       //Resolution - 960 from the left
-      return windowWidth - greaterThan1200ComponentWidth;
-    } else if (windowWidth <= minResoultionBreakPoint) {
+      return windowWidth - maxDrawerWidth;
+    } else if (windowWidth <= StyleConstants.BreakPoints.medium) {
       //All the way over to the left
       return 0;
     } else {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -10,6 +10,11 @@ const StyleConstants = require('../constants/Style');
 const Drawer = React.createClass({
   propTypes: {
     animateLeftDistance: React.PropTypes.number,
+    breakPoints: React.PropTypes.shape({
+      large: React.PropTypes.number,
+      medium: React.PropTypes.number,
+      small: React.PropTypes.number
+    }),
     buttonPrimaryColor: React.PropTypes.string,
     contentStyle: React.PropTypes.oneOfType([
       React.PropTypes.array,
@@ -21,6 +26,7 @@ const Drawer = React.createClass({
       React.PropTypes.array,
       React.PropTypes.object
     ]),
+    maxWidth: React.PropTypes.number,
     navConfig: React.PropTypes.shape({
       label: React.PropTypes.string.isRequired,
       onNextClick: React.PropTypes.func.isRequired,
@@ -34,8 +40,10 @@ const Drawer = React.createClass({
   getDefaultProps () {
     return {
       buttonPrimaryColor: StyleConstants.Colors.PRIMARY,
+      breakPoints: StyleConstants.BreakPoints,
       duration: 500,
       easing: [0.28, 0.14, 0.34, 1.04],
+      maxWidth: 960,
       showScrim: true,
       title: ''
     };
@@ -50,18 +58,19 @@ const Drawer = React.createClass({
       return this.props.animateLeftDistance + '%';
     }
 
-    const maxDrawerWidth = 960;
     const windowWidth = window.innerWidth;
 
-    if (windowWidth >= StyleConstants.BreakPoints.large) {
-      //Resolution - 960 from the left
-      return windowWidth - maxDrawerWidth;
-    } else if (windowWidth <= StyleConstants.BreakPoints.medium) {
+    if (windowWidth >= this.props.breakPoints.large) {
+      //Resolution - maxWidth
+      return windowWidth - this.props.maxWidth;
+    } else if (windowWidth <= this.props.breakPoints.medium) {
       //All the way over to the left
       return 0;
     } else {
       //20% from the left
-      return '20%';
+      const newLeft = windowWidth * 0.2;
+
+      return Math.max(newLeft, windowWidth - this.props.maxWidth);
     }
   },
 
@@ -150,11 +159,11 @@ const Drawer = React.createClass({
         backgroundColor: StyleConstants.Colors.PORCELAIN,
         boxShadow: StyleConstants.ShadowHigh,
 
-        '@media (max-width: 750px)': {
+        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
           width: '100%'
         },
-        '@media (min-width: 1200px)': {
-          width: 960
+        [`@media (min-width: ${this.props.breakPoints.large}px)`]: {
+          width: this.props.maxWidth
         }
       },
       componentWrapper: {
@@ -187,7 +196,7 @@ const Drawer = React.createClass({
         textAlign: 'left',
         width: '25%',
 
-        '@media (max-width: 750px)': {
+        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
           paddingLeft: 10
         }
       },


### PR DESCRIPTION
I.e. The half-drawer

Allow customization of the size of a Drawer and at different breakpoints.

This PR will:
* expose breakPoints and maxWidth props
* use StyleConstants.BreakPoints for default breakPoints
* use breakPoints for media queries

![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/4348/17717972/82b864a0-63ce-11e6-9f8a-de0a570c570c.gif)
