### PR TITLE
Fixes SimpleInput usage in SearchInput component

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -28,13 +28,15 @@ const SearchInput = React.createClass({
       <div style={Object.assign({}, styles.component, this.props.style)}>
         <Input
           baseColor={this.props.baseColor}
+          elementProps={{
+            onBlur: this.props.onBlur,
+            onChange: this.props.onChange,
+            placeholder: this.props.placeholder,
+            value: this.props.searchKeyword
+          }}
           focusOnLoad={this.props.focusOnLoad}
           icon='search'
-          onBlur={this.props.onBlur}
-          onChange={this.props.onChange}
-          placeholder={this.props.placeholder}
           type='text'
-          value={this.props.searchKeyword}
         />
       </div>
     );

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -32,11 +32,11 @@ const SearchInput = React.createClass({
             onBlur: this.props.onBlur,
             onChange: this.props.onChange,
             placeholder: this.props.placeholder,
+            type: 'text',
             value: this.props.searchKeyword
           }}
           focusOnLoad={this.props.focusOnLoad}
           icon='search'
-          type='text'
         />
       </div>
     );


### PR DESCRIPTION
I missed this one when I was fixing unknown props before because it was required in as `Input` rather than `SimpleInput` so when I searched for `<SimpleInput` I missed this one.