### PR TITLE
Disabled support for ButtonGroups

### DIFF
--- a/docs/components/ButtonGroupDocs.js
+++ b/docs/components/ButtonGroupDocs.js
@@ -25,6 +25,18 @@ const ButtonGroupDocs = React.createClass({
           />
         </div>
         <br /><br />
+        <div className='flex'>
+          <ButtonGroup
+            buttons={[
+              { text: 'Item 1' },
+              { text: 'Item 2, disabled', type: 'disabled' },
+              { text: 'Item 3' },
+              { text: 'Item 4' }
+            ]}
+            type='primaryOutline'
+          />
+        </div>
+        <br /><br />
         <div>
           <ButtonGroup
             buttons={[
@@ -39,7 +51,8 @@ const ButtonGroupDocs = React.createClass({
         <h3>Usage</h3>
         <h5>buttons <label>Array of Objects</label></h5>
         <p>Default: An empty array</p>
-        <p>An array of objects that will populate the button values. Works with as little as one object. Objects take an <label>icon</label>, <label>text</label>, or both.</p>
+        <p>An array of objects that will populate the button values. Works with as little as one object. Objects take an <label>icon</label>, <label>text</label>, and <label>style</label>.</p>
+        <p>A button can be disabled by adding <label>type = 'disabled'</label> but no other button types are supported within the button group.</p>
 
         <h5>icon <label>String</label></h5>
         <p>The name of the <a href='/components/icon'>icon</a></p>
@@ -61,7 +74,7 @@ const ButtonGroupDocs = React.createClass({
     <ButtonGroup
       buttons={[
          { icon: 'download' },
-         { icon: 'search' },
+         { icon: 'search', type: 'disabled' },
          { icon: 'add' }
       ]}
       type='base' />

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -7,6 +7,8 @@ const StyleConstants = require('../constants/Style');
 
 const Icon = require('../components/Icon');
 
+const { buttonTypes } = require('../constants/App');
+
 const Button = React.createClass({
   propTypes: {
     actionText: React.PropTypes.string,
@@ -15,15 +17,7 @@ const Button = React.createClass({
     onClick: React.PropTypes.func,
     primaryColor: React.PropTypes.string,
     style: React.PropTypes.object,
-    type: React.PropTypes.oneOf([
-      'base',
-      'disabled',
-      'neutral',
-      'primary',
-      'primaryOutline',
-      'primaryInverse',
-      'secondary'
-    ])
+    type: React.PropTypes.oneOf(buttonTypes)
   },
 
   getDefaultProps () {

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -5,22 +5,19 @@ const Button = require('./Button');
 
 const StyleConstants = require('../constants/Style');
 
+const { buttonTypes } = require('../constants/App');
+
 const ButtonGroup = React.createClass({
   propTypes: {
     buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
       icon: React.PropTypes.string,
       onClick: React.PropTypes.func,
       style: React.PropTypes.object,
-      text: React.PropTypes.string
+      text: React.PropTypes.string,
+      type: React.PropTypes.oneOf(buttonTypes)
     }).isRequired),
     primaryColor: React.PropTypes.string,
-    type: React.PropTypes.oneOf([
-      'base',
-      'disabled',
-      'neutral',
-      'primary',
-      'primaryOutline'
-    ])
+    type: React.PropTypes.oneOf(buttonTypes)
   },
 
   getDefaultProps () {
@@ -40,6 +37,7 @@ const ButtonGroup = React.createClass({
           const isFirstChild = i === 0;
           const isLastChild = i === this.props.buttons.length - 1;
           const isOnlyChild = isFirstChild && isLastChild;
+          const isDisabled = button.type === 'disabled';
 
           return (
             <Button
@@ -49,10 +47,10 @@ const ButtonGroup = React.createClass({
               primaryColor={this.props.primaryColor}
               style={Object.assign({},
                 styles.component,
-                styles[this.props.type],
                 isFirstChild && styles.firstChild,
                 isLastChild && styles.lastChild,
                 isOnlyChild && styles.onlyChild,
+                isDisabled && styles.disabled,
                 button.style)}
               type={this.props.type}
             >
@@ -70,7 +68,7 @@ const ButtonGroup = React.createClass({
         boxSizing: 'border-box',
         borderRadius: 0,
         borderWidth: 1,
-        borderRightWidth: 0,
+        borderRightWidth: this.props.type === 'base' ? 1 : 0,
         verticalAlign: 'middle'
       }, this.props.style),
       firstChild: {
@@ -84,11 +82,16 @@ const ButtonGroup = React.createClass({
         borderRadius: 2,
         borderWidth: 1
       },
-      base: {
-        borderRight: '1px solid transparent',
+      disabled: {
+        backgroundColor: 'transparent',
+        color: StyleConstants.Colors.FOG,
+        cursor: 'default',
+        fill: StyleConstants.Colors.FOG,
         ':hover': {
-          borderRadius: 2,
-          borderRight: '1px solid initial'
+          backgroundColor: 'transparent'
+        },
+        ':active': {
+          backgroundColor: 'transparent'
         }
       }
     };

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -43,7 +43,7 @@ const ButtonGroup = React.createClass({
             <Button
               icon={button.icon}
               key={i}
-              onClick={button.onClick}
+              onClick={!isDisabled && button.onClick}
               primaryColor={this.props.primaryColor}
               style={Object.assign({},
                 styles.component,

--- a/src/constants/App.js
+++ b/src/constants/App.js
@@ -1,4 +1,14 @@
 module.exports = {
+  buttonTypes: [
+    'base',
+    'disabled',
+    'neutral',
+    'primary',
+    'primaryOutline',
+    'primaryInverse',
+    'secondary'
+  ],
+
   Icons: [
     {
       value: 'accounts',


### PR DESCRIPTION
This PR adds support to disable a button individually inside a button group. This grays out the text, removes all hover styles, and disables `onClick` events, but does not change the disabled button's border styles.

This also moves buttonTypes into a constants/App.js.

@jtanner 

## Example
![bhwjarqzi2](https://cloud.githubusercontent.com/assets/1916697/22075900/128b4f46-dd6b-11e6-9033-d0574c98e8b5.gif)
