### PR TITLE
Luke/modal accessible

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -58,6 +58,7 @@ const Modal = React.createClass({
   },
 
   componentDidMount () {
+    this._modal.focus();
   /*eslint-disable */
     if (this.props.hasOwnProperty('isOpen')) {
       console.warn('WARNING: The prop "isOpen" is deprecated in this version of the component. Please handle Modal opening from its parent.');
@@ -187,25 +188,30 @@ const Modal = React.createClass({
         <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)}></div>
         <div
           className='mx-modal-container'
+          ref={ref => this._modal = ref}
           style={Object.assign({}, styles.container, this.props.style)}
+          tabIndex={0}
         >
-          {this.props.showCloseIcon ? (
-            <Icon
-              className='mx-modal-close'
-              elementProps={{
-                onClick: this.props.onRequestClose
-              }}
-              size={24}
-              style={styles.close}
-              type='close-solid'
-            />
-          ) : null}
           {this._renderTitleBar()}
           <div className='mx-modal-content' style={Object.assign({}, styles.content, this.props.contentStyle)}>
             {this.props.children}
             {this._renderTooltip()}
           </div>
           {this._renderFooter()}
+          {this.props.showCloseIcon && (
+            <Icon
+              className='mx-modal-close'
+              elementProps={{
+                tabIndex: 0,
+                'aria-label': 'Close Modal',
+                onClick: this.props.onRequestClose,
+                onKeyUp: (e) => e.keyCode === 13 && this.props.onRequestClose()
+              }}
+              size={24}
+              style={styles.close}
+              type='close-solid'
+            />
+          )}
         </div>
       </div>
     );

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -204,6 +204,7 @@ const Modal = React.createClass({
               elementProps={{
                 tabIndex: 0,
                 'aria-label': 'Close Modal',
+                role: 'button',
                 onClick: this.props.onRequestClose,
                 onKeyUp: (e) => e.keyCode === 13 && this.props.onRequestClose()
               }}


### PR DESCRIPTION
First cut at making modal more accessible 
* Changes DOM order - renders the close `<Icon />` last as that is a more natural flow when tabbing through modal 
* makes close icon tabable, and has the screen reader say "Close Modal" when that element is focused 
* Focus Modal component content by default on componentDidMount 