### PR TITLE
Handles IE drag cursor issues

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -9,7 +9,7 @@ const Changelog = React.createClass({
         <h3>Release Candidate 5.0.0-rc.30</h3>
         <ul>
           <li>
-            Update SimpleSlider Component.(<a href='https://github.com/mxenabled/mx-react-components/pull/476'>#475</a>)
+            Update SimpleSlider Component.(<a href='https://github.com/mxenabled/mx-react-components/pull/476'>#476</a>)
           </li>
         </ul>
 

--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -6,6 +6,13 @@ const Changelog = React.createClass({
       <div>
         <h1>Change Log</h1>
 
+        <h3>Release Candidate 5.0.0-rc.30</h3>
+        <ul>
+          <li>
+            Update SimpleSlider Component.(<a href='https://github.com/mxenabled/mx-react-components/pull/476'>#475</a>)
+          </li>
+        </ul>
+
         <h3>Release Candidate 5.0.0-rc.29</h3>
         <ul>
           <li>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "http://moneydesktop.github.io/mx-react-components/",
   "dependencies": {
+    "bowser": "^1.5.0",
     "d3": "^3.5.6",
     "lodash": "^4.6.1",
     "moment": "^2.10.3",

--- a/src/components/SimpleSlider.js
+++ b/src/components/SimpleSlider.js
@@ -2,6 +2,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const Radium = require('radium');
 const _merge = require('lodash/merge');
+const browser = require('bowser');
 
 const StyleConstants = require('../constants/Style');
 
@@ -114,11 +115,18 @@ const SimpleSlider = React.createClass({
   styles () {
     let cursorStyle = 'grab';
 
+    if (browser.msie) {
+      cursorStyle = 'pointer';
+    }
+
     if (this.props.disabled) {
       cursorStyle = 'not-allowed';
     }
     if (this.state.dragging) {
       cursorStyle = 'grabbing';
+      if (browser.msie) {
+        cursorStyle = 'pointer';
+      }
     }
 
     return _merge({}, {
@@ -135,7 +143,7 @@ const SimpleSlider = React.createClass({
       },
       trackHolder: {
         padding: `${StyleConstants.Spacing.MEDIUM}px 0`,
-        cursor: cursorStyle
+        cursor: this.props.disabled ? 'not-allowed' : 'pointer'
       },
       toggle: {
         width: StyleConstants.Spacing.LARGE,

--- a/src/components/SimpleSlider.js
+++ b/src/components/SimpleSlider.js
@@ -46,6 +46,16 @@ const SimpleSlider = React.createClass({
     }
   },
 
+  _getCursorStyle () {
+    if (this.props.disabled) {
+      return 'not-allowed';
+    } else if (browser.msie) {
+      return 'pointer';
+    } else {
+      return this.state.dragging ? 'grabbing' : 'grab';
+    }
+  },
+
   _handleMouseEvents (e) {
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const leftSpace = ReactDOM.findDOMNode(this.rangeSelectorRef).getBoundingClientRect().left;
@@ -113,21 +123,7 @@ const SimpleSlider = React.createClass({
   },
 
   styles () {
-    let cursorStyle = 'grab';
-
-    if (browser.msie) {
-      cursorStyle = 'pointer';
-    }
-
-    if (this.props.disabled) {
-      cursorStyle = 'not-allowed';
-    }
-    if (this.state.dragging) {
-      cursorStyle = 'grabbing';
-      if (browser.msie) {
-        cursorStyle = 'pointer';
-      }
-    }
+    const cursorStyle = this._getCursorStyle();
 
     return _merge({}, {
       component: {


### PR DESCRIPTION
IE does not support `drag` or `dragging` cursor icons, so I added a check to see if the browser is IE.

Gif:
![ezgif com-video-to-gif 9](https://cloud.githubusercontent.com/assets/6424668/20681538/42e30404-b561-11e6-8e19-47546c9850e8.gif)
