### PR TITLE
Let the browser know that Button should act like a button

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -44,7 +44,11 @@ const Button = React.createClass({
     const styles = this.styles();
 
     return (
-      <div onClick={this.props.type === 'disabled' ? null : this.props.onClick} style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}>
+      <div
+        onClick={this.props.type === 'disabled' ? null : this.props.onClick}
+        role='button'
+        style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}
+      >
         <div style={styles.children}>
           {(this.props.icon && !this.props.isActive) ? <Icon size={20} style={styles.icon} type={this.props.icon} /> : null}
           {this.props.isActive ? (


### PR DESCRIPTION
This change lets the browser and other accessibility tools (e.g. Vimium) know that the `Button` component is clickable.

Related to #30 