### PR TITLE
SimpleSelect accessibility using Listbox/Option

### DIFF
--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -11,13 +11,16 @@ const SimpleSelectDocs = React.createClass({
     };
   },
 
-  _handleClick () {
+  _handleItemClick (e, item) {
+    this._toggleMenu();
+    alert(`You clicked ${item.text}`); // eslint-disable-line no-alert
+  },
+
+  _toggleMenu () {
     this.setState({
       showMenu: !this.state.showMenu
     });
   },
-
-  _handleItemClick () {},
 
   render () {
     return (
@@ -31,19 +34,20 @@ const SimpleSelectDocs = React.createClass({
         <div style={{ width: 177 }}>
           <Button
             icon='gear'
-            onClick={this._handleClick}
+            onClick={this._toggleMenu}
             type='neutral'
           >
             Settings
           </Button>
           {this.state.showMenu ? (
             <SimpleSelect
+              aria-label='Select a category'
               items={[
                 { icon: 'auto', text: 'Auto', onClick: this._handleItemClick },
                 { icon: 'kids', text: 'Kids', onClick: this._handleItemClick },
                 { icon: 'pets', text: 'Pets', onClick: this._handleItemClick }
               ]}
-              onScrimClick={this._handleClick}
+              onScrimClick={this._toggleMenu}
             />
           ) : null}
         </div>
@@ -68,7 +72,12 @@ const SimpleSelectDocs = React.createClass({
         <h3>Example</h3>
         <Markdown>
   {`
-    _handleClick () {
+    _handleItemClick (e, item) {
+      this._toggleMenu();
+      alert(\`You clicked $\{item.text\}\`);
+    },
+
+    _toggleMenu () {
       this.setState({
         showMenu: !this.state.showMenu
       });
@@ -77,19 +86,20 @@ const SimpleSelectDocs = React.createClass({
     <div>
       <Button
         icon='gear'
-        onClick={this._handleClick}
+        onClick={this._toggleMenu}
         type='neutral'
       >
         Settings
       </Button>
       {this.state.showMenu ? (
         <SimpleSelect
+          aria-label='Select a category'
           items={[
-            { icon: 'auto', text: 'Auto' },
-            { icon: 'kids', text: 'Kids' },
-            { icon: 'pets', text: 'Pets' }
+            { icon: 'auto', text: 'Auto', onClick: this._handleItemClick },
+            { icon: 'kids', text: 'Kids', onClick: this._handleItemClick },
+            { icon: 'pets', text: 'Pets', onClick: this._handleItemClick }
           ]}
-          onScrimClick={this._handleClick}
+          onScrimClick={this._toggleMenu}
         />
       ) : null}
     </div>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bowser": "^1.5.0",
     "d3": "^3.5.6",
     "focus-trap-react": "^3.0.2",
+    "keycode": "^2.1.8",
     "lodash": "^4.6.1",
     "moment": "^2.10.3",
     "moment-timezone": "^0.5.4",

--- a/src/Index.js
+++ b/src/Index.js
@@ -42,6 +42,9 @@ module.exports = {
   Tooltip: require('./components/Tooltip'),
   TypeAhead: require('./components/TypeAhead'),
 
+  // Accessibility
+  Listbox: require('./components/accessibility/Listbox'),
+
   // D3 components
   AxisGroup: require('./components/d3/AxisGroup'),
   BreakPointGroup: require('./components/d3/BreakPointGroup'),

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -3,11 +3,13 @@ const Radium = require('radium');
 const _merge = require('lodash/merge');
 
 const Icon = require('./Icon');
+const { Listbox, Option } = require('./accessibility/Listbox');
 
 const StyleConstants = require('../constants/Style');
 
 const SimpleSelect = React.createClass({
   propTypes: {
+    'aria-label': React.PropTypes.string,
     hoverColor: React.PropTypes.string,
     iconSize: React.PropTypes.number,
     iconStyles: React.PropTypes.object,
@@ -48,7 +50,7 @@ const SimpleSelect = React.createClass({
       this.props.onScrimClick(e);
     }
 
-    item.onClick(e);
+    item.onClick(e, item);
   },
 
   render () {
@@ -56,13 +58,18 @@ const SimpleSelect = React.createClass({
 
     return (
       <div style={styles.component}>
-        <div style={styles.menu}>
+        <Listbox
+          aria-label={this.props['aria-label']}
+          style={styles.menu}
+          useGlobalKeyHandler={true}
+        >
           {this.props.children ?
             this.props.children :
             (this.props.items.map((item, i) => {
               return (
-                <div
+                <Option
                   key={i}
+                  label={item.text}
                   onClick={this._handleItemClick.bind(null, item)}
                   style={styles.item}
                 >
@@ -70,11 +77,11 @@ const SimpleSelect = React.createClass({
                     <Icon size={this.props.iconSize || 20} style={styles.icon} type={item.icon} />
                   ) : null}
                   <div style={styles.text}>{item.text}</div>
-                </div>
+                </Option>
               );
             })
           )}
-        </div>
+        </Listbox>
         <div onClick={this.props.onScrimClick} style={styles.scrim} />
       </div>
     );

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -1,0 +1,142 @@
+const React = require('react');
+const Radium = require('radium');
+const keycode = require('keycode');
+const _findIndex = require('lodash/findIndex');
+
+/**
+ * Listbox
+ *
+ * Handles accessibility and traversal of a list of options.
+ * Traverse the list with the `up`/`down` arrow keys and `tab`/`shift+tab`.
+ * Selecting an option is handled with `space`/`enter`.
+ * Focus is also managed.
+ *
+ * When `useGlobalKeyHandler` is `true` the event listener will bind to window.
+ *
+ * Example:
+ *   <Listbox aria-label='select things'>
+ *     <Option ...>Foo</Option>
+ *     <Option ...>Bar</Option>
+ *   </Listbox>
+ */
+const Listbox = React.createClass({
+  propTypes: {
+    'aria-label': React.PropTypes.string.isRequired,
+    useGlobalKeyHandler: React.PropTypes.bool
+  },
+
+  getDefaultProps () {
+    return {
+      useGlobalKeyHandler: false
+    };
+  },
+
+  getInitialState () {
+    return {
+      focusedIndex: this._getSelectedOptionIndex()
+    };
+  },
+
+  componentDidMount () {
+    this._eventTarget = this.props.useGlobalKeyHandler ? window : this.component;
+    this._eventTarget.addEventListener('keydown', this._handleKeyDown);
+    this._focusOption();
+  },
+
+  componentWillUnmount () {
+    this._eventTarget.removeEventListener('keydown', this._handleKeyDown);
+  },
+
+  _getChildren () {
+    return React.Children.toArray(this.props.children);
+  },
+
+  _getSelectedOptionIndex () {
+    const children = this._getChildren();
+    const focusedIndex = _findIndex(children, child => child.props.isSelected);
+
+    // default to first
+    return focusedIndex === -1 ? 0 : focusedIndex;
+  },
+
+  _handleKeyDown (e) {
+    switch (keycode(e)) {
+      case 'up':
+        e.preventDefault();
+        this._focusPrevious();
+        break;
+      case 'down':
+        e.preventDefault();
+        this._focusNext();
+        break;
+      case 'enter':
+      case 'space':
+        e.preventDefault();
+        e.target.click();
+        break;
+    }
+  },
+
+  _focusOption () {
+    const option = this.component.children[this.state.focusedIndex];
+
+    if (option) setTimeout(() => option.focus());
+  },
+
+  _focusPrevious () {
+    // go to the end if at the beginning
+    const focusedIndex = this.state.focusedIndex === 0 ? this._getChildren().length : this.state.focusedIndex;
+
+    this.setState({ focusedIndex: focusedIndex - 1 }, this._focusOption);
+  },
+
+  _focusNext () {
+    // go to the beginning if at the end
+    const focusedIndex = this.state.focusedIndex === this._getChildren().length - 1 ? -1 : this.state.focusedIndex;
+
+    // focus next
+    this.setState({ focusedIndex: focusedIndex + 1 }, this._focusOption);
+  },
+
+  render () {
+    return (
+      <div
+        aria-label={this.props['aria-label']}
+        ref={ref => this.component = ref}
+        role='listbox'
+        style={this.props.style}
+      >
+        {React.Children.map(this.props.children, (child, index) =>
+          React.cloneElement(child, {
+            onBlur: () => this.setState({ focusedIndex: -1 }),
+            onFocus: () => this.setState({ focusedIndex: index })
+          })
+        )}
+      </div>
+    );
+  }
+});
+
+/**
+ * Option
+ *
+ * Handles accessibility for options in a Listbox.
+ */
+const Option = ({ children, isSelected, label, ...props }) => (
+  <a
+    {...props}
+    aria-label={isSelected && label ? `${label}, Current selection` : label}
+    aria-selected={isSelected}
+    role='option'
+    tabIndex={0}
+  >
+    {children}
+  </a>
+);
+
+Option.propTypes = {
+  isSelected: React.PropTypes.bool,
+  label: React.PropTypes.string.isRequired
+};
+
+module.exports = { Listbox, Option: Radium(Option) };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,6 +2521,10 @@ jsx-ast-utils@^1.2.1:
     acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
 
+keycode@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.8.tgz#94d2b7098215eff0e8f9a8931d5a59076c4532fb"
+
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"


### PR DESCRIPTION
Pulling in the `Listbox`/`Option` components from our internal raja project. I put it in `components/accessibility/` because I can imagine us adding more accessibility related components.

I also updated `SimpleSelect` to use the new components. I'm happy with how easy it was to hook up. Here's an example of using it with the `enter` and `up`/`down` keys:

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/4348/25509367/9a301e1a-2b75-11e7-9358-2ba61d1a6ab1.gif)
