### PR TITLE
Spreading props fix for warning introduced in React 15.0

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -1019,12 +1019,14 @@ const Demo = React.createClass({
 
         <br /><br />
         <DisplayInput
+          elementProps={{
+            onBlur: this._handleInputStatusMessage,
+            onFocus: this._handleInputFocus,
+            onMouseOut: this._handleInputHideHint,
+            onMouseOver: this._handleInputShowHint
+          }}
           hint='Click to Edit'
           label='Display Input'
-          onBlur={this._handleInputStatusMessage}
-          onFocus={this._handleInputFocus}
-          onMouseOut={this._handleInputHideHint}
-          onMouseOver={this._handleInputShowHint}
           placeholder='Type something'
           showHint={this.state.showHint}
           status={this.state.statusMessage}

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -9,6 +9,7 @@ const Row = require('../components/grid/Row');
 
 const DisplayInput = React.createClass({
   propTypes: {
+    elementProps: React.PropTypes.object,
     hint: React.PropTypes.string,
     isFocused: React.PropTypes.bool,
     label: React.PropTypes.string,
@@ -25,6 +26,7 @@ const DisplayInput = React.createClass({
 
   getDefaultProps () {
     return {
+      elementProps: {},
       isFocused: false,
       primaryColor: StyleConstants.Colors.PRIMARY,
       valid: true
@@ -38,6 +40,9 @@ const DisplayInput = React.createClass({
   },
 
   render () {
+    // Input properties
+    const { elementProps } = this.props;
+
     // Methods
     const hasChildren = !!this.props.children;
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize();
@@ -74,7 +79,7 @@ const DisplayInput = React.createClass({
               ) : (
                 <div style={styles.inputWrapper}>
                   <input
-                    {...this.props}
+                    {...elementProps}
                     key='input'
                     label={this.props.label}
                     style={styles.input}

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -2,6 +2,7 @@ const React = require('react');
 
 const Icon = React.createClass({
   propTypes: {
+    elementProps: React.PropTypes.object,
     size: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
     style: React.PropTypes.object,
     type: React.PropTypes.string
@@ -9,6 +10,7 @@ const Icon = React.createClass({
 
   getDefaultProps () {
     return {
+      elementProps: {},
       size: 24,
       type: 'accounts'
     };
@@ -1360,11 +1362,12 @@ const Icon = React.createClass({
   },
 
   render () {
+    const { elementProps } = this.props;
     const styles = this.styles();
 
     return (
       <svg
-        {...this.props}
+        {...elementProps}
         className='mx-icon'
         preserveAspectRatio='xMidYMid meet'
         style={styles.component}

--- a/src/components/RajaIcon.js
+++ b/src/components/RajaIcon.js
@@ -3,12 +3,14 @@ const Radium = require('radium');
 
 const RajaIcon = React.createClass({
   propTypes: {
+    elementProps: React.PropTypes.object,
     size: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
     type: React.PropTypes.string
   },
 
   getDefaultProps () {
     return {
+      elementProps: {},
       size: 24,
       type: 'b'
     };
@@ -646,6 +648,7 @@ const RajaIcon = React.createClass({
   },
 
   render () {
+    const { elementProps } = this.props;
     const styles = {
       fill: this.props.style.color,
       width: this.props.size,
@@ -656,7 +659,7 @@ const RajaIcon = React.createClass({
 
     return (
       <svg
-        {...this.props}
+        {...elementProps}
         fit={true}
         preserveAspectRatio='xMidYMid meet'
         style={[styles, this.props.style]}

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -7,6 +7,7 @@ const StyleConstants = require('../constants/Style');
 const Input = React.createClass({
   propTypes: {
     baseColor: React.PropTypes.string,
+    elementProps: React.PropTypes.object,
     focusOnLoad: React.PropTypes.bool,
     icon: React.PropTypes.string,
     placeholder: React.PropTypes.string,
@@ -22,6 +23,7 @@ const Input = React.createClass({
   getDefaultProps () {
     return {
       baseColor: StyleConstants.Colors.PRIMARY,
+      elementProps: {},
       focusOnLoad: false,
       type: 'text',
       valid: true
@@ -61,6 +63,7 @@ const Input = React.createClass({
   },
 
   render () {
+    const { elementProps } = this.props;
     const styles = this.styles();
 
     return (
@@ -74,7 +77,7 @@ const Input = React.createClass({
           <Icon size={20} style={styles.icon} type={this.props.icon} />
         ) : null}
         <input
-          {...this.props}
+          {...elementProps}
           ref='input'
           style={styles.input}
           type={this.props.type}


### PR DESCRIPTION
##### NOTE:  This will be a breaking change.  Will be released in version `5.0.rc1` and has been labeled accordingly.  

### Issue

React now warns when applying properties to html elements that should not be there according to HTML standards.  We spread props across inputs in a few places so we were triggering the warning

See https://fb.me/react-unknown-prop for details

### Solution

This PR introduces a new prop for the components effected.

elementProps: Type: `Object` Default: `{}`

We now use the above prop to pass the properties that we want to apply to the HTML element within the component.  This allows us to separate this properties from the component properties and prevent the warning.  

Components effected

- DisplayInput
- Icon
- RajaIcon
- SimpleInput

I've also updated the DisplayInput in the demo app.  It was the only component there that needed it's usage updated.  Please refer to it on how to handle internally as we move forward with this change.