### PR TITLE
DateRangePicker IE 11 width issue

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -5,6 +5,13 @@ const Changelog = React.createClass({
     return (
       <div>
         <h1>Change Log</h1>
+        <h3>Release Candidate 5.0.0-rc.64</h3>
+        <ul>
+          <li>
+            Fixes DateRangePicker options wrapper width (<a href='https://github.com/mxenabled/mx-react-components/pull/529'>#529</a>)
+          </li>
+        </ul>
+
         <h3>Release Candidate 5.0.0-rc.63</h3>
         <ul>
           <li>

--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,7 +8,7 @@ const Changelog = React.createClass({
         <h3>Release Candidate 5.0.0-rc.64</h3>
         <ul>
           <li>
-            Fixes DateRangePicker options wrapper width (<a href='https://github.com/mxenabled/mx-react-components/pull/529'>#529</a>)
+            Fixes DateRangePicker options wrapper width (<a href='https://github.com/mxenabled/mx-react-components/pull/530'>#530</a>)
           </li>
         </ul>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.0.0-rc.63",
+  "version": "5.0.0-rc.64",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -478,7 +478,8 @@ class DateRangePicker extends React.Component {
         position: 'absolute',
         left: this.props.isRelative && window.innerWidth > 450 ? 'auto' : 0,
         right: 0,
-        width: window.innerWidth < 450 ? window.innerWidth : 'inherit',
+        maxWidth: 450,
+        width: window.innerWidth,
         zIndex: 10
       },
       calendarWrapper: {


### PR DESCRIPTION
The options wrapper for the DateRangePicker was set to `inherit` it's parent's width if the window width was larger than 450.  This caused an issue in IE 11 where the the options wrapper would not expand to large enough for it's content.  This PR resolves the issue by setting a max width on the wrapper to 450 and then just using the windows width for width.

### Before

![screen shot 2017-03-29 at 11 54 57 am](https://cloud.githubusercontent.com/assets/6463914/24468766/904433b6-1476-11e7-8b9f-9e1fbb11cd73.png)

### After

![screen shot 2017-03-29 at 11 47 08 am](https://cloud.githubusercontent.com/assets/6463914/24468778/9cc274c2-1476-11e7-9bce-7ce344e99c80.png)

![screen shot 2017-03-29 at 11 48 04 am](https://cloud.githubusercontent.com/assets/6463914/24468777/9cb8a3ca-1476-11e7-99bf-6bebfc71cce8.png)
