### PR TITLE
Update SimpleSelect

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -6,10 +6,70 @@ const Changelog = React.createClass({
       <div>
         <h1>Change Log</h1>
 
+        <h3>Release Candidate 5.0.0-rc.25</h3>
+        <ul>
+          <li>
+            Update SimpleSelect to use stlyes object.(<a href='https://github.com/mxenabled/mx-react-components/pull/471'>#471</a>)
+          </li>
+        </ul>
+
+        <h3>Release Candidate 5.0.0-rc.24</h3>
+        <ul>
+          <li>
+            More changes to CirlceGroup.(<a href='https://github.com/mxenabled/mx-react-components/pull/470'>#470</a>)
+          </li>
+        </ul>
+
+
+        <h3>Release Candidate 5.0.0-rc.23</h3>
+        <ul>
+          <li>
+            Minor fixes to CirlceGroup.(<a href='https://github.com/mxenabled/mx-react-components/pull/469'>#469</a>)
+          </li>
+        </ul>
+
+
+        <h3>Release Candidate 5.0.0-rc.22</h3>
+        <ul>
+          <li>
+            Convert refs from strings to callbacks.(<a href='https://github.com/mxenabled/mx-react-components/pull/468'>#468</a>)
+          </li>
+        </ul>
+
+        <h3>Release Candidate 5.0.0-rc.21</h3>
+        <ul>
+          <li>
+            Fixes layout of DatePicker on small screens.(<a href='https://github.com/mxenabled/mx-react-components/pull/467'>#467</a>)
+          </li>
+        </ul>
+
+        <h3>Release Candidate 5.0.0-rc.20</h3>
+        <ul>
+          <li>
+            Add Pause icon.(<a href='https://github.com/mxenabled/mx-react-components/pull/465'>#465</a>)
+          </li>
+        </ul>
+
+
+        <h3>Release Candidate 5.0.0-rc.19</h3>
+        <ul>
+          <li>
+            Add brand color to icon in Tabs.(<a href='https://github.com/mxenabled/mx-react-components/pull/463'>#463</a>)
+          </li>
+        </ul>
+
+        <h3>Release Candidate 5.0.0-rc.18</h3>
+        <ul>
+          <li>
+            Expose D3 elements.(<a href='https://github.com/mxenabled/mx-react-components/pull/462'>#462</a>)
+          </li>
+        </ul>
+
+
         <h3>Release Candidate 5.0.0-rc.17</h3>
         <ul>
           <li>
-            Updates the medium breakpoint to 768px to align better with the ipad and other tablets.
+            Updates the medium breakpoint to 768px to align better with the ipad and other tablets.(<a href='https://github.com/mxenabled/mx-react-components/pull/461'>#461</a>)
           </li>
         </ul>
 

--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -37,12 +37,11 @@ const SimpleSelectDocs = React.createClass({
           {this.state.showMenu ? (
             <SimpleSelect
               items={[
-                { text: 'Menu Item 1' },
-                { text: 'Menu Item 2' },
-                { text: 'Menu Item 3' }
+                { icon: 'auto', text: 'Auto' },
+                { icon: 'kids', text: 'Kids' },
+                { icon: 'pets', text: 'Pets' }
               ]}
               onScrimClick={this._handleClick}
-              showItems={this.state.showMenu}
             />
           ) : null}
         </div>
@@ -52,24 +51,14 @@ const SimpleSelectDocs = React.createClass({
         <p>Default: 20</p>
         <p>The icon size used for icons in menu items if used.</p>
 
-        <h5>ficonStyles <label>Object</label></h5>
-        <p>Styles for the icons in menu items if used.</p>
-
         <h5>items <label>Array</label> Required</h5>
         <p>An array of objects that specify <em>icon</em>, <em>text</em>, and/or <em>onClick</em> of the item..</p>
-
-        <h5>itemStyle <label>Object</label></h5>
-        <p>Styles for the items in the list.</p>
-
-        <h5>menuStyles <label>Object</label></h5>
-        <p>Styles for the menu.</p>
 
         <h5>onScrimClick <label>function</label></h5>
         <p><em>onClick</em> handler for the menu scrim.</p>
 
-        <h5>style <label>Object</label></h5>
-        <p>Default: PRIMARY</p>
-        <p>Styles for the container around the component.</p>
+        <h5>styles <label>Object</label></h5>
+        <p>A nested styles object to override/append any of the styled elements.</p>
 
         <h3>Example</h3>
         <Markdown>
@@ -80,7 +69,7 @@ const SimpleSelectDocs = React.createClass({
       });
     },
 
-    <div style={{ width: 177 }}>
+    <div>
       <Button
         icon='gear'
         onClick={this._handleClick}
@@ -91,12 +80,11 @@ const SimpleSelectDocs = React.createClass({
       {this.state.showMenu ? (
         <SimpleSelect
           items={[
-            { text: 'Menu Item 1' },
-            { text: 'Menu Item 2' },
-            { text: 'Menu Item 3' }
+            { icon: 'auto', text: 'Auto' },
+            { icon: 'kids', text: 'Kids' },
+            { icon: 'pets', text: 'Pets' }
           ]}
           onScrimClick={this._handleClick}
-          showItems={this.state.showMenu}
         />
       ) : null}
     </div>

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -40,7 +40,7 @@ const Input = React.createClass({
 
   componentDidMount () {
     if (this.props.style) {
-      console.warn('The style prop is deprecated and will be removed in a future release. Please used styles.');
+      console.warn('The style prop is deprecated and will be removed in a future release. Please use styles.');
     }
 
     if (this.props.focusOnLoad && this.input) {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const Radium = require('radium');
+const _merge = require('lodash/merge');
 
 const Icon = require('./Icon');
 
@@ -7,20 +8,37 @@ const StyleConstants = require('../constants/Style');
 
 const SimpleSelect = React.createClass({
   propTypes: {
+    hoverColor: React.PropTypes.string,
     iconSize: React.PropTypes.number,
     iconStyles: React.PropTypes.object,
     items: React.PropTypes.array.isRequired,
     itemStyles: React.PropTypes.object,
     menuStyles: React.PropTypes.object,
     onScrimClick: React.PropTypes.func,
-    style: React.PropTypes.object
+    style: React.PropTypes.object,
+    styles: React.PropTypes.object
   },
 
   getDefaultProps () {
     return {
+      hoverColor: StyleConstants.Colors.PRIMARY,
       items: [],
       onScrimClick () {}
     };
+  },
+
+  componentDidMount () {
+    if (this.props.style) {
+      console.warn('The style prop is deprecated and will be removed in a future release. Please use styles.');
+    }
+
+    if (this.props.iconStyles) {
+      console.warn('The iconStyles prop is deprecated and will be removed in a future release. Please use styles.');
+    }
+
+    if (this.props.menuStyles) {
+      console.warn('The menuStyles prop is deprecated and will be removed in a future release. Please use styles.');
+    }
   },
 
   render () {
@@ -28,18 +46,18 @@ const SimpleSelect = React.createClass({
 
     return (
       <div style={styles.component}>
-        <div style={Object.assign({}, styles.menu, this.props.menuStyles)}>
+        <div style={styles.menu}>
             {this.props.items.map((item, i) => {
               return (
                 <div
                   key={i}
                   onClick={item.onClick}
-                  style={Object.assign({}, styles.item, this.props.itemStyles)}
+                  style={styles.item}
                 >
                   {item.icon ? (
-                    <Icon size={this.props.iconSize || 20} style={Object.assign({}, styles.icon, this.props.iconStyles)} type={item.icon} />
+                    <Icon size={this.props.iconSize || 20} style={styles.icon} type={item.icon} />
                   ) : null}
-                  {item.text}
+                  <div style={styles.text}>{item.text}</div>
                 </div>
               );
             })}
@@ -50,43 +68,49 @@ const SimpleSelect = React.createClass({
   },
 
   styles () {
-    return {
+    return _merge({}, {
       component: Object.assign({
         height: 0,
         position: 'relative'
       }, this.props.style),
 
-      menu: {
+      menu: Object.assign({}, {
         alignSelf: 'stretch',
         backgroundColor: StyleConstants.Colors.WHITE,
         borderRadius: 3,
         boxShadow: StyleConstants.ShadowHigh,
         boxSizing: 'border-box',
-        color: StyleConstants.Colors.BLACK,
+        color: StyleConstants.Colors.CHARCOAL,
         display: 'flex',
         flexDirection: 'column',
-        fill: StyleConstants.Colors.BLACK,
+        fill: StyleConstants.Colors.CHARCOAL,
         fontFamily: StyleConstants.FontFamily,
         fontSize: StyleConstants.FontSizes.MEDIUM,
-        marginTop: 10,
+        top: 10,
         position: 'absolute',
         zIndex: 10
-      },
-      icon: {
-        paddingRight: StyleConstants.Spacing.SMALL
-      },
-      item: {
+      }, this.props.menuStyles),
+
+      item: Object.assign({}, {
+        display: 'flex',
+        alignItems: 'center',
         boxSizing: 'border-box',
         height: 40,
         padding: '14px 20px',
-        textAlign: 'left',
 
         ':hover': {
-          backgroundColor: StyleConstants.Colors.FOG,
-          cursor: 'pointer'
+          backgroundColor: this.props.hoverColor,
+          color: StyleConstants.Colors.WHITE,
+          cursor: 'pointer',
+          fill: StyleConstants.Colors.WHITE
         }
+      }, this.props.itemStyles),
+      icon: Object.assign({}, {
+        marginRight: StyleConstants.Spacing.SMALL
+      }, this.props.iconStyles),
+      text: {
+        whiteSpace: 'nowrap'
       },
-
       scrim: {
         bottom: 0,
         left: 0,
@@ -95,7 +119,7 @@ const SimpleSelect = React.createClass({
         top: 0,
         zIndex: 9
       }
-    };
+    }, this.props.styles);
   }
 });
 

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -96,7 +96,7 @@ const SimpleSelect = React.createClass({
         alignItems: 'center',
         boxSizing: 'border-box',
         height: 40,
-        padding: '14px 20px',
+        padding: StyleConstants.Spacing.MEDIUM,
 
         ':hover': {
           backgroundColor: this.props.hoverColor,


### PR DESCRIPTION
This updates the SimpleSelect to use a styles object along with other cleanup.

- Update docs to show icon use
- Remove style, iconStyle and menuStyle from docs
- Remove `showItems` prop from docs since it isn't supported
- Add hoverColor prop and set default to PRIMARY 
- Add styles prop
- Add console warning to deprecate style, iconStyle and menuStyle
- Move style Object.assigns to styles method
- Add `_merge` to combine prop and component styles
- Change color and fill to be CHARCOAL
- Set color and fill to white on hover

I tested this in Robinhood and Raja. The SimpleSelect is used in the Transactions Details view. I did need to make some minor changes, like set the hoverColor to brandColor and remove a paddingBottom on the menu.

Docs:
![screen shot 2016-11-09 at 1 45 52 pm](https://cloud.githubusercontent.com/assets/488916/20154063/f0e838f0-a682-11e6-8183-d450ec1dc165.png)

Robinhood:
![screen shot 2016-11-09 at 1 14 30 pm](https://cloud.githubusercontent.com/assets/488916/20154068/f7319c4c-a682-11e6-8316-2b4ced392258.png)

Raja
![screen shot 2016-11-09 at 1 21 47 pm](https://cloud.githubusercontent.com/assets/488916/20154082/03bdc648-a683-11e6-8db0-de039eda1c8f.png)
![screen shot 2016-11-09 at 1 21 52 pm](https://cloud.githubusercontent.com/assets/488916/20154081/03bc8b7a-a683-11e6-800c-e505bb0f452f.png)


