### PR TITLE
Adds documentation to PR422

### DIFF
--- a/components/Changelog.js
+++ b/components/Changelog.js
@@ -5,7 +5,12 @@ const Changelog = React.createClass({
     return (
       <div>
         <h1>Change Log</h1>
-
+        <h3><4.4.37<h3>
+        <ul>
+          <li>
+            Added a prop that allows users to focus their cursor in the text field on load in the SimpleInput and SearchInput components (<a href='https://github.com/mxenabled/mx-react-components/pull/422'>#422</a>)
+          </li>
+        </ul>
         <h3>4.4.35</h3>
         <ul>
           <li>Added spending to the Icon component (<a href='https://github.com/mxenabled/mx-react-components/pull/414'>#414</a>)</li>


### PR DESCRIPTION
- Adds docs to PR422 which allows users to focus their cursor in the text field on load in the SimpleInput and SearchInput components. I skipped the version `4.4.36` trying to publish before pushing it. Sorry about that.