### PR TITLE
SimpleSelect supports children over the items prop.

### DIFF
--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -57,7 +57,9 @@ const SimpleSelect = React.createClass({
     return (
       <div style={styles.component}>
         <div style={styles.menu}>
-            {this.props.items.map((item, i) => {
+          {this.props.children ?
+            this.props.children :
+            (this.props.items.map((item, i) => {
               return (
                 <div
                   key={i}
@@ -70,7 +72,8 @@ const SimpleSelect = React.createClass({
                   <div style={styles.text}>{item.text}</div>
                 </div>
               );
-            })}
+            })
+          )}
         </div>
         <div onClick={this.props.onScrimClick} style={styles.scrim} />
       </div>


### PR DESCRIPTION
If the SimpleSelect has children, render the children instead of the items from the items prop. This will allow me to have a native onClick function to open a window or even populate it with anchor tags.