### PR TITLE
removes overflow rule

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -186,7 +186,6 @@ const Drawer = React.createClass({
         left: '100%',
         position: 'absolute',
         width: '80%',
-        overflow: 'hidden',
         backgroundColor: StyleConstants.Colors.PORCELAIN,
         boxShadow: StyleConstants.ShadowHigh,
 


### PR DESCRIPTION
Fixes a Safari bug that was cutting off modals inside of drawers on large displays.

## Before
![screen shot 2017-03-03 at 4 55 14 pm](https://cloud.githubusercontent.com/assets/1916697/23573650/bdba7220-0034-11e7-8db0-a22536578388.png)

## After
![screen shot 2017-03-03 at 4 55 31 pm](https://cloud.githubusercontent.com/assets/1916697/23573651/c1a25ba0-0034-11e7-8fd4-54f99324f6e1.png)
