### PR TITLE
Fix tooltip elemementprops

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -156,8 +156,10 @@ const Modal = React.createClass({
         <div className='mx-modal-tooltip-label' style={styles.tooltipLabel}>
           <Icon
             className='mx-modal-tooltip-label-icon'
-            onMouseOut={this._handleTooltipToggle.bind(null, false)}
-            onMouseOver={this._handleTooltipToggle.bind(null, true)}
+            elementProps={{
+              onMouseOut: this._handleTooltipToggle.bind(null, false),
+              onMouseOver: this._handleTooltipToggle.bind(null, true)
+            }}
             size={18}
             style={{ color: this.props.color }}
             type='info'

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -87,8 +87,10 @@ const Tooltip = React.createClass({
           </div>
         ) : null}
         <Icon
-          onMouseEnter={this._handleInfoMouseEnter}
-          onMouseLeave={this._handleInfoMouseLeave}
+          elementProps={{
+            onMouseEnter: this._handleInfoMouseEnter,
+            onMouseLeave: this._handleInfoMouseLeave
+          }}
           size={this.props.iconSize}
           type={this.props.icon}
         />


### PR DESCRIPTION
This moves the mouse event props on the tooltip icon and the tooltip in the modal to the new `elementProps`.

