### PR TITLE
add tabIndex to modal content so trap-focus is happy and there is alw…

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -194,7 +194,11 @@ const Modal = React.createClass({
             style={Object.assign({}, styles.container, this.props.style)}
           >
             {this._renderTitleBar()}
-            <div className='mx-modal-content' style={Object.assign({}, styles.content, this.props.contentStyle)}>
+            <div
+              className='mx-modal-content'
+              style={Object.assign({}, styles.content, this.props.contentStyle)}
+              tabIndex={0}
+            >
               {this.props.children}
               {this._renderTooltip()}
             </div>


### PR DESCRIPTION
…ays focusable content.

`trap-focus-react` throws an error if there is no focusable content. Adding a `tabIndex={0}` to the modal content so even if there is a modal that is only text elements, the content is still focusable. 