### PR TITLE
Aphrodite- Drawer Upgrade

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -551,17 +551,17 @@ const Demo = React.createClass({
               ref='drawer'
               title='This is the drawer component'
             >
-              <p style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>
+              <div style={{ padding: 20, fontFamily: 'Helvetica, Arial, sans-serif' }}>
                 Insert Custom Content Here
-              </p>
+              </div>
 
-              <p style={{ padding: 10 }}>
+              <div style={{ padding: 10 }}>
                 <Button onClick={this._handleCloseDrawerClick}>
                   Close Drawer
                 </Button>
-              </p>
+              </div>
 
-              <p style={{ padding: 10 }}>
+              <div style={{ padding: 10 }}>
                 <Button onClick={this._handleShowSmallDrawer}>
                   Toggle Small Drawer
                 </Button>
@@ -574,7 +574,7 @@ const Demo = React.createClass({
                     title='Small Drawer'
                   />
                 ) : null}
-              </p>
+              </div>
             </Drawer>
           </div>
         ) : null}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "http://moneydesktop.github.io/mx-react-components/",
   "dependencies": {
+    "aphrodite": "^0.5.0",
     "d3": "^3.5.6",
     "lodash": "^4.6.1",
     "moment": "^2.10.3",

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -108,6 +108,8 @@ const Drawer = React.createClass({
   },
 
   _renderNav () {
+    const styles = this.styles();
+
     return this.props.navConfig ? (
       <nav className={css(styles.nav)}>
         <Button
@@ -130,33 +132,14 @@ const Drawer = React.createClass({
   },
 
   render () {
-    const dynamicStyles = StyleSheet.create({
-      backArrow: {
-        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
-          paddingLeft: 10
-        }
-      },
-      component: Object.assign({}, {
-        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
-          width: '100%'
-        },
-        [`@media (min-width: ${this.props.breakPoints.large}px)`]: {
-          width: this.props.maxWidth
-        }
-      }, this.props.style),
-      content: this.props.contentStyle,
-      header: this.props.headerStyle,
-      scrim: {
-        backgroundColor: this.props.showScrim ? StyleConstants.Colors.SCRIM : 'transparent'
-      }
-    });
+    const styles = this.styles();
 
     return (
       <div className={css(styles.componentWrapper)}>
-        <div className={css(styles.scrim, dynamicStyles.scrim)} onClick={this.close} />
-        <div className={css(styles.component, dynamicStyles.component)} ref={(ref) => (this._component = ref)}>
-          <header className={css(styles.header, dynamicStyles.header)}>
-            <span className={css(styles.backArrow, dynamicStyles.backArrow)}>
+        <div className={css(styles.scrim)} onClick={this.close} />
+        <div className={css(styles.component)} ref={(ref) => (this._component = ref)}>
+          <header className={css(styles.header)}>
+            <span className={css(styles.backArrow)}>
               <Button
                 icon='arrow-left'
                 onClick={this.close}
@@ -169,97 +152,110 @@ const Drawer = React.createClass({
             </span>
             {this._renderNav()}
           </header>
-          <div className={css(styles.content, dynamicStyles.content)}>
+          <div className={css(styles.content)}>
             {this.props.children}
           </div>
         </div>
       </div>
     );
-  }
-});
+  },
 
-const styles = StyleSheet.create({
-  component: {
-    border: '1px solid ' + StyleConstants.Colors.FOG,
-    boxSizing: 'border-box',
-    zIndex: 1001,
-    top: 0,
-    bottom: 0,
-    left: '100%',
-    position: 'absolute',
-    width: '80%',
-    overflow: 'hidden',
-    backgroundColor: StyleConstants.Colors.PORCELAIN,
-    boxShadow: StyleConstants.ShadowHigh
-  },
-  componentWrapper: {
-    bottom: 0,
-    left: 0,
-    position: 'fixed',
-    right: 0,
-    top: 0,
-    zIndex: 999
-  },
-  content: {
-    backgroundColor: StyleConstants.Colors.WHITE,
-    height: '100%'
-  },
-  scrim: {
-    zIndex: 1000,
-    position: 'fixed',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    textAlign: 'center',
-    backgroundColor: StyleConstants.Colors.SCRIM
-  },
-  icons: {
-    color: StyleConstants.Colors.ASH
-  },
-  backArrow: {
-    paddingLeft: 20,
-    textAlign: 'left',
-    width: '25%'
-  },
-  header: {
-    alignItems: 'center',
-    backgroundColor: StyleConstants.Colors.WHITE,
-    borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
-    color: StyleConstants.Colors.ASH,
-    display: 'flex',
-    fontFamily: StyleConstants.Fonts.REGULAR,
-    fontSize: StyleConstants.FontSizes.LARGE,
-    justifyContent: 'center',
-    padding: '7px 7px',
-    position: 'relative'
-  },
-  title: {
-    overflow: 'hidden',
-    textAlign: 'center',
-    textOverflow: 'ellipsis',
-    width: '50%',
-    whiteSpace: 'nowrap'
-  },
-  nav: {
-    paddingRight: 20,
-    textAlign: 'right',
-    width: '25%',
-    whiteSpace: 'nowrap',
+  styles () {
+    return StyleSheet.create({
+      component: Object.assign({}, {
+        border: '1px solid ' + StyleConstants.Colors.FOG,
+        boxSizing: 'border-box',
+        zIndex: 1001,
+        top: 0,
+        bottom: 0,
+        left: '100%',
+        position: 'absolute',
+        width: '80%',
+        overflow: 'hidden',
+        backgroundColor: StyleConstants.Colors.PORCELAIN,
+        boxShadow: StyleConstants.ShadowHigh,
 
-    '@media (max-width: 750px)': {
-      paddingRight: 10
-    }
-  },
-  navLabel: {
-    padding: '7px 14px',
-    position: 'relative',
-    bottom: 5,
+        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
+          width: '100%'
+        },
+        [`@media (min-width: ${this.props.breakPoints.large}px)`]: {
+          width: this.props.maxWidth
+        }
+      }, this.props.style),
+      componentWrapper: {
+        bottom: 0,
+        left: 0,
+        position: 'fixed',
+        right: 0,
+        top: 0,
+        zIndex: 999
+      },
+      content: Object.assign({}, {
+        backgroundColor: StyleConstants.Colors.WHITE,
+        height: '100%'
+      }, this.props.contentStyle),
+      scrim: {
+        zIndex: 1000,
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        textAlign: 'center',
+        backgroundColor: this.props.showScrim ? StyleConstants.Colors.SCRIM : 'transparent'
+      },
+      icons: {
+        color: StyleConstants.Colors.ASH
+      },
+      backArrow: {
+        paddingLeft: 20,
+        textAlign: 'left',
+        width: '25%',
 
-    '@media (max-width: 750px)': {
-      display: 'none',
-      padding: 0
-    }
+        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
+          paddingLeft: 10
+        }
+      },
+      header: Object.assign({}, {
+        alignItems: 'center',
+        backgroundColor: StyleConstants.Colors.WHITE,
+        borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
+        color: StyleConstants.Colors.ASH,
+        display: 'flex',
+        fontFamily: StyleConstants.Fonts.REGULAR,
+        fontSize: StyleConstants.FontSizes.LARGE,
+        justifyContent: 'center',
+        padding: '7px 7px',
+        position: 'relative'
+      }, this.props.headerStyle),
+      title: {
+        overflow: 'hidden',
+        textAlign: 'center',
+        textOverflow: 'ellipsis',
+        width: '50%',
+        whiteSpace: 'nowrap'
+      },
+      nav: {
+        paddingRight: 20,
+        textAlign: 'right',
+        width: '25%',
+        whiteSpace: 'nowrap',
+
+        '@media (max-width: 750px)': {
+          paddingRight: 10
+        }
+      },
+      navLabel: {
+        padding: '7px 14px',
+        position: 'relative',
+        bottom: 5,
+
+        '@media (max-width: 750px)': {
+          display: 'none',
+          padding: 0
+        }
+      }
+    });
   }
 });
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -36,10 +36,8 @@ const Drawer = React.createClass({
     return {
       buttonPrimaryColor: StyleConstants.Colors.PRIMARY,
       breakPoints: StyleConstants.BreakPoints,
-      contentStyle: {},
       duration: 500,
       easing: [0.28, 0.14, 0.34, 1.04],
-      headerStyle: {},
       maxWidth: 960,
       showScrim: true,
       title: ''

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,5 +1,5 @@
 const _isNumber = require('lodash/isNumber');
-const Radium = require('radium');
+const { StyleSheet, css } = require('aphrodite/no-important');
 const React = require('react');
 const Velocity = require('velocity-animate');
 const _throttle = require('lodash/throttle');
@@ -17,16 +17,10 @@ const Drawer = React.createClass({
       small: React.PropTypes.number
     }),
     buttonPrimaryColor: React.PropTypes.string,
-    contentStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
+    contentStyle: React.PropTypes.object,
     duration: React.PropTypes.number,
     easing: React.PropTypes.array,
-    headerStyle: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
+    headerStyle: React.PropTypes.object,
     maxWidth: React.PropTypes.number,
     navConfig: React.PropTypes.shape({
       label: React.PropTypes.string.isRequired,
@@ -42,8 +36,10 @@ const Drawer = React.createClass({
     return {
       buttonPrimaryColor: StyleConstants.Colors.PRIMARY,
       breakPoints: StyleConstants.BreakPoints,
+      contentStyle: {},
       duration: 500,
       easing: [0.28, 0.14, 0.34, 1.04],
+      headerStyle: {},
       maxWidth: 960,
       showScrim: true,
       title: ''
@@ -99,6 +95,7 @@ const Drawer = React.createClass({
   _animateComponent (transition, extraOptions) {
     const el = this._component;
     const options = Object.assign({
+      delay: 50,
       duration: this.props.duration,
       easing: this.props.easing
     }, extraOptions);
@@ -111,17 +108,15 @@ const Drawer = React.createClass({
   },
 
   _renderNav () {
-    const styles = this.styles();
-
     return this.props.navConfig ? (
-      <nav style={styles.nav}>
+      <nav className={css(styles.nav)}>
         <Button
           icon='caret-left'
           onClick={this.props.navConfig.onPreviousClick}
           primaryColor={this.props.buttonPrimaryColor}
           type='base'
         />
-        <span style={styles.navLabel}>
+        <span className={css(styles.navLabel)}>
           {this.props.navConfig.label}
         </span>
         <Button
@@ -131,18 +126,37 @@ const Drawer = React.createClass({
           type='base'
         />
       </nav>
-    ) : <div style={styles.nav} />;
+    ) : <div className={css(styles.nav)} />;
   },
 
   render () {
-    const styles = this.styles();
+    const dynamicStyles = StyleSheet.create({
+      backArrow: {
+        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
+          paddingLeft: 10
+        }
+      },
+      component: Object.assign({}, {
+        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
+          width: '100%'
+        },
+        [`@media (min-width: ${this.props.breakPoints.large}px)`]: {
+          width: this.props.maxWidth
+        }
+      }, this.props.style),
+      content: this.props.contentStyle,
+      header: this.props.headerStyle,
+      scrim: {
+        backgroundColor: this.props.showScrim ? StyleConstants.Colors.SCRIM : 'transparent'
+      }
+    });
 
     return (
-      <div style={styles.componentWrapper}>
-        <div onClick={this.close} style={styles.scrim} />
-        <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
-          <header style={Object.assign({}, styles.header, this.props.headerStyle)}>
-            <span style={styles.backArrow}>
+      <div className={css(styles.componentWrapper)}>
+        <div className={css(styles.scrim, dynamicStyles.scrim)} onClick={this.close} />
+        <div className={css(styles.component, dynamicStyles.component)} ref={(ref) => (this._component = ref)}>
+          <header className={css(styles.header, dynamicStyles.header)}>
+            <span className={css(styles.backArrow, dynamicStyles.backArrow)}>
               <Button
                 icon='arrow-left'
                 onClick={this.close}
@@ -150,116 +164,103 @@ const Drawer = React.createClass({
                 type={'base'}
               />
             </span>
-            <span style={styles.title}>
+            <span className={css(styles.title)}>
               {this.props.title}
             </span>
             {this._renderNav()}
           </header>
-          <div style={Object.assign({}, styles.content, this.props.contentStyle)}>
+          <div className={css(styles.content, dynamicStyles.content)}>
             {this.props.children}
           </div>
         </div>
       </div>
     );
-  },
-
-  styles () {
-    return {
-      component: {
-        border: '1px solid ' + StyleConstants.Colors.FOG,
-        boxSizing: 'border-box',
-        zIndex: 1001,
-        top: 0,
-        bottom: 0,
-        left: '100%',
-        position: 'absolute',
-        width: '80%',
-        overflow: 'hidden',
-        backgroundColor: StyleConstants.Colors.PORCELAIN,
-        boxShadow: StyleConstants.ShadowHigh,
-
-        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
-          width: '100%'
-        },
-        [`@media (min-width: ${this.props.breakPoints.large}px)`]: {
-          width: this.props.maxWidth
-        }
-      },
-      componentWrapper: {
-        bottom: 0,
-        left: 0,
-        position: 'fixed',
-        right: 0,
-        top: 0,
-        zIndex: 999
-      },
-      content: {
-        backgroundColor: StyleConstants.Colors.WHITE,
-        height: '100%'
-      },
-      scrim: {
-        zIndex: 1000,
-        position: 'fixed',
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-        textAlign: 'center',
-        backgroundColor: this.props.showScrim ? StyleConstants.Colors.SCRIM : 'transparent'
-      },
-      icons: {
-        color: StyleConstants.Colors.ASH
-      },
-      backArrow: {
-        paddingLeft: 20,
-        textAlign: 'left',
-        width: '25%',
-
-        [`@media (max-width: ${this.props.breakPoints.medium}px)`]: {
-          paddingLeft: 10
-        }
-      },
-      header: {
-        alignItems: 'center',
-        backgroundColor: StyleConstants.Colors.WHITE,
-        borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
-        color: StyleConstants.Colors.ASH,
-        display: 'flex',
-        fontFamily: StyleConstants.Fonts.REGULAR,
-        fontSize: StyleConstants.FontSizes.LARGE,
-        justifyContent: 'center',
-        padding: '7px 7px',
-        position: 'relative'
-      },
-      title: {
-        overflow: 'hidden',
-        textAlign: 'center',
-        textOverflow: 'ellipsis',
-        width: '50%',
-        whiteSpace: 'nowrap'
-      },
-      nav: {
-        paddingRight: 20,
-        textAlign: 'right',
-        width: '25%',
-        whiteSpace: 'nowrap',
-
-        '@media (max-width: 750px)': {
-          paddingRight: 10
-        }
-      },
-      navLabel: {
-        padding: '7px 14px',
-        position: 'relative',
-        bottom: 5,
-
-        '@media (max-width: 750px)': {
-          display: 'none',
-          padding: 0
-        }
-      }
-    };
   }
 });
 
-module.exports = Radium(Drawer);
+const styles = StyleSheet.create({
+  component: {
+    border: '1px solid ' + StyleConstants.Colors.FOG,
+    boxSizing: 'border-box',
+    zIndex: 1001,
+    top: 0,
+    bottom: 0,
+    left: '100%',
+    position: 'absolute',
+    width: '80%',
+    overflow: 'hidden',
+    backgroundColor: StyleConstants.Colors.PORCELAIN,
+    boxShadow: StyleConstants.ShadowHigh
+  },
+  componentWrapper: {
+    bottom: 0,
+    left: 0,
+    position: 'fixed',
+    right: 0,
+    top: 0,
+    zIndex: 999
+  },
+  content: {
+    backgroundColor: StyleConstants.Colors.WHITE,
+    height: '100%'
+  },
+  scrim: {
+    zIndex: 1000,
+    position: 'fixed',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    textAlign: 'center',
+    backgroundColor: StyleConstants.Colors.SCRIM
+  },
+  icons: {
+    color: StyleConstants.Colors.ASH
+  },
+  backArrow: {
+    paddingLeft: 20,
+    textAlign: 'left',
+    width: '25%'
+  },
+  header: {
+    alignItems: 'center',
+    backgroundColor: StyleConstants.Colors.WHITE,
+    borderBottom: 'solid 1px ' + StyleConstants.Colors.FOG,
+    color: StyleConstants.Colors.ASH,
+    display: 'flex',
+    fontFamily: StyleConstants.Fonts.REGULAR,
+    fontSize: StyleConstants.FontSizes.LARGE,
+    justifyContent: 'center',
+    padding: '7px 7px',
+    position: 'relative'
+  },
+  title: {
+    overflow: 'hidden',
+    textAlign: 'center',
+    textOverflow: 'ellipsis',
+    width: '50%',
+    whiteSpace: 'nowrap'
+  },
+  nav: {
+    paddingRight: 20,
+    textAlign: 'right',
+    width: '25%',
+    whiteSpace: 'nowrap',
+
+    '@media (max-width: 750px)': {
+      paddingRight: 10
+    }
+  },
+  navLabel: {
+    padding: '7px 14px',
+    position: 'relative',
+    bottom: 5,
+
+    '@media (max-width: 750px)': {
+      display: 'none',
+      padding: 0
+    }
+  }
+});
+
+module.exports = Drawer;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -49,7 +49,13 @@ const Drawer = React.createClass({
   },
 
   componentDidMount () {
-    this._animateComponent({ left: this._getAnimationDistance() });
+    // Aphrodite Buffers injecting styles so on componentDidMount
+    // styles may not be ready.  setTimeout is their suggested
+    // solution. https://github.com/Khan/aphrodite#style-injection-and-buffering
+    setTimeout(() => {
+      this._animateComponent({ left: this._getAnimationDistance() });
+    }, 0);
+
     window.addEventListener('resize', this._resizeThrottled);
   },
 
@@ -93,7 +99,6 @@ const Drawer = React.createClass({
   _animateComponent (transition, extraOptions) {
     const el = this._component;
     const options = Object.assign({
-      delay: 50,
       duration: this.props.duration,
       easing: this.props.easing
     }, extraOptions);


### PR DESCRIPTION
https://github.com/Khan/aphrodite
### Issue

Older versions of Radium are causing an `Unknown Prop` warnings with React 15.2.x +.  The 0.18.x versions of Radium resolve the issue but they now require that you wrap your application in its `StyleRoot` component if you use media queries.  

This presents an issue as we don't want users of `mx-react-components` to have to require in Radium and wrap their application in a `StyleRoot` component.  We could wrap the effected components in the StyleRoot component our selves but it looks like the `StyleRoot` component for Radium is injecting CSS style sheets similar to how `Aphrodite` works but in a way that seems more cumbersome.
### Solution

I decided to make this issue a reason to test out Aphrodite.  This PR converts the Drawer component to Aphrodite as a test.  All feed back is welcome.
### Gotchas
- Combining internal style objects with styles from props must now happen in the `StyleSheet.create` call in the styles function.  The resulting javascript object from `StyleSheet.create` prevents us from doing `Object.assign` to merge styles directly in render functions.
- We need to use the no-important version of Aphrodite so that it does not mark all our styles as `!important`.  `const { StyleSheet, css } = require('aphrodite/no-important');`  From the Aphrodite git hub page: `By default, Aphrodite will append !important to style definitions. This is intended to make integrating with a pre-existing codebase easier. If you'd like to avoid this behaviour, then instead of importing aphrodite, import aphrodite/no-important. Otherwise, usage is the same:`
- The injecting of the css style sheets seems to add a very small amount of time on load and because of this I had to delay the drawer animation by 50 ms so that it would run smoothly.  This was not a big deal since Velocity provides the `delay` option.  The increase is also not noticeable by the human eye.  It just seems to be enough to cause a race condition with the initial animation.
- Now that we have a proper style sheet, we have to be aware of nesting html elements that css does not support.  The example here is that I had to move from using the `<p>` tag to using a div because I was getting css errors for the demo app about nesting divs inside `<p>` tags.
