### PR TITLE
Add linear-gradient constant

### DIFF
--- a/docs/components/StylesDocs.js
+++ b/docs/components/StylesDocs.js
@@ -170,6 +170,25 @@ const StylesDocs = React.createClass({
           `}
         </Markdown>
 
+        <h5>Linear Gradient</h5>
+        <p>Takes a HEX color and optional opacity amount and returns a linear gradient string. Opacity defaults to 0.8</p>
+        <div style={{ background: Styles.linearGradient(Styles.Colors.PRIMARY), height: 100, width: '100%' }}></div>
+
+        <Markdown lang='js'>
+          {`
+            background: Styles.linearGradient(Styles.Colors.PRIMARY);
+          `}
+        </Markdown>
+
+        <div style={{ background: Styles.linearGradient(Styles.Colors.ORANGE, 0.2), height: 100, width: '100%' }}></div>
+
+        <Markdown lang='js'>
+          {`
+            background: Styles.linearGradient(Styles.Colors.ORANGE, 0.2);
+          `}
+        </Markdown>
+
+
         <h5>Get Window Size</h5>
         <p>Returns the <code style={{ display: 'inline', padding: 3 }}>Styles.BreakPoints</code> key for the current window width.</p>
         <Markdown lang='js'>

--- a/docs/components/StylesDocs.js
+++ b/docs/components/StylesDocs.js
@@ -180,6 +180,14 @@ const StylesDocs = React.createClass({
           `}
         </Markdown>
 
+        <div style={{ background: Styles.linearGradient(Styles.Colors.PRIMARY, 0.2), height: 100, width: '100%' }}></div>
+
+        <Markdown lang='js'>
+          {`
+            background: Styles.linearGradient(Styles.Colors.PRIMARY, 0.2);
+          `}
+        </Markdown>
+
         <div style={{ background: Styles.linearGradient(Styles.Colors.ORANGE, 1, Styles.Colors.LEMON, 1), height: 100, width: '100%' }}></div>
 
         <Markdown lang='js'>

--- a/docs/components/StylesDocs.js
+++ b/docs/components/StylesDocs.js
@@ -171,7 +171,7 @@ const StylesDocs = React.createClass({
         </Markdown>
 
         <h5>Linear Gradient</h5>
-        <p>Takes a HEX color and optional opacity amount and returns a linear gradient string. Opacity defaults to 0.8</p>
+        <p>Takes two HEX colors and optional opacity amounts and returns a linear gradient string. The first color is requried, the other color and opacities are optional. If only the first color is provided, the gradient will be a single color from 0.8 to 1.</p>
         <div style={{ background: Styles.linearGradient(Styles.Colors.PRIMARY), height: 100, width: '100%' }}></div>
 
         <Markdown lang='js'>
@@ -180,11 +180,11 @@ const StylesDocs = React.createClass({
           `}
         </Markdown>
 
-        <div style={{ background: Styles.linearGradient(Styles.Colors.ORANGE, 0.2), height: 100, width: '100%' }}></div>
+        <div style={{ background: Styles.linearGradient(Styles.Colors.ORANGE, 1, Styles.Colors.LEMON, 1), height: 100, width: '100%' }}></div>
 
         <Markdown lang='js'>
           {`
-            background: Styles.linearGradient(Styles.Colors.ORANGE, 0.2);
+            background: Styles.linearGradient(Styles.Colors.ORANGE, 1, Styles.Colors.LEMON, 1);
           `}
         </Markdown>
 

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -141,8 +141,8 @@ module.exports = {
     return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + opacity + ')';
   },
 
-  linearGradient (color, opacity = 0.8) {
-    return `linear-gradient(${this.adjustHexOpacity(color, opacity)}, ${color})`;
+  linearGradient (startColor, startOpacity = 0.8, endColor = startColor, endOpacity = 1) {
+    return `linear-gradient(${this.adjustHexOpacity(startColor, startOpacity)}, ${this.adjustHexOpacity(endColor, endOpacity)})`;
   },
 
   getWindowSize () {

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -141,6 +141,10 @@ module.exports = {
     return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + opacity + ')';
   },
 
+  linearGradient (color, opacity = 0.8) {
+    return `linear-gradient(${this.adjustHexOpacity(color, opacity)}, ${color})`;
+  },
+
   getWindowSize () {
     const breakPoints = this.BreakPoints;
     const width = window.innerWidth;


### PR DESCRIPTION
This adds a `linearGradient` helper to the Style constants. 

**Usage**
```
background: Styles.linearGradient(Styles.Colors.PRIMARY)

background: Styles.linearGradient(Styles.Colors.ORANGE, 1, Styles.Colors.LEMON, 1)
```
![screen shot 2017-01-26 at 11 53 38 am](https://cloud.githubusercontent.com/assets/488916/22345635/1b2e8a88-e3be-11e6-9306-5c5eeec40c35.png)
