### PR TITLE
Fixing Responsive Date Range Picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/Index.js",
   "scripts": {
     "release": "eslint src && babel src --out-dir dist",
-    "dev": "cd docs && yarn && open 'http://localhost:8080' && NODE_ENV=development webpack-dev-server --inline --hot",
+    "dev": "cd docs && yarn && open 'http://localhost:8080' && NODE_ENV=development webpack-dev-server --inline --hot --host 0.0.0.0",
     "docs:release": "cd docs && rm -rf node_modules && yarn && NODE_ENV=production webpack --progress && git add -A && git commit -m \"Docs Version: $(node -p 'require(\"../package.json\").version')\"",
     "test": "eslint src"
   },

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -447,14 +447,15 @@ const DateRangePicker = React.createClass({
         marginTop: isLargeOrMediumWindowSize ? 10 : 5,
         position: 'absolute',
         left: this.props.isRelative ? 'auto' : 0,
-        right: isLargeOrMediumWindowSize ? 0 : 'auto',
+        right: 0,
         zIndex: 10
       },
       calendarWrapper: {
         boxSizing: 'border-box',
         padding: isLargeOrMediumWindowSize ? 20 : 10,
         margin: 'auto',
-        width: 250
+        maxWidth: 250,
+        width: isLargeOrMediumWindowSize ? 250 : '100%'
       },
 
       //Calendar Header
@@ -546,7 +547,8 @@ const DateRangePicker = React.createClass({
         fontSize: StyleConstants.FontSizes.MEDIUM,
         paddingLeft: isLargeOrMediumWindowSize ? 10 : 0,
         paddingTop: 10,
-        width: isLargeOrMediumWindowSize ? 150 : 300
+        maxWidth: 250,
+        width: isLargeOrMediumWindowSize ? 150 : '100%'
       },
       rangeOption: {
         alignItems: 'center',

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -454,7 +454,7 @@ const DateRangePicker = React.createClass({
         boxSizing: 'border-box',
         padding: isLargeOrMediumWindowSize ? 20 : 10,
         margin: 'auto',
-        width: isLargeOrMediumWindowSize ? 250 : '100%'
+        width: 250
       },
 
       //Calendar Header
@@ -546,7 +546,7 @@ const DateRangePicker = React.createClass({
         fontSize: StyleConstants.FontSizes.MEDIUM,
         paddingLeft: isLargeOrMediumWindowSize ? 10 : 0,
         paddingTop: 10,
-        width: isLargeOrMediumWindowSize ? 150 : '100%'
+        width: isLargeOrMediumWindowSize ? 150 : 300
       },
       rangeOption: {
         alignItems: 'center',


### PR DESCRIPTION
Issue:

The date picker will expand to 100% of container on smaller screen sizes / devices, causing the flex wrap of the days and weeks to come completely out of alignment.
This sets a maxWidth to prevent that from happening while maintaining the full width design on xsmall devices / screens.

Before:
![ezgif com-video-to-gif 23](https://cloud.githubusercontent.com/assets/1081167/22491481/063ed390-e7e1-11e6-867e-2982d6ebb9cb.gif)

After:
![ezgif com-video-to-gif 22](https://cloud.githubusercontent.com/assets/1081167/22491366/2fcd2fc8-e7e0-11e6-82f2-815b062d521d.gif)

iPhone 5:
![screen shot 2017-01-31 at 6 06 34 pm](https://cloud.githubusercontent.com/assets/1081167/22491370/3955e260-e7e0-11e6-8cb5-b54d82c46988.png)
