### PR TITLE
Button Component: New primaryInverse type

### DIFF
--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -87,7 +87,7 @@ const ButtonDocs = React.createClass({
 
         <h5>type <label>String</label></h5>
         <p>Default: 'primary'</p>
-        <p>This sets the button type. Available options are 'primary', 'primaryOutline', 'secondary', 'base', 'neutral', and 'disabled'. Setting the type to `disabled` also prevents onClick events from firing.</p>
+        <p>This sets the button type. Available options are 'primary', 'primaryOutline', 'primaryInverse', 'secondary', 'base', 'neutral', and 'disabled'. Setting the type to `disabled` also prevents onClick events from firing.</p>
 
         <h3>Example</h3>
         <Markdown>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -42,6 +42,17 @@ const ButtonDocs = React.createClass({
           <Button style={style} type='neutral'>Neutral</Button>
           <Button style={style} type='disabled'>Disabled</Button>
         </div>
+        <div
+          className='flex'
+          style={{
+            backgroundColor: Styles.Colors.PRIMARY,
+            padding: Styles.Spacing.LARGE,
+            marginTop: Styles.Spacing.LARGE,
+            width: 150
+          }}
+        >
+          <Button style={style} type='primaryInverse'>Primary Inverse</Button>
+        </div>
         <br /><br />
         <div className='flex'>
           <Button icon='add'>Icon</Button>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -30,7 +30,7 @@ const ButtonDocs = React.createClass({
       <div>
         <h1>
           Button
-          <label>A standard button with 6 available styles.</label>
+          <label>A standard button with 7 available styles.</label>
         </h1>
 
         <h3>Demo</h3>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -1,6 +1,6 @@
 const React = require('react');
 
-const { Button } = require('mx-react-components');
+const { Button, Styles } = require('mx-react-components');
 
 const Markdown = require('components/Markdown');
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -21,6 +21,7 @@ const Button = React.createClass({
       'neutral',
       'primary',
       'primaryOutline',
+      'primaryInverse',
       'secondary'
     ])
   },

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -127,6 +127,24 @@ const Button = React.createClass({
           transition: 'all .2s ease-in'
         }
       },
+      primaryInverse: {
+        backgroundColor: StyleConstants.Colors.WHITE,
+        borderColor: StyleConstants.Colors.WHITE,
+        color: this.props.primaryColor,
+        fill: this.props.primaryColor,
+        transition: 'all .2s ease-in',
+
+        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+          backgroundColor: StyleConstants.adjustColor(StyleConstants.Colors.WHITE, -15),
+          borderColor: StyleConstants.adjustColor(StyleConstants.Colors.WHITE, -15),
+          transition: 'all .2s ease-in'
+        },
+        ':active': {
+          backgroundColor: StyleConstants.adjustColor(StyleConstants.Colors.WHITE, -30),
+          borderColor: StyleConstants.adjustColor(StyleConstants.Colors.WHITE, -30),
+          transition: 'all .2s ease-in'
+        }
+      },
       secondary: {
         backgroundColor: 'transparent',
         borderColor: StyleConstants.Colors.ASH,


### PR DESCRIPTION
This PR adds a new button type to the button component.  `primaryInverse`.  It's purpose is to allow for situations where the background color of the parent element is already a primary color.  The primaryOutline partially solved this type of problem but not to the extent that is needed in some cases. The main differences being, the outline, and the hover/active color.  primaryInverse remains in the white scale while the primaryOutline hover is the primary color.

<img width="979" alt="screen shot 2016-12-15 at 10 37 51 am" src="https://cloud.githubusercontent.com/assets/6463914/21235429/eedbd2ae-c2b3-11e6-89d5-abe26b8920a8.png">
