### PR TITLE
Bar Chart minBarHeight

### DIFF
--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -128,6 +128,9 @@ const BarChartDocs = React.createClass({
   `}
         </Markdown>
 
+        <h5>minBarHeight<label>Number</label></h5>
+        <p>The minimum height for a bar if the value of the data is 0.</p>
+
         <h5>onClick<label>Function</label></h5>
         <p>Callback function that will run when a bar is clicked. Provided the data values from the bar clicked.</p>
 
@@ -202,6 +205,7 @@ const BarChartDocs = React.createClass({
       <BarChart
         data={data}
         margin={margins}
+        minBarHeight={1}
         threshold={threshold}
         xAxis={xAxis}
       />

--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -22,10 +22,11 @@ for (let i = 0; i < 12; i++) {
 
   chartData.push({
     label: date.unix(),
-    value: i - 1
+    value: Math.round(Math.random() * (10000 - -10000) + -10000)
   });
 }
 
+chartData[4].value = 0;
 
 const BarChartDocs = React.createClass({
 
@@ -82,7 +83,7 @@ const BarChartDocs = React.createClass({
           animateOnHover={true}
           data={chartData}
           margin={margins}
-          minHeight={10}
+          minBarHeight={1}
           style={styles.chart}
           threshold={Math.round(Math.random() * 10000)}
           xAxis={xAxis}

--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -83,7 +83,7 @@ const BarChartDocs = React.createClass({
           animateOnHover={true}
           data={chartData}
           margin={margins}
-          minBarHeight={3}
+          minBarHeight={1}
           style={styles.chart}
           threshold={Math.round(Math.random() * 10000)}
           xAxis={xAxis}
@@ -129,7 +129,8 @@ const BarChartDocs = React.createClass({
         </Markdown>
 
         <h5>minBarHeight<label>Number</label></h5>
-        <p>The minimum height for a bar if the value of the data is 0. The minBarHeight can not be less than the radius.</p>
+        <p>The minimum height for a bar if the value of the data is 0.</p>
+        <p>NOTE: If minBarHeight is less than barRadius, the radius will be changed to equal the minBarHeight for the bar.</p>
 
         <h5>onClick<label>Function</label></h5>
         <p>Callback function that will run when a bar is clicked. Provided the data values from the bar clicked.</p>
@@ -205,7 +206,7 @@ const BarChartDocs = React.createClass({
       <BarChart
         data={data}
         margin={margins}
-        minBarHeight={3}
+        minBarHeight={1}
         threshold={threshold}
         xAxis={xAxis}
       />

--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -130,7 +130,6 @@ const BarChartDocs = React.createClass({
 
         <h5>minBarHeight<label>Number</label></h5>
         <p>The minimum height for a bar if the value of the data is 0. The minBarHeight can not be less than the radius.</p>
-        <p>Default: 3</p>
 
         <h5>onClick<label>Function</label></h5>
         <p>Callback function that will run when a bar is clicked. Provided the data values from the bar clicked.</p>

--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -83,7 +83,7 @@ const BarChartDocs = React.createClass({
           animateOnHover={true}
           data={chartData}
           margin={margins}
-          minBarHeight={1}
+          minBarHeight={3}
           style={styles.chart}
           threshold={Math.round(Math.random() * 10000)}
           xAxis={xAxis}
@@ -129,7 +129,8 @@ const BarChartDocs = React.createClass({
         </Markdown>
 
         <h5>minBarHeight<label>Number</label></h5>
-        <p>The minimum height for a bar if the value of the data is 0.</p>
+        <p>The minimum height for a bar if the value of the data is 0. The minBarHeight can not be less than the radius.</p>
+        <p>Default: 3</p>
 
         <h5>onClick<label>Function</label></h5>
         <p>Callback function that will run when a bar is clicked. Provided the data values from the bar clicked.</p>
@@ -205,7 +206,7 @@ const BarChartDocs = React.createClass({
       <BarChart
         data={data}
         margin={margins}
-        minBarHeight={1}
+        minBarHeight={3}
         threshold={threshold}
         xAxis={xAxis}
       />

--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -22,7 +22,7 @@ for (let i = 0; i < 12; i++) {
 
   chartData.push({
     label: date.unix(),
-    value: Math.round(Math.random() * (10000 - -10000) + -10000)
+    value: i - 1
   });
 }
 
@@ -82,6 +82,7 @@ const BarChartDocs = React.createClass({
           animateOnHover={true}
           data={chartData}
           margin={margins}
+          minHeight={10}
           style={styles.chart}
           threshold={Math.round(Math.random() * 10000)}
           xAxis={xAxis}

--- a/docs/components/BarChartDocs.js
+++ b/docs/components/BarChartDocs.js
@@ -94,7 +94,7 @@ const BarChartDocs = React.createClass({
         <p>If true, individual bars will animate on hover.</p>
         <p>Default: false</p>
 
-        <h5>borderRadius <label>Number</label></h5>
+        <h5>barRadius <label>Number</label></h5>
         <p>Radius for the bar applied to the top for positive and bottom for negative values.</p>
         <p>Default: 3</p>
 

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -97,16 +97,6 @@ const Bar = React.createClass({
     }
   },
 
-  _getHeight () {
-    if (this.props.minBarHeight) {
-      const adjuster = this.props.radius > this.props.minBarHeight ? this.props.radius : this.props.minBarHeight;
-
-      return this.props.height + adjuster;
-    } else {
-      return this.props.height;
-    }
-  },
-
   render () {
     const hasMinBarHeight = this.props.height === 0 && this.props.minBarHeight;
     const divisor = this.props.hasNegative && this.props.hasPositive ? 2 : 1;
@@ -127,7 +117,7 @@ const Bar = React.createClass({
           x: this.props.x,
           y,
           width: this.props.width,
-          height: this._getHeight(),
+          height: this.props.height,
           value: this.props.value,
           radius: this.props.radius
         })}
@@ -311,6 +301,16 @@ const BarChart = React.createClass({
     return -1000;
   },
 
+  _getHeight (baseHeight) {
+    if (this.props.minBarHeight) {
+      const adjuster = this.props.barRadius > this.props.minBarHeight ? this.props.barRadius : this.props.minBarHeight;
+
+      return baseHeight + adjuster;
+    } else {
+      return baseHeight;
+    }
+  },
+
   render () {
     const styles = _merge({}, this.styles(), this.props.style);
     const { height, margin, width } = this.props;
@@ -360,7 +360,8 @@ const BarChart = React.createClass({
               const x = xFunc(d.label);
               const y = positive ? yFunc(d.value) : yFunc(0);
               const w = xFunc.rangeBand();
-              const h = hasNegative ? Math.abs(yFunc(d.value) - yFunc(0)) : heightMargin - yFunc(d.value);
+              const baseHeight = hasNegative ? Math.abs(yFunc(d.value) - yFunc(0)) : heightMargin - yFunc(d.value);
+              const h = this._getHeight(baseHeight);
               const key = d.label + d.value;
               const clicked = this.state.clickedData.value === d.value && this.state.clickedData.label === d.label;
               const hovering = this.state.hoveringObj.value === d.value && this.state.hoveringObj.label === d.label;

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -65,7 +65,7 @@ const Bar = React.createClass({
   },
 
   _drawPath ({ x, y, width, height, value, radius }) {
-    if (value >= 0 && !this.props.hasNegative) {
+    if (value > 0 || (value === 0 && !this.props.hasNegative)) {
       return 'M' + x + ',' + y +
          'h' + (width - radius) +
          'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius +
@@ -74,7 +74,7 @@ const Bar = React.createClass({
          'v' + (-height + radius) +
          'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius +
          'Z';
-    } else if (value <= 0 && !this.props.hasPositive) {
+    } else if (value < 0 || (value === 0 && !this.props.hasPositive)) {
       return 'M' + x + ',' + y +
          'h' + width +
          'v' + (height - radius) +

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -284,18 +284,22 @@ const BarChart = React.createClass({
       const bboxHeight = this.tooltip.getBBox().height;
       const negativeHeightAdjustment = this.state.hoveringObj.height + bboxHeight;
       const positiveHeightAdjustment = tooltipHeight - bboxHeight / 2;
+      const { hasNegative, hasPositive } = this.state;
+      const divisor = hasNegative && hasPositive ? 2 : 1;
 
       if (negativeValue) {
         return tooltipHeight + negativeHeightAdjustment;
       } else if (positiveValue) {
         return positiveHeightAdjustment;
       } else {
-        return positiveHeightAdjustment - this.props.minBarHeight;
+        if (hasNegative && !hasPositive) {
+          return negativeHeightAdjustment + this.props.minBarHeight + tooltipHeight;
+        }
+        return positiveHeightAdjustment - this.props.minBarHeight / divisor;
       }
     }
     return -1000;
   },
-
 
   render () {
     const styles = _merge({}, this.styles(), this.props.style);

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -311,6 +311,14 @@ const BarChart = React.createClass({
     }
   },
 
+  _getRadius (d) {
+    if (d.value === 0 && this.props.minBarHeight) {
+      return Math.min(this.props.barRadius, this.props.minBarHeight);
+    } else {
+      return this.props.barRadius;
+    }
+  },
+
   render () {
     const styles = _merge({}, this.styles(), this.props.style);
     const { height, margin, width } = this.props;
@@ -362,6 +370,7 @@ const BarChart = React.createClass({
               const w = xFunc.rangeBand();
               const baseHeight = hasNegative ? Math.abs(yFunc(d.value) - yFunc(0)) : heightMargin - yFunc(d.value);
               const h = this._getHeight(baseHeight);
+              const r = this._getRadius(d);
               const key = d.label + d.value;
               const clicked = this.state.clickedData.value === d.value && this.state.clickedData.label === d.label;
               const hovering = this.state.hoveringObj.value === d.value && this.state.hoveringObj.label === d.label;
@@ -390,7 +399,7 @@ const BarChart = React.createClass({
                   onClick={this._handleOnClick.bind(null, d)}
                   onMouseOut={this._handleMouseOut}
                   onMouseOver={this._handleMouseOver.bind(null, x, y, w, h, d)}
-                  radius={this.props.barRadius}
+                  radius={r}
                   style={style}
                   value={d.value}
                   width={w}

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -99,11 +99,9 @@ const Bar = React.createClass({
 
   _getHeight () {
     if (this.props.minBarHeight) {
-      if (this.props.radius > this.props.minBarHeight) {
-        return this.props.height + this.props.radius;
-      } else {
-        return this.props.height + this.props.minBarHeight;
-      }
+      const adjuster = this.props.radius > this.props.minBarHeight ? this.props.radius : this.props.minBarHeight;
+
+      return this.props.height + adjuster;
     } else {
       return this.props.height;
     }

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -97,6 +97,18 @@ const Bar = React.createClass({
     }
   },
 
+  _getHeight () {
+    if (this.props.minBarHeight) {
+      if (this.props.radius > this.props.minBarHeight) {
+        return this.props.height + this.props.radius;
+      } else {
+        return this.props.height + this.props.minBarHeight;
+      }
+    } else {
+      return this.props.height;
+    }
+  },
+
   render () {
     const hasMinBarHeight = this.props.height === 0 && this.props.minBarHeight;
     const divisor = this.props.hasNegative && this.props.hasPositive ? 2 : 1;
@@ -117,7 +129,7 @@ const Bar = React.createClass({
           x: this.props.x,
           y,
           width: this.props.width,
-          height: hasMinBarHeight ? this.props.height + this.props.minBarHeight : this.props.height,
+          height: this._getHeight(),
           value: this.props.value,
           radius: this.props.radius
         })}


### PR DESCRIPTION
This adds `minBarHeight` to the `BarChart` component. If a value of 0 is passed to the chart, the chart will display a sliver of the bar, the height being the number used for `minBarHeight`. This sliver includes a tooltip. If no `minBarHeight` is set, so bar is displayed.

## Positive only values
![screen shot 2017-04-06 at 10 12 14 am](https://cloud.githubusercontent.com/assets/1916697/24765838/97f555d6-1ab6-11e7-8982-403aabe4afe7.png)

## Negative only values
![screen shot 2017-04-06 at 10 11 35 am](https://cloud.githubusercontent.com/assets/1916697/24765842/9c9fd9b2-1ab6-11e7-923a-6ac273b76182.png)

## Positive and negative values
![screen shot 2017-04-06 at 10 11 55 am](https://cloud.githubusercontent.com/assets/1916697/24765850/a162b492-1ab6-11e7-83dc-9f3f968ed655.png)

## No `minBarHeight` passed in
![screen shot 2017-04-06 at 10 44 48 am](https://cloud.githubusercontent.com/assets/1916697/24765854/a4c24dd2-1ab6-11e7-9042-02db8b4a2196.png)
