### PR TITLE
Calendar Fixed Width

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -140,7 +140,7 @@ class Calendar extends React.Component {
         boxSizing: 'border-box',
         marginTop: 10,
         padding: 20,
-        width: 287
+        width: 250
       }, this.props.style),
 
       //Calendar Header


### PR DESCRIPTION
Calendar can't be wider than 279, locking down to 250 for consistency with date range picker. We really need to take a look at cleaning up our multiple datepickers if possible.
### After:
Desktop: 
![screen shot 2017-02-27 at 4 22 06 pm](https://cloud.githubusercontent.com/assets/1081167/23384792/83711354-fd09-11e6-96ff-7f83fac21db8.png)

Mobile:
![screen shot 2017-02-27 at 4 24 28 pm](https://cloud.githubusercontent.com/assets/1081167/23384799/884c5a3c-fd09-11e6-85d7-280d8a397109.png)

### Before:
Desktop:
![screen shot 2017-02-27 at 4 29 05 pm](https://cloud.githubusercontent.com/assets/1081167/23384883/fc55aba4-fd09-11e6-9c32-afbc48f61342.png)

Mobile:
![screen shot 2017-02-27 at 4 28 52 pm](https://cloud.githubusercontent.com/assets/1081167/23384882/f9daf2a8-fd09-11e6-8930-334c7067463e.png)


