### PR TITLE
luke/updated color in Select

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -10,13 +10,13 @@ const StyleConstants = require('../constants/Style');
 const Select = React.createClass({
   propTypes: {
     dropdownStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
-    primaryColor: React.PropTypes.string,
     onChange: React.PropTypes.func,
     options: React.PropTypes.array,
     optionsStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     optionStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     optionTextStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     placeholderText: React.PropTypes.string,
+    primaryColor: React.PropTypes.string,
     scrimStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
     selected: React.PropTypes.object,
     selectedStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -200,7 +200,7 @@ const Select = React.createClass({
                     />
                   ) : null}
                   <div style={styles.optionText}>{option.displayValue}</div>
-                  {_isEqual(option, this.state.highlightedValue) ? <Icon size={15} type='check' /> : null }
+                  {_isEqual(option, this.state.highlightedValue) ? <Icon size={20} type='check' /> : null }
                 </li>
               );
             })}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -200,7 +200,7 @@ const Select = React.createClass({
                     />
                   ) : null}
                   <div style={styles.optionText}>{option.displayValue}</div>
-                  {_isEqual(option, this.state.highlightedValue) ? <Icon size={20} style={styles.check} type='check' /> : null }
+                  {_isEqual(option, this.state.highlightedValue) ? <Icon size={15} type='check' /> : null }
                 </li>
               );
             })}
@@ -277,8 +277,8 @@ const Select = React.createClass({
           position: 'relative'
         }, this.props.selectedStyle),
       activeItem: {
-        fill: StyleConstants.Colors.PRIMARY,
-        color: StyleConstants.Colors.PRIMARY
+        fill: this.props.hoverColor,
+        color: this.props.hoverColor
       },
       invalid: {
         borderColor: StyleConstants.Colors.STRAWBERRY

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -10,7 +10,7 @@ const StyleConstants = require('../constants/Style');
 const Select = React.createClass({
   propTypes: {
     dropdownStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
-    hoverColor: React.PropTypes.string,
+    primaryColor: React.PropTypes.string,
     onChange: React.PropTypes.func,
     options: React.PropTypes.array,
     optionsStyle: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
@@ -25,7 +25,7 @@ const Select = React.createClass({
 
   getDefaultProps () {
     return {
-      hoverColor: StyleConstants.Colors.PRIMARY,
+      primaryColor: StyleConstants.Colors.PRIMARY,
       onChange () {},
       options: [],
       placeholderText: 'Select One',
@@ -45,7 +45,7 @@ const Select = React.createClass({
   getBackgroundColor (option) {
     if (option.value === this.state.hoverItem) {
       return {
-        backgroundColor: this.props.hoverColor,
+        backgroundColor: this.props.primaryColor,
         color: StyleConstants.Colors.WHITE,
         fill: StyleConstants.Colors.WHITE
       };
@@ -277,8 +277,8 @@ const Select = React.createClass({
           position: 'relative'
         }, this.props.selectedStyle),
       activeItem: {
-        fill: this.props.hoverColor,
-        color: this.props.hoverColor
+        fill: this.props.primaryColor,
+        color: this.props.primaryColor
       },
       invalid: {
         borderColor: StyleConstants.Colors.STRAWBERRY


### PR DESCRIPTION
@derek-boman noticed this when working internally. When an option is selected, it had the `PRIMARY` color by default, this makes it the same as what the hover color is.

Issue: 

![screen shot 2017-02-21 at 12 57 31 pm](https://cloud.githubusercontent.com/assets/13579578/23183475/6eb315fe-f839-11e6-98e6-56cb55dd9506.png)
