### PR TITLE
hide datepicker icons on xsmall devices, simplify flex rules

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -298,11 +298,12 @@ const DateRangePicker = React.createClass({
     return (
       <div style={styles.component}>
         <div onClick={this._toggleCalendar} style={styles.selectedDateWrapper}>
-          <Icon
-            size={20}
-            style={styles.selectedDateIcon}
-            type='calendar'
-          />
+          {StyleConstants.getWindowSize() !== 'xsmall' &&
+            <Icon
+              size={20}
+              style={styles.selectedDateIcon}
+              type='calendar'
+            />}
           <div style={styles.selectedDateText}>
             {this.props.selectedStartDate && this.props.selectedEndDate ? (
               <div>
@@ -312,11 +313,12 @@ const DateRangePicker = React.createClass({
               </div>
             ) : this.props.placeholderText}
           </div>
-          <Icon
-            size={20}
-            style={styles.selectedDateCaret}
-            type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
-          />
+          {StyleConstants.getWindowSize() !== 'xsmall' &&
+            <Icon
+              size={20}
+              style={styles.selectedDateCaret}
+              type={this.state.showCalendar ? 'caret-up' : 'caret-down'}
+            />}
         </div>
         <Container>
           <Row>
@@ -405,6 +407,7 @@ const DateRangePicker = React.createClass({
         borderWidth: 1,
         boxSizing: 'border-box',
         color: StyleConstants.Colors.BLACK,
+        cursor: 'pointer',
         display: 'inline-block',
         fontFamily: StyleConstants.FontFamily,
         fontSize: StyleConstants.FontSizes.MEDIUM,
@@ -416,18 +419,16 @@ const DateRangePicker = React.createClass({
       // Selected Date styles
       selectedDateWrapper: {
         alignItems: 'center',
-        cursor: 'pointer',
         display: 'flex',
-        justifyContent: 'space-between',
-        position: this.props.isRelative ? 'relative' : 'static'
+        height: 20,
+        justifyContent: 'space-between'
       },
       selectedDateIcon: {
         fill: this.props.primaryColor,
         marginRight: 5
       },
       selectedDateText: {
-        color: (this.props.selectedStartDate && this.props.selectedEndDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH,
-        flex: 1
+        color: (this.props.selectedStartDate && this.props.selectedEndDate) ? StyleConstants.Colors.CHARCOAL : StyleConstants.Colors.ASH
       },
       selectedDateCaret: {
         fill: this.state.showCalendar ? this.props.primaryColor : StyleConstants.Colors.ASH


### PR DESCRIPTION
- Only display calendar and caret icons on devices large enough to support them
- Simplifies flex rules a little bit
- enforces datepicker height to match style guide

BEFORE:
--
<img width="323" alt="screen shot 2016-11-07 at 3 58 24 pm" src="https://cloud.githubusercontent.com/assets/1081167/20079702/19a9b650-a503-11e6-8fe0-fb03392b7b4c.png">

AFTER:
--
iPhone 6+
![iphone6plus](https://cloud.githubusercontent.com/assets/1081167/20078247/fe197fde-a4fc-11e6-8b44-01aa31c05339.png)
iPhone 6
![iphone6](https://cloud.githubusercontent.com/assets/1081167/20078253/056869ee-a4fd-11e6-92b5-cfd273425e37.png)
iPhone 5
![iphone5](https://cloud.githubusercontent.com/assets/1081167/20078263/0d5f4938-a4fd-11e6-99b0-8bd3f4713c1d.png)
Nexus 6p
![nexus6p](https://cloud.githubusercontent.com/assets/1081167/20078273/16879592-a4fd-11e6-9106-822a57c73908.png)
nexus 5x
![nexus5x](https://cloud.githubusercontent.com/assets/1081167/20078281/1cbdc922-a4fd-11e6-9a90-0136ac2368c7.png)
iPad:
![screen shot 2016-11-07 at 3 17 06 pm](https://cloud.githubusercontent.com/assets/1081167/20078322/4e37ddd0-a4fd-11e6-886c-b9fa6d75f2ff.png)



