### PR TITLE
Luke/modal 2!

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -188,6 +188,12 @@ const Modal = React.createClass({
         <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)}></div>
         <div
           className='mx-modal-container'
+          onKeyUp={e => {
+            if (e.shiftKey && e.keyCode === 9 && document.activeElement.className === this._modal.className) {
+              e.preventDefault();
+              this._closeIcon.focus();
+            }
+          }}
           ref={ref => this._modal = ref}
           style={Object.assign({}, styles.container, this.props.style)}
           tabIndex={0}
@@ -206,10 +212,15 @@ const Modal = React.createClass({
                 'aria-label': 'Close Modal',
                 role: 'button',
                 onClick: this.props.onRequestClose,
-                onKeyDown: (e) => {
+                onKeyUp: (e) => {
                   if (e.keyCode === 13) this.props.onRequestClose();
                   if (e.keyCode === 9) this._modal.focus();
-                }
+                  if (e.shiftKey && e.keyCode === 9) {
+                    this._modal.focus();
+                    e.stopPropagation();
+                  }
+                },
+                ref: ref => this._closeIcon = ref
               }}
               size={24}
               style={styles.close}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -206,7 +206,10 @@ const Modal = React.createClass({
                 'aria-label': 'Close Modal',
                 role: 'button',
                 onClick: this.props.onRequestClose,
-                onKeyUp: (e) => e.keyCode === 13 && this.props.onRequestClose()
+                onKeyDown: (e) => {
+                  if (e.keyCode === 13) this.props.onRequestClose();
+                  if (e.keyCode === 9) this._modal.focus();
+                }
               }}
               size={24}
               style={styles.close}


### PR DESCRIPTION
Traps Focus inside of Modal for Accessibility

A lot of what I've been reading about doing modals and accessibility state that keyboard focus should be trapped inside the modal. 
[example](https://www.webaccessibility.com/best_practices.php?best_practice_id=2051)
[blog post](https://www.nomensa.com/blog/2014/how-improve-accessibility-overlay-windows-part-1)
[one more](https://www.w3.org/WAI/GL/wiki/Using_ARIA_role%3Ddialog_to_implement_a_modal_dialog_box)

Even when using [the dialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role) it seems that keyboard focus still needs to be trapped manually. 

One article I read gave an alternative solution: 
> An alternative solution to keyboard focus cycling around the dialog window is to close the dialog automatically when focus is moved away from it


![modalfocus](https://cloud.githubusercontent.com/assets/13579578/24315680/1789341a-10ae-11e7-94bc-fd4f093f5c34.gif)
