### PR TITLE
Chart utils getDataMinMaxValues function fix

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -51,5 +51,8 @@ module.exports = {
 
   // App constants
   AppConstants: require('./constants/App'),
-  Styles: require('./constants/Style')
+  Styles: require('./constants/Style'),
+
+  // App Utils
+  ChartUtils: require('./utils/Chart')
 };

--- a/src/utils/Chart.js
+++ b/src/utils/Chart.js
@@ -10,15 +10,8 @@ const Chart = {
       return d[axis];
     });
 
-    //remove negative character if it exists
-    let maxString = Math.ceil(max).toString();
-    let minString = Math.floor(min).toString();
-
-    maxString = maxString.replace('-', '');
-    minString = minString.replace('-', '');
-
-    const maxDigits = maxString.length - 1;
-    const minDigits = minString.length - 1;
+    const maxDigits = Math.ceil(Math.abs(max)).toString().length - 1;
+    const minDigits = Math.floor(Math.abs(min)).toString().length - 1;
 
     const maxMultiplier = Math.pow(10, maxDigits) < 100 ? 100 : Math.pow(10, maxDigits);
     const minMultiplier = Math.pow(10, minDigits) < 100 ? 100 : Math.pow(10, maxDigits);

--- a/src/utils/Chart.js
+++ b/src/utils/Chart.js
@@ -10,8 +10,16 @@ const Chart = {
       return d[axis];
     });
 
-    const maxDigits = Math.ceil(max).toString().length - 1;
-    const minDigits = Math.floor(min).toString().length - 1;
+    //remove negative character if it exists
+    let maxString = Math.ceil(max).toString();
+    let minString = Math.floor(min).toString();
+
+    maxString = maxString.replace('-', '');
+    minString = minString.replace('-', '');
+
+    const maxDigits = maxString.length - 1;
+    const minDigits = minString.length - 1;
+
     const maxMultiplier = Math.pow(10, maxDigits) < 100 ? 100 : Math.pow(10, maxDigits);
     const minMultiplier = Math.pow(10, minDigits) < 100 ? 100 : Math.pow(10, maxDigits);
 


### PR DESCRIPTION
The axis domain for charts that use the AxisGroup d3 component was off by a power of 1.  This was due to the fact that if the min or max value was a negative number then the negative character was included in the length check done after converting the number to a string.

![giphy 26](https://cloud.githubusercontent.com/assets/6463914/20992619/7c7b1d9e-bca2-11e6-9d72-f820f6cb8140.gif)

I also have added the ChartUtils to the module.exports so that I can use them internally rather than duplicating the min max value code.
