### PR TITLE
Luke/VisuallyHidden Button Children - Drawer Implementation

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,6 +12,7 @@ const { buttonTypes } = require('../constants/App');
 class Button extends React.Component {
   static propTypes = {
     actionText: React.PropTypes.string,
+    ariaLabel: React.PropTypes.string,
     icon: React.PropTypes.string,
     isActive: React.PropTypes.bool,
     onClick: React.PropTypes.func,
@@ -58,6 +59,7 @@ class Button extends React.Component {
 
     return (
       <button
+        aria-label={this.props.ariaLabel}
         onClick={this.props.type === 'disabled' ? null : this.props.onClick}
         style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}
       >

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -34,8 +34,27 @@ class Button extends React.Component {
     return windowSize === 'medium' || windowSize === 'large';
   };
 
+  _hasVisibleChildren = () => {
+    let hasVisibleChildren = false;
+
+    if (!this.props.children) {
+      return hasVisibleChildren;
+    }
+
+    if (!Array.isArray(this.props.children)) {
+      return !this.props.children.props || this.props.children.props.className !== 'visuallyHidden';
+    }
+
+    this.props.children.forEach((child) => {
+      if (child.props && child.props.className !== 'visuallyHidden') {
+        hasVisibleChildren = true;
+      }
+    });
+
+    return hasVisibleChildren;
+  };
+
   render () {
-    console.log("this is this.props.children.props.className.", this.props.children && this.props.children.props && this.props.children.props.className)
     const styles = this.styles();
 
     return (
@@ -209,8 +228,8 @@ class Button extends React.Component {
         fill: StyleConstants.Colors.FOG
       },
       icon: {
-        marginLeft: this.props.children ? -4 : 0,
-        marginRight: this.props.children ? 5 : 0
+        marginLeft: this._hasVisibleChildren() ? -4 : 0,
+        marginRight: this._hasVisibleChildren() ? 5 : 0
       },
       buttonText: {
         marginLeft: (this.props.isActive && this.props.actionText) ? 10 : 0

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -35,6 +35,7 @@ class Button extends React.Component {
   };
 
   render () {
+    console.log("this is this.props.children.props.className.", this.props.children && this.props.children.props && this.props.children.props.className)
     const styles = this.styles();
 
     return (

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,7 +12,6 @@ const { buttonTypes } = require('../constants/App');
 class Button extends React.Component {
   static propTypes = {
     actionText: React.PropTypes.string,
-    ariaLabel: React.PropTypes.string,
     icon: React.PropTypes.string,
     isActive: React.PropTypes.bool,
     onClick: React.PropTypes.func,
@@ -59,7 +58,6 @@ class Button extends React.Component {
 
     return (
       <button
-        aria-label={this.props.ariaLabel}
         onClick={this.props.type === 'disabled' ? null : this.props.onClick}
         style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}
       >

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -34,24 +34,19 @@ class Button extends React.Component {
     return windowSize === 'medium' || windowSize === 'large';
   };
 
-  _hasVisibleChildren = () => {
-    let hasVisibleChildren = false;
+  _childIsVisible = child =>
+    !child.props || child.props.className !== 'visuallyHidden';
 
+  _hasVisibleChildren = () => {
     if (!this.props.children) {
-      return hasVisibleChildren;
+      return false;
     }
 
     if (!Array.isArray(this.props.children)) {
-      return !this.props.children.props || this.props.children.props.className !== 'visuallyHidden';
+      return this._childIsVisible(this.props.children);
     }
 
-    this.props.children.forEach((child) => {
-      if (child.props && child.props.className !== 'visuallyHidden') {
-        hasVisibleChildren = true;
-      }
-    });
-
-    return hasVisibleChildren;
+    return this.props.children.some(this._childIsVisible);
   };
 
   render () {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -163,7 +163,9 @@ const Drawer = React.createClass({
                     onClick={this.close}
                     primaryColor={this.props.buttonPrimaryColor}
                     type={'base'}
-                  />
+                  >
+                    <span className='visuallyHidden' style={styles.visuallyHidden}>Close Drawer</span>
+                  </Button>
                 }
               </span>
               <span style={styles.title}>
@@ -276,6 +278,17 @@ const Drawer = React.createClass({
           display: 'none',
           padding: 0
         }
+      },
+      visuallyHidden: {
+        border: 0,
+        clip: 'rect(0 0 0 0)',
+        clipPath: 'insert(50%)',
+        height: 1,
+        margin: '-1px',
+        overflow: 'hidden',
+        padding: 0,
+        position: 'absolute',
+        width: 1
       }
     }, this.props.styles);
   }

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -164,7 +164,7 @@ const Drawer = React.createClass({
                     primaryColor={this.props.buttonPrimaryColor}
                     type={'base'}
                   >
-                    <span style={styles.visuallyHidden}>Close Drawer</span>
+                    <span className='visuallyHidden' style={styles.visuallyHidden}>Close Drawer</span>
                   </Button>
                 }
               </span>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -164,7 +164,7 @@ const Drawer = React.createClass({
                     primaryColor={this.props.buttonPrimaryColor}
                     type={'base'}
                   >
-                    <span className='visuallyHidden' style={styles.visuallyHidden}>Close Drawer</span>
+                    <span style={styles.visuallyHidden}>Close Drawer</span>
                   </Button>
                 }
               </span>


### PR DESCRIPTION
This helps make `<Button />` more accessible by allowing to pass children that are visuallyHidden from the user. This is necessary for icon-only buttons - with these buttons currently, there is no indication to the user what the button is. 

Also I added an implementation of this to the `<Drawer />` component's back button 

This seems the recommended way of making accessible Icon-Only buttons. 

References: 
https://egghead.io/lessons/css-accessible-icon-buttons
https://blog.jayway.com/2015/03/03/making-icon-only-buttons-a-little-more-accessible/

The hairiest part of this PR is the `_hasVisibleChildren` method - comment with suggestions on any improvements with that implementation or other ideas. 