### PR TITLE
Modal: Fixes close icon

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -190,7 +190,9 @@ const Modal = React.createClass({
           {this.props.showCloseIcon ? (
             <Icon
               className='mx-modal-close'
-              onClick={this.props.onRequestClose}
+              elementProps={{
+                onClick: this.props.onRequestClose
+              }}
               size={24}
               style={styles.close}
               type='close-solid'


### PR DESCRIPTION
This PR fixes an issue where the close icon does not work in the `Modal` component.

- Pass `onClick` prop to the `Icon` component as a property in the `elementProps` object 

