### PR TITLE
Chart utils tweaks

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -272,9 +272,17 @@ const TimeBasedLineChart = React.createClass({
   },
 
   _yRangeContainsZero () {
-    const minMaxValues = ChartUtils.getDataMinMaxValues(this.props.data, 'y');
+    const max = d3.max(this.props.data, d => {
+      return d.y;
+    });
 
-    return minMaxValues.min <= 0 && minMaxValues.max >= 0;
+    const min = d3.min(this.props.data, d => {
+      return d.y;
+    });
+
+    const tickSpec = ChartUtils.getAxisTickSpecification(min, max);
+
+    return tickSpec.min <= 0 && tickSpec.max >= 0;
   },
 
   // Handle functions
@@ -365,11 +373,19 @@ const TimeBasedLineChart = React.createClass({
   },
 
   _getYScaleFunction () {
-    const minMaxValues = ChartUtils.getDataMinMaxValues(this.props.data, 'y');
+    const max = d3.max(this.props.data, d => {
+      return d.y;
+    });
+
+    const min = d3.min(this.props.data, d => {
+      return d.y;
+    });
+
+    const tickSpec = ChartUtils.getAxisTickSpecification(min, max);
 
     return d3.scale.linear()
       .range([this.state.adjustedHeight, 0])
-      .domain([minMaxValues.min, minMaxValues.max]);
+      .domain([tickSpec.min, tickSpec.max]);
   },
 
   _getYScaleValue (value) {

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -272,14 +272,8 @@ const TimeBasedLineChart = React.createClass({
   },
 
   _yRangeContainsZero () {
-    const max = d3.max(this.props.data, d => {
-      return d.y;
-    });
-
-    const min = d3.min(this.props.data, d => {
-      return d.y;
-    });
-
+    const max = d3.max(this.props.data, d => d.y);
+    const min = d3.min(this.props.data, d => d.y);
     const tickSpec = ChartUtils.getAxisTickSpecification(min, max);
 
     return tickSpec.min <= 0 && tickSpec.max >= 0;
@@ -373,14 +367,8 @@ const TimeBasedLineChart = React.createClass({
   },
 
   _getYScaleFunction () {
-    const max = d3.max(this.props.data, d => {
-      return d.y;
-    });
-
-    const min = d3.min(this.props.data, d => {
-      return d.y;
-    });
-
+    const max = d3.max(this.props.data, d => d.y);
+    const min = d3.min(this.props.data, d => d.y);
     const tickSpec = ChartUtils.getAxisTickSpecification(min, max);
 
     return d3.scale.linear()

--- a/src/components/d3/AxisGroup.js
+++ b/src/components/d3/AxisGroup.js
@@ -28,7 +28,16 @@ const AxisGroup = React.createClass({
   },
 
   _renderAxis () {
-    const tickValues = ChartUtils.getAxisTickValues(this.props.data, this .props.axis);
+    const max = d3.max(this.props.data, d => {
+      return d[this.props.axis];
+    });
+
+    const min = d3.min(this.props.data, d => {
+      return d[this.props.axis];
+    });
+
+    const { tickValues } = ChartUtils.getAxisTickSpecification(min, max);
+
     const axisFunction = d3.svg.axis()
       .scale(this.props.scaleFunction())
       .orient(this.props.orientation)

--- a/src/components/d3/AxisGroup.js
+++ b/src/components/d3/AxisGroup.js
@@ -28,14 +28,8 @@ const AxisGroup = React.createClass({
   },
 
   _renderAxis () {
-    const max = d3.max(this.props.data, d => {
-      return d[this.props.axis];
-    });
-
-    const min = d3.min(this.props.data, d => {
-      return d[this.props.axis];
-    });
-
+    const max = d3.max(this.props.data, d => d[this.props.axis]);
+    const min = d3.min(this.props.data, d => d[this.props.axis]);
     const { tickValues } = ChartUtils.getAxisTickSpecification(min, max);
 
     const axisFunction = d3.svg.axis()

--- a/src/components/d3/GridLinesGroup.js
+++ b/src/components/d3/GridLinesGroup.js
@@ -30,7 +30,15 @@ const GridLinesGroup = React.createClass({
   },
 
   _renderGridLines () {
-    const tickValues = ChartUtils.getAxisTickValues(this.props.data, this.props.axis);
+    const max = d3.max(this.props.data, d => {
+      return d[this.props.axis];
+    });
+
+    const min = d3.min(this.props.data, d => {
+      return d[this.props.axis];
+    });
+
+    const { tickValues } = ChartUtils.getAxisTickSpecification(min, max);
 
     const gridLinesFunction = d3.svg.axis()
       .scale(this.props.scaleFunction())

--- a/src/components/d3/GridLinesGroup.js
+++ b/src/components/d3/GridLinesGroup.js
@@ -30,14 +30,8 @@ const GridLinesGroup = React.createClass({
   },
 
   _renderGridLines () {
-    const max = d3.max(this.props.data, d => {
-      return d[this.props.axis];
-    });
-
-    const min = d3.min(this.props.data, d => {
-      return d[this.props.axis];
-    });
-
+    const max = d3.max(this.props.data, d => d[this.props.axis]);
+    const min = d3.min(this.props.data, d => d[this.props.axis]);
     const { tickValues } = ChartUtils.getAxisTickSpecification(min, max);
 
     const gridLinesFunction = d3.svg.axis()


### PR DESCRIPTION
We were running into issues where the internal widgets axis ranges/ticks were not matching the mobile applications ranges/ticks.  To solve the problem, I've ported the mobile c++ code over and revamped the Chart Utils file.  Eventually I'll port more of the mobile teams code but for now this allows our line charts to be in parity with theirs.

This only has an effect on the TimeBasedLineChart in the open source but will also effect the internal NetWorth chart.  I'll have screen shots in the internal PR showing how the graphs now look but the gist is that the y range and tick values are dialed in closer so that the line changes between points more dramatically.

@jmophoto Once this goes live you can start using it in Insight/Target as well.