### PR TITLE
removes margin on buttons in groups

### DIFF
--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -69,6 +69,7 @@ class ButtonGroup extends React.Component {
         borderRadius: 0,
         borderWidth: 1,
         borderRightWidth: this.props.type === 'base' ? 1 : 0,
+        margin: 0,
         verticalAlign: 'middle'
       }, this.props.style),
       firstChild: {


### PR DESCRIPTION
This fixes a bug where Safari was adding margins to buttons in groups, breaking the borders.

### Before
![screen shot 2017-03-03 at 11 17 41 am](https://cloud.githubusercontent.com/assets/1916697/23563387/b81e475a-0003-11e7-88d7-758951ec3a2d.png)

### After
![screen shot 2017-03-03 at 11 17 54 am](https://cloud.githubusercontent.com/assets/1916697/23563391/bd3ac592-0003-11e7-8f8f-079707bd0b27.png)
