### PR TITLE
Added letter spacing to the modal title

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -256,7 +256,8 @@ const Modal = React.createClass({
         padding: '15px 20px',
         color: StyleConstants.Colors.ASH,
         fontSize: StyleConstants.FontSizes.SMALL,
-        textTransform: 'uppercase'
+        textTransform: 'uppercase',
+        letterSpacing: 1
       },
       content: {
         position: 'relative',


### PR DESCRIPTION
### Issue
The modal title uses all caps which makes the word look to squished and hard to read.

### Solution
I added letter spacing to make it easier to read.

#### Screenshots

Before:
<img width="326" alt="screen shot 2016-09-22 at 11 30 50 am" src="https://cloud.githubusercontent.com/assets/6424668/18762835/d62b60d6-80c7-11e6-8c60-466545fb60db.png">
After:
![image](https://cloud.githubusercontent.com/assets/6424668/18762918/4f70cb02-80c8-11e6-9215-13b948c56889.png)

