### PR TITLE
Tabs: Fixes brand color issue for caret

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -89,7 +89,7 @@ const Tabs = React.createClass({
         {selectedTabName}
         <Icon
           size={20}
-          style={{ color: this.state.brandColor }}
+          style={{ color: this.props.brandColor }}
           type={!this.state.showMenu ? 'caret-down' : 'caret-up' }
         />
         {this.state.showMenu ? (


### PR DESCRIPTION
This PR fixes an issue with brand color not being passed to the `Icon` component properly.

- Changes `this.state.brandColor` to `this.props.brandColor`
