### PR TITLE
BarChart: Fixes scaling issue

### DIFF
--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -211,11 +211,26 @@ const BarChart = React.createClass({
       return d.value;
     });
     const gap = 0.3;
-    const y0 = Math.max(Math.abs(d3.min(data)), Math.abs(d3.max(data)));
+    const hasNegative = !!data.filter(value => value < 0).length;
+    const hasPositive = !!data.filter(value => value > 0).length;
+    let domain;
+    let range;
 
+    if (hasNegative && !hasPositive) {
+      domain = [d3.min(data), 0];
+      range = [-height, 0];
+    } else if (!hasNegative && hasPositive) {
+      domain = [0, d3.max(data)];
+      range = [0, height];
+    } else if (hasNegative && hasPositive) {
+      const y0 = Math.max(Math.abs(d3.min(data)), Math.abs(d3.max(data)));
+
+      domain = [-y0, y0];
+      range = [-height, height];
+    }
     const yScale = d3.scale.linear()
-      .domain([-y0, y0])
-      .range([0, height]);
+      .domain(domain)
+      .range(range);
 
     const xScale = d3.scale.ordinal()
       .domain(d3.range(this.props.data.length))

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -180,10 +180,10 @@ const BarChart = React.createClass({
     });
   },
 
-  _renderBar (yScale, xScale, barWidth, value, index) {
-    const height = value < 0 ? Math.abs(yScale(value) - yScale(0)) : yScale(value);
+  _renderBar (yScale, xScale, barWidth, value, index, maxHeight) {
+    const height = Math.abs(yScale(value));
     const x = xScale(index);
-    const y = value > 0 ? this.props.height - height : 0;
+    const y = value > 0 ? maxHeight - height : 0;
 
     return (
       <Rect
@@ -226,7 +226,7 @@ const BarChart = React.createClass({
       const y0 = Math.max(Math.abs(d3.min(data)), Math.abs(d3.max(data)));
 
       domain = [-y0, y0];
-      range = [-height, height];
+      range = [-height / 2, height / 2];
     }
     const yScale = d3.scale.linear()
       .domain(domain)
@@ -237,17 +237,17 @@ const BarChart = React.createClass({
       .rangeRoundBands([0, width], gap);
 
     const barWidth = xScale.rangeBand();
-
+    const maxHeight = Math.max.apply(null, range.map(Math.abs));
     const positiveBars = data.map((value, index) => {
-      return value > 0 ? this._renderBar(yScale, xScale, barWidth, value, index) : null;
+      return value > 0 ? this._renderBar(yScale, xScale, barWidth, value, index, maxHeight) : null;
     });
 
     const negativeBars = data.map((value, index) => {
-      return value < 0 ? this._renderBar(yScale, xScale, barWidth, value, index) : null;
+      return value < 0 ? this._renderBar(yScale, xScale, barWidth, value, index, maxHeight) : null;
     });
 
-    const maxHeightForPositiveBars = d3.max(data) > 0 ? yScale(d3.max(data)) : 0;
-    const maxHeightForNegativeBars = d3.min(data) < 0 ? yScale(Math.abs(d3.min(data))) - yScale(0) : 0;
+    const maxHeightForPositiveBars = hasPositive ? yScale(d3.max(data)) : 0;
+    const maxHeightForNegativeBars = hasNegative ? yScale(Math.abs(d3.min(data))) : 0;
     const tooltipMargin = 20;
     const tooltipWidth = barWidth * 1.5;
     const tooltipXPos = (tooltipWidth - barWidth) / 2;


### PR DESCRIPTION
This PR fixes an issue with bars in the BarChart not scaling data values correctly. For example: A data value 1200 should be twice as tall as a data value 600 in the bar chart. This was caused by calculating the `domain` and `range` values on the assumption that all data passed as a prop to this component are positive.

Before
<img width="719" alt="screen shot 2016-09-12 at 3 59 38 pm" src="https://cloud.githubusercontent.com/assets/9920303/18454618/9bccb812-7902-11e6-8434-756bdf369a84.png">

After
<img width="715" alt="screen shot 2016-09-12 at 3 59 16 pm" src="https://cloud.githubusercontent.com/assets/9920303/18454630/a3460c6a-7902-11e6-89a3-e71d4660db40.png">

