### PR TITLE
Adds brandcolor to hover state

### DIFF
--- a/docs/components/SelectDocs.js
+++ b/docs/components/SelectDocs.js
@@ -65,11 +65,11 @@ const SelectDocs = React.createClass({
         />
 
         <h3>Usage</h3>
-        <h5>color <label>String</label></h5>
-        <p>Color that changes hover state color on menu options.</p>
-
         <h5>dropdownStyle <label>Object | Array</label></h5>
         <p>A style object or Radium array that modifies the css styles of the 'div' element that wraps the selected option and options menu elements.</p>
+
+        <h5>hoverColor <label>String</label></h5>
+        <p>This will be the background color for the menu options.</p>
 
         <h5>onChange <label>Function</label></h5>
         <p>A function that is called when a new value has been selected.</p>

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -9,6 +9,7 @@ const StyleConstants = require('../constants/Style');
 
 const Select = React.createClass({
   propTypes: {
+    brandColor: React.PropTypes.string,
     color: React.PropTypes.string,
     dropdownStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     onChange: React.PropTypes.func,
@@ -25,6 +26,7 @@ const Select = React.createClass({
 
   getDefaultProps () {
     return {
+      brandColor: StyleConstants.Colors.PRIMARY,
       color: StyleConstants.Colors.PRIMARY,
       onChange () {},
       options: [],
@@ -45,7 +47,7 @@ const Select = React.createClass({
   getBackgroundColor (option) {
     if (option.value === this.state.hoverItem) {
       return {
-        backgroundColor: StyleConstants.Colors.PRIMARY,
+        backgroundColor: this.props.brandColor,
         color: StyleConstants.Colors.WHITE,
         fill: StyleConstants.Colors.WHITE
       };

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -9,9 +9,8 @@ const StyleConstants = require('../constants/Style');
 
 const Select = React.createClass({
   propTypes: {
-    brandColor: React.PropTypes.string,
-    color: React.PropTypes.string,
     dropdownStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
+    hoverColor: React.PropTypes.string,
     onChange: React.PropTypes.func,
     options: React.PropTypes.array,
     optionsStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
@@ -26,8 +25,7 @@ const Select = React.createClass({
 
   getDefaultProps () {
     return {
-      brandColor: StyleConstants.Colors.PRIMARY,
-      color: StyleConstants.Colors.PRIMARY,
+      hoverColor: StyleConstants.Colors.PRIMARY,
       onChange () {},
       options: [],
       placeholderText: 'Select One',
@@ -47,7 +45,7 @@ const Select = React.createClass({
   getBackgroundColor (option) {
     if (option.value === this.state.hoverItem) {
       return {
-        backgroundColor: this.props.brandColor,
+        backgroundColor: this.props.hoverColor,
         color: StyleConstants.Colors.WHITE,
         fill: StyleConstants.Colors.WHITE
       };


### PR DESCRIPTION
This PR allows the user to set the hoverstate color on the select component.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/6424668/22392756/0fd1ecfa-e4ba-11e6-8292-5bd60d9ba1f6.png)
