### PR TITLE
Drawer docs and new props

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -11,6 +11,7 @@ const DatePickerFullScreen = require('components/DatePickerFullScreenDocs');
 const DateRangePicker = require('components/DateRangePickerDocs');
 const DateTimePicker = require('components/DateTimePickerDocs');
 const DisplayInput = require('components/DisplayInputDocs');
+const Drawer = require('components/DrawerDocs');
 const DonutChart = require('components/DonutChartDocs');
 const FileUpload = require('components/FileUploadDocs');
 const Gauge = require('components/GaugeDocs');
@@ -69,6 +70,7 @@ ReactDOM.render((
         <Route component={DateRangePicker} path='date-range-picker' />
         <Route component={DateTimePicker} path='date-time-picker' />
         <Route component={DisplayInput} path='display-input' />
+        <Route component={Drawer} path='drawer' />
         <Route component={DonutChart} path='donut' />
         <Route component={FileUpload} path='file-upload' />
         <Route component={Gauge} path='gauge' />

--- a/docs/components/Components.js
+++ b/docs/components/Components.js
@@ -49,6 +49,10 @@ const Components = React.createClass({
                   displayValue: 'Display Input'
                 },
                 {
+                  value: 'drawer',
+                  displayValue: 'Drawer'
+                },
+                {
                   value: 'donut',
                   displayValue: 'Donut'
                 },
@@ -161,6 +165,7 @@ const Components = React.createClass({
             <Link to='/components/date-range-picker'>Date Range Picker</Link>
             <Link to='/components/date-time-picker'>Date Time Picker</Link>
             <Link to='/components/display-input'>Display Input</Link>
+            <Link to='/components/drawer'>Drawer</Link>
             <Link to='/components/file-upload'>File Upload</Link>
             <Link to='/components/radio-button'>Radio Button</Link>
             <Link to='/components/range-selector'>Range Selector</Link>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -8,7 +8,9 @@ const DrawerDocs = React.createClass({
 
   getInitialState () {
     return {
-      demoDrawerOpen: false
+      demoDrawerOpen: false,
+      currentPage: 3,
+      totalPages: 8
     };
   },
 
@@ -24,12 +26,30 @@ const DrawerDocs = React.createClass({
     });
   },
 
+  _handlePreviousClick () {
+    if (this.state.currentPage > 1) {
+      this.setState({
+        currentPage: this.state.currentPage - 1
+      });
+    }
+  },
+
+  _handleNextClick () {
+    if (this.state.currentPage < this.state.totalPages) {
+      this.setState({
+        currentPage: this.state.currentPage + 1
+      });
+    }
+  },
+
   _renderDrawer () {
     const styles = this.styles();
 
     return (
       <Drawer
+        breakPoints={{ large: 1200, medium: 1100, small: 1320 }}
         contentStyle={styles.content}
+        navConfig={{ label: this.state.currentPage + ' of ' + this.state.totalPages, onNextClick: this._handleNextClick, onPreviousClick: this._handlePreviousClick }}
         onClose={this._handleDrawerClose}
         title='Demo Drawer'
       >
@@ -57,7 +77,7 @@ const DrawerDocs = React.createClass({
         <h5>animateLeftDistance<label>Number</label></h5>
         <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
 
-        <h5>breakPoints<label></label></h5>
+        <h5>breakPoints<label>Object</label></h5>
         <p></p>
 
         <h5>buttonPrimaryColor<label>String</label></h5>
@@ -73,24 +93,29 @@ const DrawerDocs = React.createClass({
 
         <h5>duration<label>Number</label></h5>
         <p>Default: 500</p>
-        <p></p>
+        <p>This number sets the duration of the drawer animation.</p>
 
         <h5>easing<label>Array</label></h5>
-        <p>Easing: [0.28, 0.14, 0.34, 1.04]</p>
-        <p></p>
+        <p>Default: [0.28, 0.14, 0.34, 1.04]</p>
+        <p>Easing takes an array for how to step through the drawer animation.</p>
 
         <h5>headerStyle<label>Object or Array</label></h5>
         <p>Styles for the header part of the drawer.</p>
 
         <h5>maxWidth<label></label></h5>
         <p>Default: 960</p>
-        <p></p>
+        <p>This is the maximum width of the drawer component.</p>
 
-        <h5>navConfig<label></label></h5>
-        <p></p>
+        <h5>navConfig<label>Object</label></h5>
+        <p>This object requires 3 properties:</p>
+        <ul>
+          <li><h5>label <label>String</label></h5>This will be displayed between the two arrow buttons.</li>
+          <li><h5>onPreviousClick <label>Function</label></h5> This function will be called when the left arrow is clicked.</li>
+          <li><h5>onNextClick <label>Function</label></h5> this function will be called when the right arrow is clicked.</li>
+        </ul>
 
         <h5>onClose<label>Function</label> Required</h5>
-        <p></p>
+        <p>This function will be called when a user clicks the close drawer button.</p>
 
         <h5>showCloseButton<label>Boolean</label></h5>
         <p>Default: true</p>
@@ -104,18 +129,13 @@ const DrawerDocs = React.createClass({
         <p>Default: ''</p>
         <p>This will be displayed in the header of the drawer component.</p>
 
-        <h5><label></label></h5>
-        <p></p>
-
-        <h5><label></label></h5>
-        <p></p>
-
         <h3>Example</h3>
         <Markdown>
   {`
     <Drawer
-      onClose={ () => {}}
       buttonPrimaryColor='#333333'
+      onClose={this._handleCloseDrawerClick}
+      showScrim={false}
       title='Demo Drawer'
     />
   `}
@@ -127,7 +147,8 @@ const DrawerDocs = React.createClass({
   styles () {
     return {
       content: {
-        padding: 20
+        padding: 60,
+        fontFamily: 'ProximaNovaRegular, Helvetica, Arial, sans-serif'
       }
     };
   }

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -1,0 +1,138 @@
+const React = require('react');
+
+const { Button, Drawer } = require('mx-react-components');
+
+const Markdown = require('components/Markdown');
+
+const DrawerDocs = React.createClass({
+
+  getInitialState () {
+    return {
+      demoDrawerOpen: false
+    };
+  },
+
+  _handleDemoButtonClick () {
+    this.setState({
+      demoDrawerOpen: true
+    });
+  },
+
+  _handleDrawerClose () {
+    this.setState({
+      demoDrawerOpen: false
+    });
+  },
+
+  _renderDrawer () {
+    const styles = this.styles();
+
+    return (
+      <Drawer
+        contentStyle={styles.content}
+        onClose={this._handleDrawerClose}
+        title='Demo Drawer'
+      >
+        Pellentesque finibus eros magna, ac feugiat mauris pretium posuere. Aliquam nec turpis bibendum, hendrerit eros et, interdum neque. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc pulvinar tempus sollicitudin. Mauris vel suscipit dolor. Vestibulum hendrerit malesuada ipsum. Mauris feugiat dui vel leo consequat tempor. Praesent aliquet posuere consequat. Nunc vel tellus eleifend leo finibus auctor.
+      </Drawer>
+
+    );
+  },
+
+  render () {
+    return (
+      <div>
+        <h1>
+          Drawer
+          <label>A basic drawer component</label>
+        </h1>
+
+        <h3>Demo</h3>
+        <Button onClick={this._handleDemoButtonClick}>
+          Demo Drawer
+        </Button>
+        {this.state.demoDrawerOpen && this._renderDrawer()}
+
+        <h3>Usage</h3>
+        <h5>animateLeftDistance<label>Number</label></h5>
+        <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
+
+        <h5>breakPoints<label></label></h5>
+        <p></p>
+
+        <h5>buttonPrimaryColor<label>String</label></h5>
+        <p>Default: '#359BCF'</p>
+        <p>This sets the color of the arrow in the close button at the top left of the drawer.</p>
+
+        <h5>closeOnScrimClick<label>Boolean</label></h5>
+        <p>Default: true</p>
+        <p>To prevent the drawer from closing if a user clicks on the screen outside of the drawer, set this to <em>false</em>.</p>
+
+        <h5>contentStyle<label></label></h5>
+        <p>Styles for the content inside the drawer.</p>
+
+        <h5>duration<label>Number</label></h5>
+        <p>Default: 500</p>
+        <p></p>
+
+        <h5>easing<label>Array</label></h5>
+        <p>Easing: [0.28, 0.14, 0.34, 1.04]</p>
+        <p></p>
+
+        <h5>headerStyle<label>Object or Array</label></h5>
+        <p>Styles for the header part of the drawer.</p>
+
+        <h5>maxWidth<label></label></h5>
+        <p>Default: 960</p>
+        <p></p>
+
+        <h5>navConfig<label></label></h5>
+        <p></p>
+
+        <h5>onClose<label>Function</label> Required</h5>
+        <p></p>
+
+        <h5>showCloseButton<label>Boolean</label></h5>
+        <p>Default: true</p>
+        <p>To remove the close drawer button in the top left corner, set this to <em>false</em>.</p>
+
+        <h5>showScrim<label>Boolean</label></h5>
+        <p>Default: true</p>
+        <p>If set to <em>true</em>, the part of the screen not covered by the drawer will be opaque. If set to <em>false</em>, the content will stay visible.</p>
+
+        <h5>title<label>String</label></h5>
+        <p>Default: ''</p>
+        <p>This will be displayed in the header of the drawer component.</p>
+
+        <h5><label></label></h5>
+        <p></p>
+
+        <h5><label></label></h5>
+        <p></p>
+
+        <h3>Example</h3>
+        <Markdown>
+  {`
+    <Drawer
+      onClose={ () => {}}
+      buttonPrimaryColor='#333333'
+      title='Demo Drawer'
+    />
+  `}
+        </Markdown>
+      </div>
+    );
+  },
+
+  styles () {
+    return {
+      content: {
+        padding: 20
+      }
+    };
+  }
+});
+
+
+module.exports = DrawerDocs;
+

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -137,7 +137,9 @@ const DrawerDocs = React.createClass({
       onClose={this._handleCloseDrawerClick}
       showScrim={false}
       title='Demo Drawer'
-    />
+    >
+      //Content here
+    </Drawer>
   `}
         </Markdown>
       </div>
@@ -148,7 +150,8 @@ const DrawerDocs = React.createClass({
     return {
       content: {
         padding: 60,
-        fontFamily: 'ProximaNovaRegular, Helvetica, Arial, sans-serif'
+        fontFamily: 'ProximaNovaRegular, Helvetica, Arial, sans-serif',
+        color: '#2E323F'
       }
     };
   }

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -87,7 +87,7 @@ const DrawerDocs = React.createClass({
         </ul>
         <p>When the screen size is: <br />
           &#62;&#61; large: drawer width is maxWidth <br />
-          &#60;	large and > medium: drawer width is 20% from left side <br />
+          &#60;	large and &#62; medium: drawer width is 20% from left side <br />
           &#60;&#61; medium: drawer width is 100%
         </p>
 

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -99,7 +99,7 @@ const DrawerDocs = React.createClass({
         <p>Default: true</p>
         <p>To prevent the drawer from closing if a user clicks on the screen outside of the drawer, set this to <em>false</em>.</p>
 
-        <h5>contentStyle<label></label></h5>
+        <h5>contentStyle<label>Object or Array</label></h5>
         <p>Styles for the content inside the drawer.</p>
 
         <h5>duration<label>Number</label></h5>
@@ -113,7 +113,7 @@ const DrawerDocs = React.createClass({
         <h5>headerStyle<label>Object or Array</label></h5>
         <p>Styles for the header part of the drawer.</p>
 
-        <h5>maxWidth<label></label></h5>
+        <h5>maxWidth<label>Number</label></h5>
         <p>Default: 960</p>
         <p>This is the maximum width of the drawer component.</p>
 

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -47,7 +47,7 @@ const DrawerDocs = React.createClass({
 
     return (
       <Drawer
-        breakPoints={{ large: 1200, medium: 1100, small: 1320 }}
+        breakPoints={{ large: 1200, medium: 1100 }}
         contentStyle={styles.content}
         navConfig={{ label: this.state.currentPage + ' of ' + this.state.totalPages, onNextClick: this._handleNextClick, onPreviousClick: this._handlePreviousClick }}
         onClose={this._handleDrawerClose}
@@ -60,6 +60,8 @@ const DrawerDocs = React.createClass({
   },
 
   render () {
+    const styles = this.styles();
+
     return (
       <div>
         <h1>
@@ -78,7 +80,16 @@ const DrawerDocs = React.createClass({
         <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
 
         <h5>breakPoints<label>Object</label></h5>
-        <p></p>
+        <p>This object takes 2 properties:</p>
+        <ul style={styles.unorderdLists}>
+          <li style={styles.listItem}><h5 style={styles.listItem}>large <label>Number</label></h5></li>
+          <li style={styles.listItem}><h5 style={styles.listItem}>medium <label>Number</label></h5></li>
+        </ul>
+        <p>When the screen size is: <br />
+          &#62;&#61; large: drawer width is maxWidth <br />
+          &#60;	large and > medium: drawer width is 20% from left side <br />
+          &#60;&#61; medium: drawer width is 100%
+        </p>
 
         <h5>buttonPrimaryColor<label>String</label></h5>
         <p>Default: '#359BCF'</p>
@@ -108,10 +119,10 @@ const DrawerDocs = React.createClass({
 
         <h5>navConfig<label>Object</label></h5>
         <p>This object requires 3 properties:</p>
-        <ul>
-          <li><h5>label <label>String</label></h5>This will be displayed between the two arrow buttons.</li>
-          <li><h5>onPreviousClick <label>Function</label></h5> This function will be called when the left arrow is clicked.</li>
-          <li><h5>onNextClick <label>Function</label></h5> this function will be called when the right arrow is clicked.</li>
+        <ul style={styles.unorderdLists}>
+          <li style={styles.listItem}><h5 style={styles.h5ListItem}>label <label>String</label></h5>This will be displayed between the two arrow buttons.</li>
+          <li style={styles.listItem}><h5 style={styles.h5ListItem}>onPreviousClick <label>Function</label></h5> This function will be called when the left arrow is clicked.</li>
+          <li style={styles.listItem}><h5 style={styles.h5ListItem}>onNextClick <label>Function</label></h5> this function will be called when the right arrow is clicked.</li>
         </ul>
 
         <h5>onClose<label>Function</label> Required</h5>
@@ -152,6 +163,18 @@ const DrawerDocs = React.createClass({
         padding: 60,
         fontFamily: 'ProximaNovaRegular, Helvetica, Arial, sans-serif',
         color: '#2E323F'
+      },
+      unorderdLists: {
+        marginTop: 0,
+        marginBottom: 8
+      },
+      listItem: {
+        marginTop: 0,
+        marginBottom: 0
+      },
+      h5ListItem: {
+        marginTop: 0,
+        marginBottom: 0
       }
     };
   }

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -13,8 +13,7 @@ const Drawer = React.createClass({
     animateLeftDistance: React.PropTypes.number,
     breakPoints: React.PropTypes.shape({
       large: React.PropTypes.number,
-      medium: React.PropTypes.number,
-      small: React.PropTypes.number
+      medium: React.PropTypes.number
     }),
     buttonPrimaryColor: React.PropTypes.string,
     closeOnScrimClick: React.PropTypes.bool,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -17,6 +17,7 @@ const Drawer = React.createClass({
       small: React.PropTypes.number
     }),
     buttonPrimaryColor: React.PropTypes.string,
+    closeOnScrimClick: React.PropTypes.bool,
     contentStyle: React.PropTypes.oneOfType([
       React.PropTypes.array,
       React.PropTypes.object
@@ -34,6 +35,7 @@ const Drawer = React.createClass({
       onPreviousClick: React.PropTypes.func.isRequired
     }),
     onClose: React.PropTypes.func.isRequired,
+    showCloseButton: React.PropTypes.bool,
     showScrim: React.PropTypes.bool,
     title: React.PropTypes.string
   },
@@ -42,9 +44,11 @@ const Drawer = React.createClass({
     return {
       buttonPrimaryColor: StyleConstants.Colors.PRIMARY,
       breakPoints: StyleConstants.BreakPoints,
+      closeOnScrimClick: true,
       duration: 500,
       easing: [0.28, 0.14, 0.34, 1.04],
       maxWidth: 960,
+      showCloseButton: true,
       showScrim: true,
       title: ''
     };
@@ -139,16 +143,18 @@ const Drawer = React.createClass({
 
     return (
       <div style={styles.componentWrapper}>
-        <div onClick={this.close} style={styles.scrim} />
+        <div onClick={this.props.closeOnScrimClick && this.close} style={styles.scrim} />
         <div ref={(ref) => (this._component = ref)} style={Object.assign({}, styles.component, this.props.style)}>
           <header style={Object.assign({}, styles.header, this.props.headerStyle)}>
             <span style={styles.backArrow}>
-              <Button
-                icon='arrow-left'
-                onClick={this.close}
-                primaryColor={this.props.buttonPrimaryColor}
-                type={'base'}
-              />
+              {this.props.showCloseButton &&
+                <Button
+                  icon='arrow-left'
+                  onClick={this.close}
+                  primaryColor={this.props.buttonPrimaryColor}
+                  type={'base'}
+                />
+              }
             </span>
             <span style={styles.title}>
               {this.props.title}
@@ -229,7 +235,8 @@ const Drawer = React.createClass({
         fontSize: StyleConstants.FontSizes.LARGE,
         justifyContent: 'center',
         padding: '7px 7px',
-        position: 'relative'
+        position: 'relative',
+        minHeight: StyleConstants.Spacing.XLARGE
       },
       title: {
         overflow: 'hidden',


### PR DESCRIPTION
### Issue
The monthly contribution drawer needs to stay open if the scrim is clicked and I needed to remove the close button from the drawer, so I added 2 new props.

- closeOnScrimClick: this defaults to true, but if you set it to false the drawer will stay open if the scrim is clicked

- showCloseButton: this also defaults to true, but if you set it to false the button will be hidden

Since the drawer component doesn't exist in the docs I went ahead and added it. I'm pretty confident about most of the explanations, but I definitely would love some extra eyes to check coherency, grammers and spells.

I played around with the breakPoints prop and I just don't feel like I can explain that prop in the docs so I will need some help there. breakpoints takes in a `small` property but it doesn't appear to even be used in the code.

@paniclater @cerinman 