### PR TITLE
SimpleInput: fix onblur

### DIFF
--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -59,6 +59,8 @@ const Input = React.createClass({
     this.setState({
       focus: false
     });
+
+    if (this.props.elementProps.onBlur) this.props.elementProps.onBlur();
   },
 
   render () {


### PR DESCRIPTION
With the addition of the `_onBlur` method, any `onBlur` prop sent in would be overridden. This adds a check for that prop and calls the method from the `_onBlur`.

