### PR TITLE
DateRangePicker > Default Range Options style polish

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -6,6 +6,13 @@ const Changelog = React.createClass({
       <div>
         <h1>Change Log</h1>
 
+        <h3>Release Candidate 5.0.0-rc.61</h3>
+        <ul>
+          <li>
+            Style Polish and Fixes for default range options in DateRangePicker (<a href='https://github.com/mxenabled/mx-react-components/pull/526'>#526</a>)
+          </li>
+        </ul>
+
         <h3>Release Candidate 5.0.0-rc.60</h3>
         <ul>
           <li>

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -10,31 +10,29 @@ const Row = require('../components/grid/Row');
 
 const StyleConstants = require('../constants/Style');
 
-const DefaultRanges = ({ defaultRanges, handleDefaultRangeSelection, selectedStartDate, selectedEndDate, styles }) => (
+const DefaultRanges = Radium(({ defaultRanges, handleDefaultRangeSelection, primaryColor, selectedStartDate, selectedEndDate, styles }) => (
   <div style={styles.rangeOptions}>
-    <div style={styles.defaultRangesTitle}>
+    <div style={Object.assign({}, styles.defaultRangesTitle, { color: primaryColor })}>
       Select a Range
     </div>
     {defaultRanges.map(range => (
-      <div key={range.displayValue + range.startDate} style={styles.rangeOption}>
+      <div key={range.displayValue + range.startDate} onClick={handleDefaultRangeSelection.bind(null, range)} style={styles.rangeOption}>
         <div>
           <Icon
             size={20}
-            style={{
-              fill: range.startDate === selectedStartDate && range.endDate === selectedEndDate ?
-              props.primaryColor : 'transparent'
-            }}
+            style={Object.assign({}, styles.rangeOptionIcon, {
+              fill: range.startDate === selectedStartDate && range.endDate === selectedEndDate ? primaryColor : 'transparent'
+            })}
             type='check-solid'
           />
-        </ div>
-        <div onClick={handleDefaultRangeSelection.bind(null, range)}>
+        </div>
+        <div>
           {range.displayValue}
         </div>
       </div>
-      )
-    )}
+    ))}
   </div>
-);
+));
 
 DefaultRanges.propTypes = {
   defaultRanges: React.PropTypes.array,
@@ -341,6 +339,8 @@ const DateRangePicker = React.createClass({
                       defaultRanges={this.props.defaultRanges}
                       handleDefaultRangeSelection={this._handleDefaultRangeSelection}
                       primaryColor={this.props.primaryColor}
+                      selectedEndDate={this.props.selectedEndDate}
+                      selectedStartDate={this.props.selectedStartDate}
                       styles={styles}
                     />
                   }
@@ -566,10 +566,11 @@ const DateRangePicker = React.createClass({
 
       //Default Ranges
       defaultRangesTitle: {
+        color: StyleConstants.Colors.PRIMARY,
         display: isLargeOrMediumWindowSize ? 'inline-block' : 'none',
-        fontSize: StyleConstants.FontSizes.LARGE,
-        marginTop: 10,
-        marginBottom: 20
+        fontFamily: StyleConstants.Fonts.SEMIBOLD,
+        fontSize: StyleConstants.FontSizes.SMALL,
+        padding: `${StyleConstants.Spacing.LARGE}px 0px ${StyleConstants.Spacing.SMALL}px ${StyleConstants.Spacing.LARGE}px`
       },
       rangeOptions: {
         borderRight: isLargeOrMediumWindowSize ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
@@ -580,8 +581,8 @@ const DateRangePicker = React.createClass({
         flexDirection: isLargeOrMediumWindowSize ? 'column' : 'row',
         flexWrap: isLargeOrMediumWindowSize ? 'nowrap' : 'wrap',
         fontSize: StyleConstants.FontSizes.MEDIUM,
-        paddingLeft: isLargeOrMediumWindowSize ? 10 : 0,
-        paddingTop: 10,
+        marginLeft: isLargeOrMediumWindowSize ? -10 : 0,
+        marginRight: isLargeOrMediumWindowSize ? -10 : 0,
         maxWidth: window.innerWidth > 450 ? 250 : 'inherit',
         width: isLargeOrMediumWindowSize ? 150 : '100%'
       },
@@ -590,13 +591,15 @@ const DateRangePicker = React.createClass({
         boxSizing: 'border-box',
         cursor: 'pointer',
         display: 'flex',
-        marginBottom: isLargeOrMediumWindowSize ? 20 : 10,
-        padding: isLargeOrMediumWindowSize ? 0 : 10,
+        padding: `${StyleConstants.Spacing.SMALL}px ${StyleConstants.Spacing.MEDIUM}px`,
         width: isLargeOrMediumWindowSize ? '100%' : '50%',
 
         ':hover': {
-          color: this.props.primaryColor
+          backgroundColor: StyleConstants.Colors.PORCELAIN
         }
+      },
+      rangeOptionIcon: {
+        paddingRight: StyleConstants.Spacing.SMALL
       },
 
       //Selected and Selecting Range


### PR DESCRIPTION
Internally, the product team has asked us to polish the styles around the default range options for the `DateRangePicker`.  This PR does that plus fixes a few minor bugs along the way.

- Style Polish
- Fixes hover by wrapping the `DefaultRanges` component in Radium
- Fixes selected icon not showing for selected range
- Minor code formatting fixes
- Change log for update

#### Screen Shots

<img width="1128" alt="screen shot 2017-03-08 at 2 48 39 pm" src="https://cloud.githubusercontent.com/assets/6463914/23726194/a5f7d6b6-0410-11e7-8c23-60e8adcb0e9d.png">

<img width="393" alt="screen shot 2017-03-08 at 2 59 01 pm" src="https://cloud.githubusercontent.com/assets/6463914/23726193/a5f580e6-0410-11e7-8dd4-813721f22e82.png">
