### PR TITLE
Drawer.close needs to return a Promise like it says in the comment :)

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -90,10 +90,10 @@ const Drawer = React.createClass({
    * @returns {Promise} that is resolved when the animation finishes
    */
   close () {
-    this._animateComponent({ left: '100%' })
-    .then(() => {
-      this.props.onClose();
-    });
+    return this._animateComponent({ left: '100%' })
+      .then(() => {
+        this.props.onClose();
+      });
   },
 
   _animateComponent (transition, extraOptions) {


### PR DESCRIPTION
#405 made `close` public, but it didn't return a `Promise` like I said it would in the docs. This fixes that discrepancy.