### PR TITLE
BarChart: add threshold

### DIFF
--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -83,6 +83,7 @@ const BarChartDocs = React.createClass({
           data={chartData}
           margin={margins}
           style={styles.chart}
+          threshold={Math.round(Math.random() * 10000)}
           xAxis={xAxis}
         />
 
@@ -141,10 +142,14 @@ const BarChartDocs = React.createClass({
       negativeBarHover,
       positiveBarClicked,
       negativeBarClicked,
+      threshold,
       tooltipContainer,
       tooltipText
   `}
         </Markdown>
+
+        <h5>threshold<label>Number</label></h5>
+        <p>A value used to render an optional threshold line.</p>
 
         <h5>tooltipFormat<label>Function</label></h5>
         <p>A function that is called to format the value being displayed in the tooltip.</p>
@@ -173,6 +178,8 @@ const BarChartDocs = React.createClass({
 
     const data = [{label: 1485470502878, value:, 1337}, {...}];
 
+    const threshold = 2000;
+
     const ticks = data.map(d => {
       return d.label;
     });
@@ -193,6 +200,7 @@ const BarChartDocs = React.createClass({
       <BarChart
         data={data}
         margin={margins}
+        threshold={threshold}
         xAxis={xAxis}
       />
     );

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -123,6 +123,8 @@ const BarChart = React.createClass({
     onHover: React.PropTypes.func,
     showTooltips: React.PropTypes.bool,
     style: React.PropTypes.object,
+    threshold: React.PropTypes.number,
+    thresholdStyles: React.PropTypes.object,
     tooltipFormat: React.PropTypes.func,
     width: React.PropTypes.number,
     xAxis: React.PropTypes.element,
@@ -327,6 +329,17 @@ const BarChart = React.createClass({
           </g>
           {this.props.yAxis ? this.props.yAxis : null}
           {this.props.xAxis ? this.props.xAxis : null}
+          {this.props.threshold ? (
+            <g transform={`translate(${margin.left},${margin.top})`}>
+              <line
+                style={styles.threshold}
+                x1={0}
+                x2={width - margin.left - margin.right}
+                y1={yFunc(this.props.threshold)}
+                y2={yFunc(this.props.threshold)}
+              />
+            </g>
+          ) : null }
           <g
             ref={(ref) => {
               this.tooltip = ref;
@@ -368,6 +381,11 @@ const BarChart = React.createClass({
         color: StyleConstants.Colors.CHARCOAL,
         textAlign: 'center',
         whiteSpace: 'nowrap'
+      },
+      threshold: {
+        stroke: StyleConstants.Colors.ASH,
+        strokeDasharray: '4,4',
+        strokeWidth: 1
       }
     };
   }

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -124,7 +124,6 @@ const BarChart = React.createClass({
     showTooltips: React.PropTypes.bool,
     style: React.PropTypes.object,
     threshold: React.PropTypes.number,
-    thresholdStyles: React.PropTypes.object,
     tooltipFormat: React.PropTypes.func,
     width: React.PropTypes.number,
     xAxis: React.PropTypes.element,


### PR DESCRIPTION
This adds an optional threshold line to the bar chart. 

```
      <BarChart
        data={data}
        margin={margins}
        threshold={threshold}
        xAxis={xAxis}
      />
```

<img width="545" alt="screen shot 2017-03-31 at 5 11 21 pm" src="https://cloud.githubusercontent.com/assets/488916/24572515/8e11a0a8-1636-11e7-9f91-db742648e4d1.png">
