### PR TITLE
adding check for navConfig in order for drawer to render

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -163,7 +163,7 @@ const Drawer = React.createClass({
                 {this.props.title}
               </span>
               <div style={styles.headerMenu}>
-                {this.props.headerMenu ? this.props.headerMenu : this._renderNav()}
+                {this.props.headerMenu ? this.props.headerMenu : this.props.navConfig && this._renderNav()}
               </div>
             </header>
             <div style={Object.assign({}, styles.content, this.props.contentStyle)}>


### PR DESCRIPTION
The last drawer release removed a check for `navConfig` before rendering the nav. This was breaking previous implementations that had neither a headerMenu prop or a navConfig. 

This adds the check back in.