### PR TITLE
D3 CircleGroup: Add ability to have an overlay for circles

### DIFF
--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -48,7 +48,7 @@ const CirclesGroup = React.createClass({
   },
 
   render () {
-    const { adjustedHeight, circleRadius, data, shouldAnimate, translation, xScaleValueFunction, yScaleValueFunction } = this.props;
+    const { adjustedHeight, circleOverlayRadius, circleRadius, data, shouldAnimate, translation, useCircleOverlay, xScaleValueFunction, yScaleValueFunction } = this.props;
     const preventCircleOverlapCutOff = 45;
 
     return (
@@ -63,19 +63,35 @@ const CirclesGroup = React.createClass({
             const cy = shouldAnimate ? adjustedHeight : yScaleValueFunction(item.y);
 
             return (
-              <circle
-                className='circle'
-                cx={cx}
-                cy={cy}
-                fill={StyleConstants.Colors.WHITE}
-                key={index}
-                onClick={() => {
-                  this.props.onCircleClick(item);
-                }}
-                r={circleRadius}
-                stroke={this.props.circleColor}
-                style={{ 'stroke-width': this.props.strokeWidth }}
-              />
+              <g key={index}>
+                <circle
+                  className='circle'
+                  cx={cx}
+                  cy={cy}
+                  fill={StyleConstants.Colors.WHITE}
+                  onClick={() => {
+                    if (!useCircleOverlay) {
+                      this.props.onCircleClick(item);
+                    }
+                  }}
+                  r={circleRadius}
+                  stroke={this.props.circleColor}
+                  style={{ 'strokeWidth': this.props.strokeWidth }}
+                />
+                {useCircleOverlay && (
+                  <circle
+                    className='circle-overlay'
+                    cx={cx}
+                    cy={yScaleValueFunction(item.y)}
+                    fill={StyleConstants.Colors.WHITE}
+                    onClick={() => {
+                      this.props.onCircleClick(item);
+                    }}
+                    r={circleOverlayRadius}
+                    style={{ 'fillOpacity': 0 }}
+                  />
+                )}
+              </g>
             );
           })
         ) : null}

--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -6,6 +6,7 @@ const CirclesGroup = React.createClass({
   propTypes: {
     adjustedHeight: React.PropTypes.number.isRequired,
     circleColor: React.PropTypes.string,
+    circleOverlayRadius: React.PropTypes.number,
     circleRadius: React.PropTypes.number,
     data: React.PropTypes.array.isRequired,
     onCircleClick: React.PropTypes.func,
@@ -19,6 +20,7 @@ const CirclesGroup = React.createClass({
   getDefaultProps () {
     return {
       circleColor: StyleConstants.Colors.CHARCOAL,
+      circleOverlayRadius: 6,
       circleRadius: 3,
       onCircleClick: () => {},
       shouldAnimate: true,

--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -13,6 +13,7 @@ const CirclesGroup = React.createClass({
     shouldAnimate: React.PropTypes.bool,
     strokeWidth: React.PropTypes.number,
     translation: React.PropTypes.string,
+    useCircleOverlay: React.PropTypes.bool,
     xScaleValueFunction: React.PropTypes.func.isRequired,
     yScaleValueFunction: React.PropTypes.func.isRequired
   },
@@ -25,7 +26,8 @@ const CirclesGroup = React.createClass({
       onCircleClick: () => {},
       shouldAnimate: true,
       strokeWidth: 2,
-      translation: 'translate(0,0)'
+      translation: 'translate(0,0)',
+      useCircleOverlay: false
     };
   },
 


### PR DESCRIPTION
I have a need internally to be able to render a 0 opacity circle overlay with a larger radius over the visible circles to make clicking simpler in both desktop and mobile.  This PR does this by..

- Adding a new `useCircleOverlay` prop that defaults to false.
- Adding a new `circleOverlayRadius` prop that defaults to 6.
- If `useCircleOverlay` is true then we add a second circle with an opacity of 0 that has a radius equal to the `circleOverlayRadius` prop.
- Adds the onClick handler to the overlay and removes it from visible circle.
- Also fixed a console error around incorrect style property for `strokeWidth`

### Screen shot of the invisible overlay 

<img width="771" alt="screen shot 2016-12-01 at 9 40 34 am" src="https://cloud.githubusercontent.com/assets/6463914/20803156/7b3bb778-b7ab-11e6-80cf-8a291a4dfdb3.png">
