### PR TITLE
Search Input - reset icon & other style fixes 

### DIFF
--- a/docs/components/SearchInputDocs.js
+++ b/docs/components/SearchInputDocs.js
@@ -25,6 +25,9 @@ const SearchInputDocs = React.createClass({
         <h5>onChange <label>Function</label></h5>
         <p>A method to be called as the user types in the search input field.</p>
 
+        <h5>handleResetClick <label>Function</label></h5>
+        <p>A method to be called when reset icon is clicked.</p>
+
         <h5>placeholder <label>String</label></h5>
         <p>The text to show before the user starts typing or when the search input field is empty.</p>
 

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -6,6 +6,7 @@ const SearchInput = React.createClass({
   propTypes: {
     baseColor: React.PropTypes.string,
     focusOnLoad: React.PropTypes.bool,
+    handleResetClick: React.PropTypes.func,
     onBlur: React.PropTypes.func,
     onChange: React.PropTypes.func,
     placeholder: React.PropTypes.string,
@@ -36,7 +37,10 @@ const SearchInput = React.createClass({
             value: this.props.searchKeyword
           }}
           focusOnLoad={this.props.focusOnLoad}
+          handleResetClick={this.props.handleResetClick}
           icon='search'
+          resetClick={this.props.handleResetClick}
+          rightIcon='close-solid'
         />
       </div>
     );

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -9,8 +9,10 @@ const Input = React.createClass({
     baseColor: React.PropTypes.string,
     elementProps: React.PropTypes.object,
     focusOnLoad: React.PropTypes.bool,
+    handleResetClick: React.PropTypes.func,
     icon: React.PropTypes.string,
     placeholder: React.PropTypes.string,
+    rightIcon: React.PropTypes.string,
     style: React.PropTypes.oneOfType([
       React.PropTypes.array,
       React.PropTypes.object
@@ -88,6 +90,16 @@ const Input = React.createClass({
           style={styles.input}
           type={this.props.type}
         />
+        {this.props.rightIcon ? (
+          <Icon
+            elementProps={{
+              onClick: this.props.handleResetClick
+            }}
+            size={20}
+            style={styles.rightIcon}
+            type={this.props.rightIcon}
+          />
+        ) : null}
       </div>
     );
   },
@@ -110,11 +122,18 @@ const Input = React.createClass({
         border: '1px solid ' + this.props.baseColor
       },
       icon: {
-        paddingRight: StyleConstants.Spacing.XSMALL,
+        paddingRight: 7,
         fill: this.props.baseColor
+      },
+      rightIcon: {
+        paddingLeft: StyleConstants.Spacing.XSMALL,
+        fill: StyleConstants.Colors.FOG,
+        cursor: 'pointer'
       },
       input: {
         flex: '1 0 0%',
+        color: StyleConstants.Colors.CHARCOAL,
+        fontSize: StyleConstants.FontSizes.MEDIUM,
         backgroundColor: StyleConstants.Colors.WHITE,
         border: 'none',
         outline: 'none',


### PR DESCRIPTION
Addresses https://github.com/mxenabled/mx-react-components/issues/442 

I was kind of 50/50 on whether to just kill the SearchInput and add more props to the SimpleInput to make this happen, but the reason I decided to keep it is I think it will make a faster dev experience for us && have less potential to break things in existing SimpleInputs.  

![searchinput gif](https://cloud.githubusercontent.com/assets/13579578/18678706/288c7d9c-7f1a-11e6-991e-93baeced05bf.gif)
