### PR TITLE
Allow DisplayInput to be "focused" programmatically

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -10,6 +10,7 @@ const Row = require('../components/grid/Row');
 const DisplayInput = React.createClass({
   propTypes: {
     hint: React.PropTypes.string,
+    isFocused: React.PropTypes.bool,
     label: React.PropTypes.string,
     labelStyle: React.PropTypes.object,
     placeholder: React.PropTypes.string,
@@ -24,6 +25,7 @@ const DisplayInput = React.createClass({
 
   getDefaultProps () {
     return {
+      isFocused: false,
       primaryColor: StyleConstants.Colors.PRIMARY,
       valid: true
     };
@@ -52,7 +54,7 @@ const DisplayInput = React.createClass({
 
     return (
       <Container>
-        <div style={styles.wrapper}>
+        <div style={Object.assign({}, styles.wrapper, this.props.isFocused ? styles.wrapperFocus : {})}>
           <Row>
             {this.props.label ? (
               <Column span={labelColumn}>
@@ -107,6 +109,11 @@ const DisplayInput = React.createClass({
 
   styles () {
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize();
+    const wrapperFocus = {
+      borderBottom: this.props.valid ? '1px solid ' + this.props.primaryColor : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
+      boxShadow: 'none',
+      outline: 'none'
+    };
 
     return {
       error: {
@@ -180,12 +187,10 @@ const DisplayInput = React.createClass({
         WebkitAppearance: 'none',
         whiteSpace: 'nowrap',
 
-        ':focus': {
-          borderBottom: this.props.valid ? '1px solid ' + this.props.primaryColor : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
-          boxShadow: 'none',
-          outline: 'none'
-        }
-      }, this.props.style)
+        ':focus': wrapperFocus
+      }, this.props.style),
+
+      wrapperFocus
     };
   }
 });


### PR DESCRIPTION
We need a way to manually focus the `DisplayInput` for custom inputs to match the behavior of other `DisplayInput`s.

Does this seem like a reasonable approach?

__Here's an example use case__ (I was using these changes for the screen shot):

![2016-08-19_1647](https://cloud.githubusercontent.com/assets/4348/17826370/476573e6-662d-11e6-8945-f614284fc607.png)
