### PR TITLE
Rename ariaLabel to aria-label to match React's naming conventions

### DIFF
--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -53,7 +53,7 @@ class ButtonDocs extends React.Component {
         <br /><br />
         <div className='flex'>
           <Button icon='add'>Icon</Button>
-          <Button ariaLabel='delete' icon='delete' style={style} />
+          <Button aria-label='delete' icon='delete' style={style} />
         </div>
         <br /><br />
         <div className='flex'>
@@ -77,7 +77,7 @@ class ButtonDocs extends React.Component {
         <h5>actionText <label>String</label></h5>
         <p>The button text when isActive is true. If not defined, a spinner without text is shown.</p>
 
-        <h5>ariaLabel <label>String</label></h5>
+        <h5>aria-label <label>String</label></h5>
         <p>If defined, adds an aria-label attribute equal to the supplied value on the button element for accessibility.</p>
         <p><a href='https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute'>aria-label documentation</a></p>
 
@@ -99,7 +99,7 @@ class ButtonDocs extends React.Component {
         <h3>Example</h3>
         <Markdown>
   {`
-    <Button ariaLabel='Submit Form' primaryColor='#333333' type='secondary' />
+    <Button aria-label='Submit Form' primaryColor='#333333' type='secondary' />
   `}
         </Markdown>
       </div>

--- a/docs/components/ButtonGroupDocs.js
+++ b/docs/components/ButtonGroupDocs.js
@@ -17,9 +17,9 @@ class ButtonGroupDocs extends React.Component {
         <div className='flex'>
           <ButtonGroup
             buttons={[
-              { ariaLabel: 'Back', icon: 'caret-left' },
-              { ariaLabel: 'March 2015 to February 2016', text: 'Mar 2015 - Feb 2016' },
-              { ariaLabel: 'Forward', icon: 'caret-right' }
+              { 'aria-label': 'Back', icon: 'caret-left' },
+              { 'aria-label': 'March 2015 to February 2016', text: 'Mar 2015 - Feb 2016' },
+              { 'aria-label': 'Forward', icon: 'caret-right' }
             ]}
             type='primaryOutline'
           />
@@ -40,9 +40,9 @@ class ButtonGroupDocs extends React.Component {
         <div>
           <ButtonGroup
             buttons={[
-              { ariaLabel: 'Download', icon: 'download' },
-              { ariaLabel: 'Search', icon: 'search' },
-              { ariaLabel: 'Add', icon: 'add' }
+              { 'aria-label': 'Download', icon: 'download' },
+              { 'aria-label': 'Search', icon: 'search' },
+              { 'aria-label': 'Add', icon: 'add' }
             ]}
             type='base'
           />
@@ -51,9 +51,9 @@ class ButtonGroupDocs extends React.Component {
         <h3>Usage</h3>
         <h5>buttons <label>Array of Objects</label></h5>
         <p>Default: An empty array</p>
-        <p>An array of objects that will populate the button values. Works with as little as one object. Objects take an <label>ariaLabel</label>, <label>icon</label>, <label>text</label>, and <label>style</label>.</p>
+        <p>An array of objects that will populate the button values. Works with as little as one object. Objects take an <label>aria-label</label>, <label>icon</label>, <label>text</label>, and <label>style</label>.</p>
         <p>A button can be disabled by adding <label>type = 'disabled'</label> but no other button types are supported within the button group.</p>
-        <p>The ariaLabel attribute for each button is used for accessibility purposes but is not required.  See the Button component documentation for more details.</p>
+        <p>The aria-label attribute for each button is used for accessibility purposes but is not required.  See the Button component documentation for more details.</p>
 
         <h5>icon <label>String</label></h5>
         <p>The name of the <a href='/components/icon'>icon</a></p>
@@ -74,9 +74,9 @@ class ButtonGroupDocs extends React.Component {
   {`
     <ButtonGroup
       buttons={[
-         { ariaLabel: 'Download', icon: 'download' },
-         { ariaLabel: 'Search', icon: 'search', type: 'disabled' },
-         { ariaLabel: 'Add', icon: 'add' }
+         { 'aria-label': 'Download', icon: 'download' },
+         { 'aria-label': 'Search', icon: 'search', type: 'disabled' },
+         { 'aria-label': 'Add', icon: 'add' }
       ]}
       type='base' />
     />

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -11,8 +11,8 @@ const { buttonTypes } = require('../constants/App');
 
 class Button extends React.Component {
   static propTypes = {
+    'aria-label': React.PropTypes.string,
     actionText: React.PropTypes.string,
-    ariaLabel: React.PropTypes.string,
     icon: React.PropTypes.string,
     isActive: React.PropTypes.bool,
     onClick: React.PropTypes.func,
@@ -54,7 +54,7 @@ class Button extends React.Component {
 
     return (
       <button
-        aria-label={this.props.ariaLabel}
+        aria-label={this.props['aria-label']}
         onClick={this.props.type === 'disabled' ? null : this.props.onClick}
         style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}
       >

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -10,7 +10,7 @@ const { buttonTypes } = require('../constants/App');
 class ButtonGroup extends React.Component {
   static propTypes = {
     buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
-      ariaLabel: React.PropTypes.string,
+      'aria-label': React.PropTypes.string,
       icon: React.PropTypes.string,
       onClick: React.PropTypes.func,
       style: React.PropTypes.object,
@@ -40,7 +40,7 @@ class ButtonGroup extends React.Component {
 
           return (
             <Button
-              ariaLabel={button.ariaLabel}
+              aria-label={button['aria-label']}
               icon={button.icon}
               key={i}
               onClick={isDisabled ? null : button.onClick}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,7 +8,7 @@ const StyleConstants = require('../constants/Style');
 
 const Modal = React.createClass({
   propTypes: {
-    ariaLabel: React.PropTypes.string,
+    'aria-label': React.PropTypes.string,
     buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
       actionText: React.PropTypes.string,
       className: React.PropTypes.string,
@@ -39,7 +39,7 @@ const Modal = React.createClass({
 
   getDefaultProps () {
     return {
-      ariaLabel: '',
+      'aria-label': '',
       buttons: [],
       color: StyleConstants.Colors.PRIMARY,
       isRelative: false,
@@ -196,7 +196,7 @@ const Modal = React.createClass({
           >
             {this._renderTitleBar()}
             <div
-              aria-label={this.props.ariaLabel}
+              aria-label={this.props['aria-label']}
               className='mx-modal-content'
               ref={ref => this._modalContent = ref}
               style={Object.assign({}, styles.content, this.props.contentStyle)}

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -25,6 +25,7 @@ const SimpleSelect = React.createClass({
 
   getDefaultProps () {
     return {
+      'aria-label': '',
       scrimClickOnSelect: false,
       hoverColor: StyleConstants.Colors.PRIMARY,
       items: [],


### PR DESCRIPTION
Rename `ariaLabel` to `aria-label` to match React's naming conventions.