### PR TITLE
Tabs: Passes brand color to Icon

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -89,7 +89,7 @@ const Tabs = React.createClass({
         {selectedTabName}
         <Icon
           size={20}
-          style={{ color: this.props.brandColor }}
+          style={{ fill: this.props.brandColor }}
           type={!this.state.showMenu ? 'caret-down' : 'caret-up' }
         />
         {this.state.showMenu ? (


### PR DESCRIPTION
This PR fixes an issue with the `Tabs` component where the brand color does not show up in the Icon component for mobile.

