### PR TITLE
SimpleInput shift+tab accessibility fix

### DIFF
--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -4,6 +4,7 @@ var webpack = require('webpack');
 var isProd = (process.env.NODE_ENV === 'production');
 
 module.exports = {
+  devtool: !isProd && 'eval',
   entry: {
     app: './app.js'
   },

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -49,20 +49,12 @@ const Input = React.createClass({
   },
 
   _onFocus () {
-    if (this.input) {
-      this.input.focus();
-    }
-
     this.setState({
       focus: true
     });
   },
 
   _onBlur () {
-    if (this.input) {
-      this.input.blur();
-    }
-
     this.setState({
       focus: false
     });
@@ -74,16 +66,15 @@ const Input = React.createClass({
 
     return (
       <div
-        onBlur={this._onBlur}
-        onFocus={this._onFocus}
         style={Object.assign({}, styles.wrapper, this.state.focus ? styles.activeWrapper : null)}
-        tabIndex={0}
       >
         {this.props.icon ? (
           <Icon size={20} style={styles.icon} type={this.props.icon} />
         ) : null}
         <input
           {...elementProps}
+          onBlur={this._onBlur}
+          onFocus={this._onFocus}
           ref={(ref) => {
             this.input = ref;
           }}

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -75,9 +75,7 @@ const Input = React.createClass({
           {...elementProps}
           onBlur={this._onBlur}
           onFocus={this._onFocus}
-          ref={(ref) => {
-            this.input = ref;
-          }}
+          ref={ref => this.input = ref}
           style={styles.input}
           type={this.props.type}
         />


### PR DESCRIPTION
Typing `shift+tab` when the `SimpleInput` had focus was not working, it kept the focus on the input instead of going to the previous focusable element. `tabIndex` on the parent element turned out to be the problem. Removing that attribute and moving the focus/blur handlers to the input fixes the issue.

This also adds `devtool` when developing for better debugging (separate files in the dev tools makes it easier to set breakpoints).