### PR TITLE
FileUpload: reset input on new props

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -42,6 +42,8 @@ const FileUpload = React.createClass({
   },
 
   componentWillReceiveProps (newProps) {
+    this._input.value = null;
+
     if (newProps.uploadedFile !== this.props.uploadedFile) {
       this._readFile(newProps.uploadedFile, result => {
         this._validateFile(result.file, result.width, result.height);


### PR DESCRIPTION
This fixes an issue where using the file select after clearing the previous file does not work. When new props are received, set the input value to null, resetting the form and allowing for another file to be selected.

