### PR TITLE
DisplayInput children styles

### DIFF
--- a/docs/components/DisplayInputDocs.js
+++ b/docs/components/DisplayInputDocs.js
@@ -1,6 +1,6 @@
 const React = require('react');
 
-const { DisplayInput } = require('mx-react-components');
+const { DisplayInput, Styles } = require('mx-react-components');
 
 const Markdown = require('components/Markdown');
 
@@ -66,11 +66,20 @@ const DisplayInputDocs = React.createClass({
           status={this.state.statusMessage}
           valid={true}
         />
+        <DisplayInput
+          childrenStyle={{ backgroundColor: Styles.Colors.PORCELAIN }}
+          label='Display Children'
+        >
+          Custom &nbsp;<span style={{ fontFamily: 'monospace' }}>children</span>
+        </DisplayInput>
 
         <h3>Usage</h3>
 
         <h5>children <label>Node</label></h5>
         <p>JSX node to be rendered in place of the standard input.</p>
+
+        <h5>childrenStyle <label>Object</label></h5>
+        <p>When providing custom children use this to to style the wrapping div.</p>
 
         <h5>hint <label>String</label></h5>
         <p>Hint text to display to user on input hover.</p>

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -9,6 +9,7 @@ const Row = require('../components/grid/Row');
 
 const DisplayInput = React.createClass({
   propTypes: {
+    childrenStyle: React.PropTypes.object,
     elementProps: React.PropTypes.object,
     hint: React.PropTypes.string,
     isFocused: React.PropTypes.bool,
@@ -73,7 +74,7 @@ const DisplayInput = React.createClass({
 
             <Column relative={!hasChildren} span={inputColumn}>
               {hasChildren ? (
-                <div style={styles.children}>
+                <div style={Object.assign({}, styles.children, this.props.childrenStyle)}>
                   {this.props.children}
                 </div>
               ) : (

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -135,7 +135,7 @@ const DisplayInput = React.createClass({
 
       input: {
         backgroundColor: 'transparent',
-        border: '1px solid transparent',
+        border: 0,
         color: StyleConstants.Colors.CHARCOAL,
         fontSize: StyleConstants.FontSizes.LARGE,
         lineHeight: 1,
@@ -156,7 +156,10 @@ const DisplayInput = React.createClass({
 
       children: {
         alignItems: 'center',
+        color: StyleConstants.Colors.CHARCOAL,
         display: 'flex',
+        fontSize: StyleConstants.FontSizes.LARGE,
+        height: StyleConstants.Spacing.LARGE,
         padding: StyleConstants.Spacing.SMALL
       },
 


### PR DESCRIPTION
This PR:
* adds a `childrenStyle` prop to `DisplayInput` for customizing the `children` wrapping `div`
* updates the styles for `children` to match the font and size of the default input

Here's what it looks like in the docs:

![screen shot 2017-04-27 at 11 11 03 am](https://cloud.githubusercontent.com/assets/4348/25495773/b0f1aef0-2b3b-11e7-96ac-e0710d8f3b0d.png)
