### PR TITLE
DisplayInput > Sets line height for input to 1

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -5,6 +5,13 @@ const Changelog = React.createClass({
     return (
       <div>
         <h1>Change Log</h1>
+        <h3>Release Candidate 5.0.0-rc.65</h3>
+        <ul>
+          <li>
+            DisplayInput - prevent input text clipping (<a href='https://github.com/mxenabled/mx-react-components/pull/531'>#531</a>)
+          </li>
+        </ul>
+
         <h3>Release Candidate 5.0.0-rc.64</h3>
         <ul>
           <li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.0.0-rc.64",
+  "version": "5.0.0-rc.65",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -137,6 +137,7 @@ const DisplayInput = React.createClass({
         border: '1px solid transparent',
         color: StyleConstants.Colors.CHARCOAL,
         fontSize: StyleConstants.FontSizes.LARGE,
+        lineHeight: 1,
         textAlign: 'left',
         width: '100%',
 


### PR DESCRIPTION
Ensures IE 11 doesn’t clip text in input for letters such as `q` and `p`.

![screen shot 2017-03-29 at 2 32 44 pm](https://cloud.githubusercontent.com/assets/6463914/24475408/f510b088-148c-11e7-81ff-7f1ab0d62b31.png)
