### PR TITLE
Luke/class extends conversion src

### DIFF
--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -26,7 +26,7 @@ class Bar extends React.Component {
     y: PropTypes.number
   };
 
-  componentDidMount() {
+  componentDidMount () {
     if (this.props.animationDuration) {
       const transform = this._getTransformWithScale(0);
 
@@ -38,11 +38,11 @@ class Bar extends React.Component {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate (nextProps) {
     return !_isEqual(_omit(nextProps, _functions(nextProps)), _omit(this.props, _functions(this.props)));
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     if (this.props.hovering && this.props.animateOnHover) {
       const transform = this._getTransformWithScale(0.9);
 
@@ -98,7 +98,7 @@ class Bar extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const hasMinBarHeight = this.props.height === 0 && this.props.minBarHeight;
     const divisor = this.props.hasNegative && this.props.hasPositive ? 2 : 1;
 
@@ -185,15 +185,15 @@ class BarChart extends React.Component {
     hasPositive: false
   };
 
-  componentWillMount() {
+  componentWillMount () {
     this._hasPositiveOrNegativeValues();
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate (nextProps, nextState) {
     return !_isEqual(nextProps, this.props) || !_isEqual(nextState, this.state);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     let transform;
 
     if (Object.keys(this.state.hoveringObj).length) {
@@ -316,7 +316,7 @@ class BarChart extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const styles = _merge({}, this.styles(), this.props.style);
     const { height, margin, width } = this.props;
     const widthMargin = width - margin.left - margin.right;

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -7,8 +7,8 @@ const _functions = require('lodash/functions');
 
 const StyleConstants = require('../constants/Style');
 
-const Bar = React.createClass({
-  propTypes: {
+class Bar extends React.Component {
+  static propTypes = {
     animateOnHover: PropTypes.bool,
     animationDuration: PropTypes.number,
     hasNegative: PropTypes.bool,
@@ -24,9 +24,9 @@ const Bar = React.createClass({
     width: PropTypes.number,
     x: PropTypes.number,
     y: PropTypes.number
-  },
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     if (this.props.animationDuration) {
       const transform = this._getTransformWithScale(0);
 
@@ -36,13 +36,13 @@ const Bar = React.createClass({
         .duration(this.props.animationDuration)
         .attr('transform', 'scale(1)');
     }
-  },
+  }
 
-  shouldComponentUpdate (nextProps) {
+  shouldComponentUpdate(nextProps) {
     return !_isEqual(_omit(nextProps, _functions(nextProps)), _omit(this.props, _functions(this.props)));
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     if (this.props.hovering && this.props.animateOnHover) {
       const transform = this._getTransformWithScale(0.9);
 
@@ -54,18 +54,18 @@ const Bar = React.createClass({
           .duration(100)
           .attr('transform', 'scale(1)');
     }
-  },
+  }
 
-  _getTransformWithScale (factor) {
+  _getTransformWithScale = (factor) => {
     const centerX = 0;
     const centerY = (this.props.value > 0) ? this.props.y + this.props.height : this.props.y;
     const sx = -centerX * (factor - 1);
     const sy = -centerY * (factor - 1);
 
     return `translate(${sx},${sy}) scale(1, ${factor})`;
-  },
+  };
 
-  _drawPath ({ x, y, width, height, value, radius }) {
+  _drawPath = ({ x, y, width, height, value, radius }) => {
     if (value > 0 || (value === 0 && !this.props.hasNegative)) {
       return 'M' + x + ',' + y +
          'h' + (width - radius) +
@@ -96,9 +96,9 @@ const Bar = React.createClass({
          'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius +
          'Z';
     }
-  },
+  };
 
-  render () {
+  render() {
     const hasMinBarHeight = this.props.height === 0 && this.props.minBarHeight;
     const divisor = this.props.hasNegative && this.props.hasPositive ? 2 : 1;
 
@@ -132,10 +132,10 @@ const Bar = React.createClass({
       />
     );
   }
-});
+}
 
-const BarChart = React.createClass({
-  propTypes: {
+class BarChart extends React.Component {
+  static propTypes = {
     animateOnHover: PropTypes.bool,
     barRadius: PropTypes.number,
     data: PropTypes.array.isRequired,
@@ -157,47 +157,43 @@ const BarChart = React.createClass({
     width: PropTypes.number,
     xAxis: PropTypes.element,
     yAxis: PropTypes.element
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      animateOnHover: false,
-      barRadius: 3,
-      height: 300,
-      margin: {
-        top: 20,
-        right: 20,
-        bottom: 40,
-        left: 20
-      },
-      minBarHeight: 0,
-      onClick: () => {},
-      onHover: () => {},
-      style: {},
-      tooltipFormat: (val) => val,
-      width: 500,
-      showTooltips: true
-    };
-  },
+  static defaultProps = {
+    animateOnHover: false,
+    barRadius: 3,
+    height: 300,
+    margin: {
+      top: 20,
+      right: 20,
+      bottom: 40,
+      left: 20
+    },
+    minBarHeight: 0,
+    onClick: () => {},
+    onHover: () => {},
+    style: {},
+    tooltipFormat: (val) => val,
+    width: 500,
+    showTooltips: true
+  };
 
-  getInitialState () {
-    return {
-      hoveringObj: {},
-      clickedData: this.props.initialSelectedData || {},
-      hasNegative: false,
-      hasPositive: false
-    };
-  },
+  state = {
+    hoveringObj: {},
+    clickedData: this.props.initialSelectedData || {},
+    hasNegative: false,
+    hasPositive: false
+  };
 
-  componentWillMount () {
+  componentWillMount() {
     this._hasPositiveOrNegativeValues();
-  },
+  }
 
-  shouldComponentUpdate (nextProps, nextState) {
+  shouldComponentUpdate(nextProps, nextState) {
     return !_isEqual(nextProps, this.props) || !_isEqual(nextState, this.state);
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     let transform;
 
     if (Object.keys(this.state.hoveringObj).length) {
@@ -211,9 +207,9 @@ const BarChart = React.createClass({
 
     d3.select(this.tooltip)
       .attr('transform', transform);
-  },
+  }
 
-  _hasPositiveOrNegativeValues () {
+  _hasPositiveOrNegativeValues = () => {
     let hasNegative = false;
     let hasPositive = false;
 
@@ -230,9 +226,9 @@ const BarChart = React.createClass({
       hasNegative,
       hasPositive
     });
-  },
+  };
 
-  _handleMouseOver (x, y, width, height, data) {
+  _handleMouseOver = (x, y, width, height, data) => {
     this.setState({
       hoveringObj: {
         x,
@@ -245,23 +241,23 @@ const BarChart = React.createClass({
     });
 
     this.props.onHover(data);
-  },
+  };
 
-  _handleMouseOut () {
+  _handleMouseOut = () => {
     this.setState({
       hoveringObj: {}
     });
-  },
+  };
 
-  _handleOnClick (data) {
+  _handleOnClick = (data) => {
     this.setState({
       clickedData: data
     });
 
     this.props.onClick(data);
-  },
+  };
 
-  _getTooltipX () {
+  _getTooltipX = () => {
     if (Object.keys(this.state.hoveringObj).length) {
       const margin = this.props.margin;
       const bb = this.tooltip.getBBox();
@@ -274,9 +270,9 @@ const BarChart = React.createClass({
       return hoverCX - tooltipCX;
     }
     return -1000;
-  },
+  };
 
-  _getTooltipY () {
+  _getTooltipY = () => {
     if (Object.keys(this.state.hoveringObj).length) {
       const margin = this.props.margin;
       const negativeValue = this.state.hoveringObj.value < 0;
@@ -300,9 +296,9 @@ const BarChart = React.createClass({
       }
     }
     return -1000;
-  },
+  };
 
-  _getHeight (baseHeight) {
+  _getHeight = (baseHeight) => {
     if (this.props.minBarHeight) {
       const adjuster = this.props.barRadius > this.props.minBarHeight ? this.props.barRadius : this.props.minBarHeight;
 
@@ -310,17 +306,17 @@ const BarChart = React.createClass({
     } else {
       return baseHeight;
     }
-  },
+  };
 
-  _getRadius (d) {
+  _getRadius = (d) => {
     if (d.value === 0 && this.props.minBarHeight) {
       return Math.min(this.props.barRadius, this.props.minBarHeight);
     } else {
       return this.props.barRadius;
     }
-  },
+  };
 
-  render () {
+  render() {
     const styles = _merge({}, this.styles(), this.props.style);
     const { height, margin, width } = this.props;
     const widthMargin = width - margin.left - margin.right;
@@ -436,9 +432,9 @@ const BarChart = React.createClass({
         </svg>
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       bar: {
         fill: StyleConstants.Colors.FOG
@@ -471,7 +467,7 @@ const BarChart = React.createClass({
         strokeWidth: 1
       }
     };
-  }
-});
+  };
+}
 
 module.exports = BarChart;

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -39,7 +39,7 @@ class DatePickerFullScreen extends React.Component {
     useInputForSelectedDate: true
   };
 
-  componentDidMount() {
+  componentDidMount () {
     window.onkeyup = e => {
       if (e.keyCode === 27) {
         this._handleCloseClick();
@@ -236,7 +236,7 @@ class DatePickerFullScreen extends React.Component {
     showCalendar: false
   };
 
-  render() {
+  render () {
     const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
     let leftNavIconStyle = Object.assign({}, styles.navIcon, styles.navLeft);

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -7,8 +7,8 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const DatePickerFullScreen = React.createClass({
-  propTypes: {
+class DatePickerFullScreen extends React.Component {
+  static propTypes = {
     closeIcon: PropTypes.string,
     closeOnDateSelect: PropTypes.bool,
     defaultDate: PropTypes.number,
@@ -25,41 +25,29 @@ const DatePickerFullScreen = React.createClass({
     style: PropTypes.object,
     title: PropTypes.string,
     useInputForSelectedDate: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      closeIcon: 'close',
-      closeOnDateSelect: false,
-      format: 'MMM D, YYYY',
-      isFixed: false,
-      locale: 'en',
-      onDateSelect () {},
-      showDayBorders: false,
-      title: 'Select A Date',
-      useInputForSelectedDate: true
-    };
-  },
+  static defaultProps = {
+    closeIcon: 'close',
+    closeOnDateSelect: false,
+    format: 'MMM D, YYYY',
+    isFixed: false,
+    locale: 'en',
+    onDateSelect () {},
+    showDayBorders: false,
+    title: 'Select A Date',
+    useInputForSelectedDate: true
+  };
 
-  getInitialState () {
-    return {
-      currentDate: null,
-      inputValue: this._getInputValueByDate(this.props.defaultDate),
-      isValid: true,
-      selectedDate: this.props.defaultDate,
-      showCalendar: false
-    };
-  },
-
-  componentDidMount () {
+  componentDidMount() {
     window.onkeyup = e => {
       if (e.keyCode === 27) {
         this._handleCloseClick();
       }
     };
-  },
+  }
 
-  _getInputValueByDate (date) {
+  _getInputValueByDate = (date) => {
     let inputValue = null;
 
     if (date) {
@@ -73,21 +61,21 @@ const DatePickerFullScreen = React.createClass({
     }
 
     return inputValue;
-  },
+  };
 
-  _getSelectedDate () {
+  _getSelectedDate = () => {
     const selectedDate = this.state.selectedDate;
 
     return selectedDate && moment.unix(selectedDate).isValid() ? this.state.selectedDate : moment().unix();
-  },
+  };
 
-  _handleCloseClick () {
+  _handleCloseClick = () => {
     this.setState({
       showCalendar: false
     });
-  },
+  };
 
-  _handleDateSelect (date) {
+  _handleDateSelect = (date) => {
     if (this.props.closeOnDateSelect) {
       this._handleScrimClick();
     }
@@ -99,9 +87,9 @@ const DatePickerFullScreen = React.createClass({
     });
 
     this.props.onDateSelect(date);
-  },
+  };
 
-  _handleInputBlur (evt) {
+  _handleInputBlur = (evt) => {
     if (evt.target.value.length === 0) {
       this.props.onDateSelect(null);
 
@@ -114,15 +102,15 @@ const DatePickerFullScreen = React.createClass({
         inputValue: moment.unix(this.state.selectedDate).format(this.props.format)
       });
     }
-  },
+  };
 
-  _handleInputChange (evt) {
+  _handleInputChange = (evt) => {
     this.setState({
       inputValue: evt.target.value
     });
-  },
+  };
 
-  _handlePreviousClick () {
+  _handlePreviousClick = () => {
     const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
@@ -131,9 +119,9 @@ const DatePickerFullScreen = React.createClass({
     this.setState({
       currentDate
     });
-  },
+  };
 
-  _handleNextClick () {
+  _handleNextClick = () => {
     const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     let currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
 
@@ -142,21 +130,21 @@ const DatePickerFullScreen = React.createClass({
     this.setState({
       currentDate
     });
-  },
+  };
 
-  _handleScrimClick () {
+  _handleScrimClick = () => {
     this.setState({
       showCalendar: false
     });
-  },
+  };
 
-  _toggleCalendar () {
+  _toggleCalendar = () => {
     this.setState({
       showCalendar: !this.state.showCalendar
     });
-  },
+  };
 
-  _renderMonthTable (currentDate, selectedDate) {
+  _renderMonthTable = (currentDate, selectedDate) => {
     const days = [];
     const startDate = moment(currentDate, this.props.format).startOf('month').startOf('week');
     const endDate = moment(currentDate, this.props.format).endOf('month').endOf('week');
@@ -193,9 +181,9 @@ const DatePickerFullScreen = React.createClass({
     }
 
     return days;
-  },
+  };
 
-  _renderSelectedDate () {
+  _renderSelectedDate = () => {
     if (this.props.useInputForSelectedDate) {
       const hidePlaceholder = this.state.inputValue && this.state.inputValue.length;
 
@@ -226,9 +214,9 @@ const DatePickerFullScreen = React.createClass({
         </div>
       );
     }
-  },
+  };
 
-  _renderTitle (styles) {
+  _renderTitle = (styles) => {
     if (this.props.title) {
       return (
         <div key='title' style={styles.title}>
@@ -238,9 +226,17 @@ const DatePickerFullScreen = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  render () {
+  state = {
+    currentDate: null,
+    inputValue: this._getInputValueByDate(this.props.defaultDate),
+    isValid: true,
+    selectedDate: this.props.defaultDate,
+    showCalendar: false
+  };
+
+  render() {
     const selectedDate = moment.unix(this._getSelectedDate()).locale(this.props.locale);
     const currentDate = this.state.currentDate ? this.state.currentDate.locale(this.props.locale) : selectedDate;
     let leftNavIconStyle = Object.assign({}, styles.navIcon, styles.navLeft);
@@ -314,7 +310,7 @@ const DatePickerFullScreen = React.createClass({
       </div>
     );
   }
-});
+}
 
 const styles = {
   calendarDay: {

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -39,6 +39,18 @@ class DatePickerFullScreen extends React.Component {
     useInputForSelectedDate: true
   };
 
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      currentDate: null,
+      inputValue: this._getInputValueByDate(props.defaultDate),
+      isValid: true,
+      selectedDate: props.defaultDate,
+      showCalendar: false
+    };
+  }
+
   componentDidMount () {
     window.onkeyup = e => {
       if (e.keyCode === 27) {
@@ -226,14 +238,6 @@ class DatePickerFullScreen extends React.Component {
     } else {
       return null;
     }
-  };
-
-  state = {
-    currentDate: null,
-    inputValue: this._getInputValueByDate(this.props.defaultDate),
-    isValid: true,
-    selectedDate: this.props.defaultDate,
-    showCalendar: false
   };
 
   render () {

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -9,8 +9,8 @@ const Column = require('../components/grid/Column');
 const Container = require('../components/grid/Container');
 const Row = require('../components/grid/Row');
 
-const DisplayInput = React.createClass({
-  propTypes: {
+class DisplayInput extends React.Component {
+  static propTypes = {
     childrenStyle: PropTypes.object,
     elementProps: PropTypes.object,
     hint: PropTypes.string,
@@ -25,29 +25,27 @@ const DisplayInput = React.createClass({
       message: PropTypes.string
     }),
     valid: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      elementProps: {},
-      isFocused: false,
-      primaryColor: StyleConstants.Colors.PRIMARY,
-      valid: true
-    };
-  },
+  static defaultProps = {
+    elementProps: {},
+    isFocused: false,
+    primaryColor: StyleConstants.Colors.PRIMARY,
+    valid: true
+  };
 
-  componentWillMount () {
+  componentWillMount() {
     this._labelId = _uniqueId('DI');
     this._inputId = _uniqueId('DI');
-  },
+  }
 
-  _isLargeOrMediumWindowSize () {
+  _isLargeOrMediumWindowSize = () => {
     const windowSize = StyleConstants.getWindowSize();
 
     return windowSize === 'large' || windowSize === 'medium';
-  },
+  };
 
-  render () {
+  render() {
     // Input properties
     const { elementProps } = this.props;
 
@@ -117,9 +115,9 @@ const DisplayInput = React.createClass({
         </Row>
       </Container>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize();
     const wrapperFocus = {
       borderBottom: this.props.valid ? '1px solid ' + this.props.primaryColor : '1px solid ' + StyleConstants.Colors.STRAWBERRY,
@@ -209,7 +207,7 @@ const DisplayInput = React.createClass({
 
       wrapperFocus
     };
-  }
-});
+  };
+}
 
 module.exports = Radium(DisplayInput);

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -34,7 +34,7 @@ class DisplayInput extends React.Component {
     valid: true
   };
 
-  componentWillMount() {
+  componentWillMount () {
     this._labelId = _uniqueId('DI');
     this._inputId = _uniqueId('DI');
   }
@@ -45,7 +45,7 @@ class DisplayInput extends React.Component {
     return windowSize === 'large' || windowSize === 'medium';
   };
 
-  render() {
+  render () {
     // Input properties
     const { elementProps } = this.props;
 

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1467,7 +1467,7 @@ class Icon extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const { elementProps } = this.props;
     const styles = this.styles();
 

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,23 +1,21 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const Icon = React.createClass({
-  propTypes: {
+class Icon extends React.Component {
+  static propTypes = {
     elementProps: PropTypes.object,
     size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     style: PropTypes.object,
     type: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      elementProps: {},
-      size: 24,
-      type: 'accounts'
-    };
-  },
+  static defaultProps = {
+    elementProps: {},
+    size: 24,
+    type: 'accounts'
+  };
 
-  _renderSvg () {
+  _renderSvg = () => {
     switch (this.props.type) {
       case 'accounts':
         return (
@@ -1467,9 +1465,9 @@ const Icon = React.createClass({
       default:
         return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const { elementProps } = this.props;
     const styles = this.styles();
 
@@ -1484,9 +1482,9 @@ const Icon = React.createClass({
         {this._renderSvg()}
       </svg>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: Object.assign({
         width: this.props.size,
@@ -1495,7 +1493,7 @@ const Icon = React.createClass({
         verticalAlign: 'middle'
       }, this.props.style)
     };
-  }
-});
+  };
+}
 
 module.exports = Icon;

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -29,7 +29,7 @@ class Menu extends React.Component {
     hoverItemIndex: null
   };
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps (nextProps) {
     if (!nextProps.isOpen) {
       this.setState({
         hoverItemIndex: null
@@ -77,7 +77,7 @@ class Menu extends React.Component {
     });
   };
 
-  render() {
+  render () {
     const { isOpen, alignItems } = this.props;
     const styles = this.styles();
 

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -5,8 +5,8 @@ const Icon = require('../components/Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const Menu = React.createClass({
-  propTypes: {
+class Menu extends React.Component {
+  static propTypes = {
     alignItems: PropTypes.oneOf(['left', 'right']),
     isOpen: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape({
@@ -16,44 +16,40 @@ const Menu = React.createClass({
     })).isRequired,
     onClick: PropTypes.func,
     primaryColor: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      alignItems: 'left',
-      primaryColor: StyleConstants.Colors.PRIMARY,
-      isOpen: false,
-      onClick: () => {}
-    };
-  },
+  static defaultProps = {
+    alignItems: 'left',
+    primaryColor: StyleConstants.Colors.PRIMARY,
+    isOpen: false,
+    onClick: () => {}
+  };
 
-  getInitialState () {
-    return {
-      hoverItemIndex: null
-    };
-  },
+  state = {
+    hoverItemIndex: null
+  };
 
-  componentWillReceiveProps (nextProps) {
+  componentWillReceiveProps(nextProps) {
     if (!nextProps.isOpen) {
       this.setState({
         hoverItemIndex: null
       });
     }
-  },
+  }
 
-  _handleMouseOver (hoverItemIndex) {
+  _handleMouseOver = (hoverItemIndex) => {
     this.setState({
       hoverItemIndex
     });
-  },
+  };
 
-  _handleMouseOut () {
+  _handleMouseOut = () => {
     this.setState({
       hoverItemIndex: null
     });
-  },
+  };
 
-  _renderItems () {
+  _renderItems = () => {
     const styles = this.styles();
 
     return this.props.items.map((item, index) => {
@@ -79,9 +75,9 @@ const Menu = React.createClass({
         </div>
       );
     });
-  },
+  };
 
-  render () {
+  render() {
     const { isOpen, alignItems } = this.props;
     const styles = this.styles();
 
@@ -104,9 +100,9 @@ const Menu = React.createClass({
         ) : null}
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: {
         display: 'block',
@@ -151,7 +147,7 @@ const Menu = React.createClass({
         top: 3
       }
     };
-  }
-});
+  };
+}
 
 module.exports = Menu;

--- a/src/components/MessageBox.js
+++ b/src/components/MessageBox.js
@@ -24,7 +24,7 @@ class MessageBox extends React.Component {
     });
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/MessageBox.js
+++ b/src/components/MessageBox.js
@@ -5,28 +5,26 @@ const _merge = require('lodash/merge');
 const StyleConstants = require('../constants/Style');
 const Icon = require('../components/Icon');
 
-const MessageBox = React.createClass({
-  propTypes: {
+class MessageBox extends React.Component {
+  static propTypes = {
     children: PropTypes.node,
     color: PropTypes.string,
     icon: PropTypes.string,
     styles: PropTypes.object,
     title: PropTypes.string
-  },
+  };
 
-  getInitialState () {
-    return {
-      isOpen: true
-    };
-  },
+  state = {
+    isOpen: true
+  };
 
-  _toggleMessageBox () {
+  _toggleMessageBox = () => {
     this.setState({
       isOpen: !this.state.isOpen
     });
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -58,9 +56,9 @@ const MessageBox = React.createClass({
 
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return _merge({}, {
       component: {
         color: StyleConstants.Colors.WHITE,
@@ -90,7 +88,7 @@ const MessageBox = React.createClass({
         padding: this.props.children ? StyleConstants.Spacing.SMALL : null
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = MessageBox;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -57,7 +57,7 @@ class Modal extends React.Component {
     showTooltip: false
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._modalContent.focus();
   /*eslint-disable */
     if (this.props.hasOwnProperty('isOpen')) {
@@ -180,7 +180,7 @@ class Modal extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -7,8 +7,8 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const Modal = React.createClass({
-  propTypes: {
+class Modal extends React.Component {
+  static propTypes = {
     'aria-label': PropTypes.string,
     buttons: PropTypes.arrayOf(PropTypes.shape({
       actionText: PropTypes.string,
@@ -36,47 +36,43 @@ const Modal = React.createClass({
     tooltip: PropTypes.string,
     tooltipLabel: PropTypes.string,
     tooltipTitle: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      'aria-label': '',
-      buttons: [],
-      color: StyleConstants.Colors.PRIMARY,
-      isRelative: false,
-      showCloseIcon: true,
-      showFooter: false,
-      showScrim: true,
-      showTitleBar: false,
-      title: '',
-      tooltip: null,
-      tooltipLabel: '',
-      tooltipTitle: null
-    };
-  },
+  static defaultProps = {
+    'aria-label': '',
+    buttons: [],
+    color: StyleConstants.Colors.PRIMARY,
+    isRelative: false,
+    showCloseIcon: true,
+    showFooter: false,
+    showScrim: true,
+    showTitleBar: false,
+    title: '',
+    tooltip: null,
+    tooltipLabel: '',
+    tooltipTitle: null
+  };
 
-  getInitialState () {
-    return {
-      showTooltip: false
-    };
-  },
+  state = {
+    showTooltip: false
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._modalContent.focus();
   /*eslint-disable */
     if (this.props.hasOwnProperty('isOpen')) {
       console.warn('WARNING: The prop "isOpen" is deprecated in this version of the component. Please handle Modal opening from its parent.');
     }
   /*eslint-enable */
-  },
+  }
 
-  _handleTooltipToggle (show) {
+  _handleTooltipToggle = (show) => {
     this.setState({
       showTooltip: show
     });
-  },
+  };
 
-  _renderTitleBar () {
+  _renderTitleBar = () => {
     if (this.props.showTitleBar) {
       const styles = this.styles();
 
@@ -88,9 +84,9 @@ const Modal = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  _renderFooter () {
+  _renderFooter = () => {
     if (this.props.showFooter) {
       const styles = this.styles();
 
@@ -122,9 +118,9 @@ const Modal = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  _renderFooterContent () {
+  _renderFooterContent = () => {
     const styles = this.styles();
 
     return (
@@ -132,9 +128,9 @@ const Modal = React.createClass({
         {this.props.footerContent}
       </div>
     );
-  },
+  };
 
-  _renderTooltip () {
+  _renderTooltip = () => {
     if (this.state.showTooltip) {
       const styles = this.styles();
 
@@ -151,9 +147,9 @@ const Modal = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  _renderTooltipIconAndLabel () {
+  _renderTooltipIconAndLabel = () => {
     if (this.props.tooltip) {
       const styles = this.styles();
 
@@ -182,9 +178,9 @@ const Modal = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -226,9 +222,9 @@ const Modal = React.createClass({
         </div>
       </FocusTrap>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       scrim: {
         zIndex: 1000,
@@ -333,7 +329,7 @@ const Modal = React.createClass({
         textAlign: 'center'
       }
     };
-  }
-});
+  };
+}
 
 module.exports = Modal;

--- a/src/components/NotifyOnScrollThreshold.js
+++ b/src/components/NotifyOnScrollThreshold.js
@@ -2,29 +2,25 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const _throttle = require('lodash/throttle');
 
-const NotifyOnScrollThreshold = React.createClass({
-  propTypes: {
+class NotifyOnScrollThreshold extends React.Component {
+  static propTypes = {
     children: PropTypes.func.isRequired,
     onThresholdMet: PropTypes.func,
     threshold: PropTypes.number // Number between 0 and 1 representing 0 to 100%
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      onThresholdMet: () => {},
-      threshold: 0.9
-    };
-  },
+  static defaultProps = {
+    onThresholdMet: () => {},
+    threshold: 0.9
+  };
 
-  getInitialState () {
-    return {
-      scrollHeight: 0,
-      scrollPosition: 0,
-      thresholdMet: false
-    };
-  },
+  state = {
+    scrollHeight: 0,
+    scrollPosition: 0,
+    thresholdMet: false
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._handleScroll = _throttle(this._handleScroll, 200);
 
     this.container.parentElement.addEventListener('scroll', this._handleScroll);
@@ -35,13 +31,13 @@ const NotifyOnScrollThreshold = React.createClass({
         thresholdMet: true
       });
     }
-  },
+  }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.container.parentElement.removeEventListener('scroll', this._handleScroll);
-  },
+  }
 
-  _handleScroll (evt) {
+  _handleScroll = (evt) => {
     const element = evt.target;
     const heightDifference = element.scrollHeight - element.clientHeight;
     const position = element.scrollTop / heightDifference;
@@ -55,15 +51,15 @@ const NotifyOnScrollThreshold = React.createClass({
         thresholdMet
       }, this.props.onThresholdMet);
     }
-  },
+  };
 
-  render () {
+  render() {
     return (
       <div ref={(ref) => this.container = ref}>
         {this.props.children(this.state.thresholdMet, this.state.scrollPosition, this.state.scrollHeight)}
       </div>
     );
   }
-});
+}
 
 module.exports = NotifyOnScrollThreshold;

--- a/src/components/NotifyOnScrollThreshold.js
+++ b/src/components/NotifyOnScrollThreshold.js
@@ -20,7 +20,7 @@ class NotifyOnScrollThreshold extends React.Component {
     thresholdMet: false
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._handleScroll = _throttle(this._handleScroll, 200);
 
     this.container.parentElement.addEventListener('scroll', this._handleScroll);
@@ -33,7 +33,7 @@ class NotifyOnScrollThreshold extends React.Component {
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     this.container.parentElement.removeEventListener('scroll', this._handleScroll);
   }
 
@@ -53,7 +53,7 @@ class NotifyOnScrollThreshold extends React.Component {
     }
   };
 
-  render() {
+  render () {
     return (
       <div ref={(ref) => this.container = ref}>
         {this.props.children(this.state.thresholdMet, this.state.scrollPosition, this.state.scrollHeight)}

--- a/src/components/PageIndicator.js
+++ b/src/components/PageIndicator.js
@@ -3,20 +3,20 @@ const React = require('react');
 
 const StyleConstants = require('../constants/Style');
 
-const PageIndicator = React.createClass({
-  propTypes: {
+class PageIndicator extends React.Component {
+  static propTypes = {
     activeIndex: PropTypes.number,
     count: PropTypes.number.isRequired,
     onClick: PropTypes.func
-  },
+  };
 
-  _handleDotClick (index = 0) {
+  _handleDotClick = (index = 0) => {
     if (this.props.onClick) {
       this.props.onClick(index);
     }
-  },
+  };
 
-  _renderDots () {
+  _renderDots = () => {
     const styles = this.styles();
     const dots = [];
 
@@ -29,9 +29,9 @@ const PageIndicator = React.createClass({
     }
 
     return dots;
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -39,9 +39,9 @@ const PageIndicator = React.createClass({
         {this._renderDots()}
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: {
         textAlign: 'center',
@@ -61,7 +61,7 @@ const PageIndicator = React.createClass({
         backgroundColor: StyleConstants.Colors.CHARCOAL
       }
     };
-  }
-});
+  };
+}
 
 module.exports = PageIndicator;

--- a/src/components/PageIndicator.js
+++ b/src/components/PageIndicator.js
@@ -31,7 +31,7 @@ class PageIndicator extends React.Component {
     return dots;
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/PaginationButtons.js
+++ b/src/components/PaginationButtons.js
@@ -7,8 +7,8 @@ const StyleConstants = require('../constants/Style');
 
 const { buttonTypes } = require('../constants/App');
 
-const PaginationButtons = React.createClass({
-  propTypes: {
+class PaginationButtons extends React.Component {
+  static propTypes = {
     currentPage: PropTypes.number.isRequired,
     onClick: PropTypes.func,
     pageRange: PropTypes.number,
@@ -16,19 +16,17 @@ const PaginationButtons = React.createClass({
     style: PropTypes.object,
     totalPages: PropTypes.number.isRequired,
     type: PropTypes.oneOf(buttonTypes)
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      currentPage: 1,
-      pageRange: 9,
-      primaryColor: StyleConstants.Colors.PRIMARY,
-      totalPages: 1,
-      type: 'primaryOutline'
-    };
-  },
+  static defaultProps = {
+    currentPage: 1,
+    pageRange: 9,
+    primaryColor: StyleConstants.Colors.PRIMARY,
+    totalPages: 1,
+    type: 'primaryOutline'
+  };
 
-  _handleButtonClick (buttonClicked) {
+  _handleButtonClick = (buttonClicked) => {
     const { currentPage, totalPages } = this.props;
     let goToPage = buttonClicked;
 
@@ -39,9 +37,9 @@ const PaginationButtons = React.createClass({
     }
 
     this.props.onClick(goToPage);
-  },
+  };
 
-  _getPrevButton () {
+  _getPrevButton = () => {
     const type = this.props.currentPage <= 1 ? 'disabled' : null;
     const style = this.styles().component;
 
@@ -51,9 +49,9 @@ const PaginationButtons = React.createClass({
       style,
       type
     };
-  },
+  };
 
-  _getNextButton () {
+  _getNextButton = () => {
     const type = this.props.currentPage >= this.props.totalPages ? 'disabled' : null;
     const style = this.styles().component;
 
@@ -63,9 +61,9 @@ const PaginationButtons = React.createClass({
       style,
       type
     };
-  },
+  };
 
-  _getStartingPage (currentPage, maxStartingPage, staticSet, startingSet, middleSet) {
+  _getStartingPage = (currentPage, maxStartingPage, staticSet, startingSet, middleSet) => {
     let startingPage = 1;
 
     if (!staticSet && !startingSet) {
@@ -77,9 +75,9 @@ const PaginationButtons = React.createClass({
     }
 
     return startingPage;
-  },
+  };
 
-  _getEndingPage (totalPages, pageRange, startingSet, staticSet, middleSet, startingPage) {
+  _getEndingPage = (totalPages, pageRange, startingSet, staticSet, middleSet, startingPage) => {
     let endingPage = totalPages;
 
     if (!staticSet) {
@@ -91,9 +89,9 @@ const PaginationButtons = React.createClass({
     }
 
     return endingPage;
-  },
+  };
 
-  _addFirstPageButtons () {
+  _addFirstPageButtons = () => {
     const style = this.styles().component;
 
     return [{
@@ -105,9 +103,9 @@ const PaginationButtons = React.createClass({
       style,
       type: 'disabled'
     }];
-  },
+  };
 
-  _addLastPageButtons (totalPages) {
+  _addLastPageButtons = (totalPages) => {
     const style = this.styles().component;
 
     return [{
@@ -119,9 +117,9 @@ const PaginationButtons = React.createClass({
       style,
       text: totalPages.toString()
     }];
-  },
+  };
 
-  _getPageButtons () {
+  _getPageButtons = () => {
     const style = this.styles();
     const { currentPage, pageRange, totalPages } = this.props;
     const pages = [];
@@ -155,9 +153,9 @@ const PaginationButtons = React.createClass({
     }
 
     return pages;
-  },
+  };
 
-  render () {
+  render() {
     return (
       <ButtonGroup
         buttons={[
@@ -168,9 +166,9 @@ const PaginationButtons = React.createClass({
         type={this.props.type}
       />
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: Object.assign({
         padding: '4px 8px',
@@ -180,7 +178,7 @@ const PaginationButtons = React.createClass({
         backgroundColor: StyleConstants.adjustHexOpacity(this.props.primaryColor, 0.15)
       }
     };
-  }
-});
+  };
+}
 
 module.exports = PaginationButtons;

--- a/src/components/PaginationButtons.js
+++ b/src/components/PaginationButtons.js
@@ -155,7 +155,7 @@ class PaginationButtons extends React.Component {
     return pages;
   };
 
-  render() {
+  render () {
     return (
       <ButtonGroup
         buttons={[

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -19,7 +19,7 @@ class ProgressBar extends React.Component {
     progressColor: StyleConstants.Colors.PRIMARY
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -4,24 +4,22 @@ const _merge = require('lodash/merge');
 
 const StyleConstants = require('../constants/Style');
 
-const ProgressBar = React.createClass({
-  propTypes: {
+class ProgressBar extends React.Component {
+  static propTypes = {
     baseColor: PropTypes.string,
     height: PropTypes.number,
     percentage: PropTypes.number,
     progressColor: PropTypes.string,
     styles: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      baseColor: StyleConstants.Colors.FOG,
-      height: 10,
-      progressColor: StyleConstants.Colors.PRIMARY
-    };
-  },
+  static defaultProps = {
+    baseColor: StyleConstants.Colors.FOG,
+    height: 10,
+    progressColor: StyleConstants.Colors.PRIMARY
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -29,9 +27,9 @@ const ProgressBar = React.createClass({
         <div style={styles.progress}>{this.props.children}</div>
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return _merge({}, {
       component: {
         backgroundColor: this.props.baseColor,
@@ -45,7 +43,7 @@ const ProgressBar = React.createClass({
         width: this.props.percentage > 100 ? '100%' : this.props.percentage + '%'
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = ProgressBar;

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -18,7 +18,7 @@ class RadioButton extends React.Component {
     onClick: () => {}
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -3,24 +3,22 @@ const React = require('react');
 
 const StyleConstants = require('../constants/Style');
 
-const RadioButton = React.createClass({
-  propTypes: {
+class RadioButton extends React.Component {
+  static propTypes = {
     activeButtonStyle: PropTypes.object,
     buttonStyle: PropTypes.object,
     checked: PropTypes.bool,
     color: PropTypes.string,
     onClick: PropTypes.func,
     style: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      color: StyleConstants.Colors.PRIMARY,
-      onClick: () => {}
-    };
-  },
+  static defaultProps = {
+    color: StyleConstants.Colors.PRIMARY,
+    onClick: () => {}
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -31,9 +29,9 @@ const RadioButton = React.createClass({
         <div style={styles.children}>{this.props.children}</div>
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: Object.assign({}, {
         cursor: 'pointer',
@@ -58,7 +56,7 @@ const RadioButton = React.createClass({
         backgroundColor: this.props.color
       }, this.props.activeButtonStyle)
     };
-  }
-});
+  };
+}
 
 module.exports = RadioButton;

--- a/src/components/RajaIcon.js
+++ b/src/components/RajaIcon.js
@@ -646,7 +646,7 @@ class RajaIcon extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const { elementProps } = this.props;
     const styles = {
       fill: this.props.style.color,

--- a/src/components/RajaIcon.js
+++ b/src/components/RajaIcon.js
@@ -2,22 +2,20 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
-const RajaIcon = React.createClass({
-  propTypes: {
+class RajaIcon extends React.Component {
+  static propTypes = {
     elementProps: PropTypes.object,
     size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     type: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      elementProps: {},
-      size: 24,
-      type: 'b'
-    };
-  },
+  static defaultProps = {
+    elementProps: {},
+    size: 24,
+    type: 'b'
+  };
 
-  _renderSvg () {
+  _renderSvg = () => {
     switch (this.props.type) {
       case 'about':
         return (
@@ -646,9 +644,9 @@ const RajaIcon = React.createClass({
       default:
         return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const { elementProps } = this.props;
     const styles = {
       fill: this.props.style.color,
@@ -669,6 +667,6 @@ const RajaIcon = React.createClass({
       </svg>
     );
   }
-});
+}
 
 module.exports = Radium(RajaIcon);

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -6,8 +6,8 @@ const _throttle = require('lodash/throttle');
 
 const StyleConstants = require('../constants/Style');
 
-const RangeSelector = React.createClass({
-  propTypes: {
+class RangeSelector extends React.Component {
+  static propTypes = {
     defaultLowerValue: PropTypes.number,
     defaultUpperValue: PropTypes.number,
     formatter: PropTypes.func,
@@ -19,54 +19,53 @@ const RangeSelector = React.createClass({
     selectedColor: PropTypes.string,
     updateOnDrag: PropTypes.bool,
     upperBound: PropTypes.number
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      defaultLowerValue: 0,
-      defaultUpperValue: 1,
-      interval: 1,
-      formatter (value) {
-        return value;
-      },
-      lowerBound: 0,
-      onLowerDragStop () {},
-      onUpperDragStop () {},
-      presets: [],
-      selectedColor: StyleConstants.Colors.PRIMARY,
-      updateOnDrag: false,
-      upperBound: 100
-    };
-  },
+  static defaultProps = {
+    defaultLowerValue: 0,
+    defaultUpperValue: 1,
+    interval: 1,
+    formatter (value) {
+      return value;
+    },
+    lowerBound: 0,
+    onLowerDragStop () {},
+    onUpperDragStop () {},
+    presets: [],
+    selectedColor: StyleConstants.Colors.PRIMARY,
+    updateOnDrag: false,
+    upperBound: 100
+  };
 
-  getInitialState () {
-    const lowerValue = this.props.defaultLowerValue;
-    const upperValue = this.props.defaultUpperValue;
+  constructor(props, context) {
+    super(props, context);
+    const lowerValue = props.defaultLowerValue;
+    const upperValue = props.defaultUpperValue;
 
-    return {
+    this.state = {
       dragging: null,
       lowerPixels: 0,
       lowerValue,
-      range: this.props.upperBound - this.props.lowerBound,
+      range: props.upperBound - props.lowerBound,
       selectedLabel: this._getSelectedLabel(lowerValue, upperValue),
-      showPresets: !!this.props.presets.length && !lowerValue && !upperValue,
+      showPresets: !!props.presets.length && !lowerValue && !upperValue,
       upperPixels: 1,
       upperValue,
       trackClicked: false
     };
-  },
+  }
 
-  componentDidMount () {
+  componentDidMount() {
     this._setDefaultRangeValues();
 
     window.addEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
-  },
+  }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
-  },
+  }
 
-  _getSelectedLabel (lowerValue, upperValue) {
+  _getSelectedLabel = (lowerValue, upperValue) => {
     if (this.props.presets) {
       const preset = this.props.presets.filter(preset => {
         return preset.lowerValue === lowerValue && preset.upperValue === upperValue;
@@ -76,9 +75,9 @@ const RangeSelector = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  _setDefaultRangeValues () {
+  _setDefaultRangeValues = () => {
     const component = ReactDOM.findDOMNode(this.rangeSelectorRef);
     const componentStyles = window.getComputedStyle(component);
     const width = parseInt(componentStyles.width, 0);
@@ -96,9 +95,9 @@ const RangeSelector = React.createClass({
       upperPixels,
       width
     });
-  },
+  };
 
-  _handlePresetClick (preset) {
+  _handlePresetClick = (preset) => {
     //convert our values to a 0-based scale
     const lowerPosition = preset.lowerValue - (this.props.lowerBound);
     const upperPosition = preset.upperValue - (this.props.lowerBound);
@@ -118,15 +117,15 @@ const RangeSelector = React.createClass({
 
     this.props.onLowerDragStop(preset.lowerValue);
     this.props.onUpperDragStop(preset.upperValue);
-  },
+  };
 
-  _handleDragStart (type) {
+  _handleDragStart = (type) => {
     this.setState({
       dragging: type
     });
-  },
+  };
 
-  _handleTrackMouseDown (e) {
+  _handleTrackMouseDown = (e) => {
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const newPixels = clientX - ReactDOM.findDOMNode(this.rangeSelectorRef).getBoundingClientRect().left;
     const updatedState = {
@@ -146,10 +145,10 @@ const RangeSelector = React.createClass({
     }
 
     this.setState(updatedState, this._handleDragging(e));
-  },
+  };
 
   //this method now handles both the dragging of the toggle, and moving it when track is clicked
-  _handleDragging (e) {
+  _handleDragging = (e) => {
     if (this.state.dragging) {
       const clientX = e.touches ? e.touches[0].clientX : e.clientX;
       const pixelInterval = this.props.interval * this.state.width / this.state.range;
@@ -200,9 +199,9 @@ const RangeSelector = React.createClass({
 
       e.preventDefault();
     }
-  },
+  };
 
-  _handleDragEnd (e) {
+  _handleDragEnd = (e) => {
     if (this.state.dragging) {
       if (this.state.trackClicked) {
         this._handleDragging(e);
@@ -217,16 +216,16 @@ const RangeSelector = React.createClass({
         });
       }
     }
-  },
+  };
 
-  _handleToggleViews () {
+  _handleToggleViews = () => {
     this.setState({
       selectedLabel: null,
       showPresets: !this.state.showPresets
     });
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -304,9 +303,9 @@ const RangeSelector = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: {
         position: 'relative',
@@ -422,7 +421,7 @@ const RangeSelector = React.createClass({
         opacity: 0.5
       }
     };
-  }
-});
+  };
+}
 
 module.exports = Radium(RangeSelector);

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -37,7 +37,7 @@ class RangeSelector extends React.Component {
     upperBound: 100
   };
 
-  constructor(props, context) {
+  constructor (props, context) {
     super(props, context);
     const lowerValue = props.defaultLowerValue;
     const upperValue = props.defaultUpperValue;
@@ -55,13 +55,13 @@ class RangeSelector extends React.Component {
     };
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this._setDefaultRangeValues();
 
     window.addEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     window.removeEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
   }
 
@@ -225,7 +225,7 @@ class RangeSelector extends React.Component {
     });
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -24,11 +24,11 @@ class SearchInput extends React.Component {
     placeholder: 'Search'
   };
 
-  componentWillMount() {
+  componentWillMount () {
     StylesUtil.checkForDeprecated(this.props);
   }
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -5,8 +5,8 @@ const Input = require('./SimpleInput');
 
 const StylesUtil = require('../utils/Styles');
 
-const SearchInput = React.createClass({
-  propTypes: {
+class SearchInput extends React.Component {
+  static propTypes = {
     baseColor: PropTypes.string,
     focusOnLoad: PropTypes.bool,
     handleResetClick: PropTypes.func,
@@ -16,21 +16,19 @@ const SearchInput = React.createClass({
     searchKeyword: PropTypes.string,
     style: PropTypes.object,
     styles: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      onBlur: () => {},
-      onChange: () => {},
-      placeholder: 'Search'
-    };
-  },
+  static defaultProps = {
+    onBlur: () => {},
+    onChange: () => {},
+    placeholder: 'Search'
+  };
 
-  componentWillMount () {
+  componentWillMount() {
     StylesUtil.checkForDeprecated(this.props);
-  },
+  }
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -52,16 +50,16 @@ const SearchInput = React.createClass({
         />
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return Object.assign({}, {
       component: {
         display: 'inline-block',
         width: '100%'
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = SearchInput;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -8,8 +8,8 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const Select = React.createClass({
-  propTypes: {
+class Select extends React.Component {
+  static propTypes = {
     dropdownStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     onChange: PropTypes.func,
     options: PropTypes.array,
@@ -22,28 +22,24 @@ const Select = React.createClass({
     selected: PropTypes.object,
     selectedStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     valid: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      primaryColor: StyleConstants.Colors.PRIMARY,
-      onChange () {},
-      options: [],
-      placeholderText: 'Select One',
-      valid: true
-    };
-  },
+  static defaultProps = {
+    primaryColor: StyleConstants.Colors.PRIMARY,
+    onChange () {},
+    options: [],
+    placeholderText: 'Select One',
+    valid: true
+  };
 
-  getInitialState () {
-    return {
-      highlightedValue: null,
-      isOpen: false,
-      selected: false,
-      hoverItem: null
-    };
-  },
+  state = {
+    highlightedValue: null,
+    isOpen: false,
+    selected: false,
+    hoverItem: null
+  };
 
-  getBackgroundColor (option) {
+  getBackgroundColor = (option) => {
     if (option.value === this.state.hoverItem) {
       return {
         backgroundColor: this.props.primaryColor,
@@ -53,23 +49,23 @@ const Select = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  _handleScrimClick () {
+  _handleScrimClick = () => {
     this.setState({
       isOpen: false,
       highlightedValue: null,
       hoverItem: null
     });
-  },
+  };
 
-  _handleClick () {
+  _handleClick = () => {
     this.setState({
       isOpen: !this.state.isOpen
     });
-  },
+  };
 
-  _handleOptionClick (option) {
+  _handleOptionClick = (option) => {
     this.setState({
       selected: option,
       isOpen: false,
@@ -78,23 +74,23 @@ const Select = React.createClass({
     });
 
     this.props.onChange(option);
-  },
+  };
 
-  _handleOptionMouseOver (option) {
+  _handleOptionMouseOver = (option) => {
     this.setState({
       hoverItem: option.value
     });
-  },
+  };
 
-  _handleSelectChange (e) {
+  _handleSelectChange = (e) => {
     const selectedOption = this.props.options.filter(option => {
       return option.value + '' === e.target.value;
     })[0];
 
     this._handleOptionClick(selectedOption);
-  },
+  };
 
-  _handleInputKeyDown (e) {
+  _handleInputKeyDown = (e) => {
     const highlightedValue = this.state.highlightedValue;
 
     if (e.keyCode === 13 && highlightedValue) {
@@ -128,9 +124,9 @@ const Select = React.createClass({
         this._scrollListUp(previousIndex);
       }
     }
-  },
+  };
 
-  _scrollListDown (nextIndex) {
+  _scrollListDown = (nextIndex) => {
     const ul = ReactDOM.findDOMNode(this.optionList);
     const activeLi = ul.children[nextIndex];
     const heightFromTop = nextIndex * activeLi.clientHeight;
@@ -138,9 +134,9 @@ const Select = React.createClass({
     if (heightFromTop > ul.clientHeight) {
       ul.scrollTop = activeLi.offsetTop - activeLi.clientHeight;
     }
-  },
+  };
 
-  _scrollListUp (prevIndex) {
+  _scrollListUp = (prevIndex) => {
     const ul = ReactDOM.findDOMNode(this.optionList);
     const activeLi = ul.children[prevIndex];
     const heightFromBottom = (this.props.options.length - prevIndex) * activeLi.clientHeight;
@@ -148,9 +144,9 @@ const Select = React.createClass({
     if (heightFromBottom > ul.clientHeight) {
       ul.scrollTop = activeLi.offsetTop - activeLi.clientHeight;
     }
-  },
+  };
 
-  _renderScrim () {
+  _renderScrim = () => {
     if (this.state.isOpen) {
       const styles = this.styles();
 
@@ -164,9 +160,9 @@ const Select = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  _renderOptions () {
+  _renderOptions = () => {
     if (this.state.isOpen) {
       const styles = this.styles();
 
@@ -211,9 +207,9 @@ const Select = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
     const selected = this.state.selected || this.props.selected || { displayValue: this.props.placeholderText, value: '' };
 
@@ -244,9 +240,9 @@ const Select = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: Object.assign({},
         {
@@ -326,8 +322,8 @@ const Select = React.createClass({
         left: 0
       }
     };
-  }
-});
+  };
+}
 
 
 module.exports = Radium(Select);

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -209,7 +209,7 @@ class Select extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const styles = this.styles();
     const selected = this.state.selected || this.props.selected || { displayValue: this.props.placeholderText, value: '' };
 

--- a/src/components/SelectFullScreen.js
+++ b/src/components/SelectFullScreen.js
@@ -6,8 +6,8 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const SelectFullScreen = React.createClass({
-  propTypes: {
+class SelectFullScreen extends React.Component {
+  static propTypes = {
     closeIcon: PropTypes.string,
     isFixed: PropTypes.bool,
     onChange: PropTypes.func,
@@ -19,72 +19,68 @@ const SelectFullScreen = React.createClass({
     placeholderText: PropTypes.string,
     selected: PropTypes.object,
     selectedStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      closeIcon: 'close',
-      isFixed: false,
-      onChange () {},
-      optionFormatter (option) {
-        return (
-          <div key={option.displayValue + option.value + '_value'} style={styles.option}>
-            {option.displayValue}
-          </div>
-        );
-      },
-      options: [],
-      optionsHeaderText: 'Select An Option',
-      placeholderText: 'Select One',
-      selected: false
-    };
-  },
+  static defaultProps = {
+    closeIcon: 'close',
+    isFixed: false,
+    onChange () {},
+    optionFormatter (option) {
+      return (
+        <div key={option.displayValue + option.value + '_value'} style={styles.option}>
+          {option.displayValue}
+        </div>
+      );
+    },
+    options: [],
+    optionsHeaderText: 'Select An Option',
+    placeholderText: 'Select One',
+    selected: false
+  };
 
-  getInitialState () {
-    return {
-      isOpen: false,
-      selected: false
-    };
-  },
+  state = {
+    isOpen: false,
+    selected: false
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     window.onkeyup = e => {
       if (e.keyCode === 27) {
         this._handleCloseClick();
       }
     };
-  },
+  }
 
-  _handleClick () {
+  _handleClick = () => {
     this.setState({
       isOpen: true
     });
-  },
+  };
 
-  _handleCloseClick () {
+  _handleCloseClick = () => {
     this.setState({
       isOpen: false
     });
-  },
+  };
 
-  _handleOptionClick (option) {
+  _handleOptionClick = (option) => {
     this.setState({
       selected: option,
       isOpen: false
     });
 
     this.props.onChange(option);
-  },
+  };
 
-  _handleSelectChange (e) {
+  _handleSelectChange = (e) => {
     const selectedOption = this.props.options.filter(option => {
       return option.value + '' === e.target.value;
     })[0];
 
     this._handleOptionClick(selectedOption);
-  },
+  };
 
-  _renderOptions () {
+  _renderOptions = () => {
     if (this.state.isOpen) {
       return (
         <div style={[styles.optionsScrim, this.props.isFixed && { position: 'fixed' }]}>
@@ -119,9 +115,9 @@ const SelectFullScreen = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const selected = this.state.selected || this.props.selected || { displayValue: this.props.placeholderText, value: '' };
 
     return (
@@ -138,7 +134,7 @@ const SelectFullScreen = React.createClass({
       </div>
     );
   }
-});
+}
 
 const styles = {
   close: {

--- a/src/components/SelectFullScreen.js
+++ b/src/components/SelectFullScreen.js
@@ -43,7 +43,7 @@ class SelectFullScreen extends React.Component {
     selected: false
   };
 
-  componentDidMount() {
+  componentDidMount () {
     window.onkeyup = e => {
       if (e.keyCode === 27) {
         this._handleCloseClick();
@@ -117,7 +117,7 @@ class SelectFullScreen extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const selected = this.state.selected || this.props.selected || { displayValue: this.props.placeholderText, value: '' };
 
     return (

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -8,8 +8,8 @@ const StyleConstants = require('../constants/Style');
 
 const StylesUtil = require('../utils/Styles');
 
-const Input = React.createClass({
-  propTypes: {
+class Input extends React.Component {
+  static propTypes = {
     baseColor: PropTypes.string,
     elementProps: PropTypes.object,
     focusOnLoad: PropTypes.bool,
@@ -24,49 +24,45 @@ const Input = React.createClass({
     styles: PropTypes.object,
     type: PropTypes.string,
     valid: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      baseColor: StyleConstants.Colors.PRIMARY,
-      elementProps: {},
-      focusOnLoad: false,
-      type: 'text',
-      valid: true
-    };
-  },
+  static defaultProps = {
+    baseColor: StyleConstants.Colors.PRIMARY,
+    elementProps: {},
+    focusOnLoad: false,
+    type: 'text',
+    valid: true
+  };
 
-  getInitialState () {
-    return {
-      focus: false
-    };
-  },
+  state = {
+    focus: false
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     StylesUtil.checkForDeprecated(this.props);
 
     if (this.props.focusOnLoad && this.input) {
       this.input.focus();
     }
-  },
+  }
 
-  _onFocus (e) {
+  _onFocus = (e) => {
     this.setState({
       focus: true
     });
 
     if (this.props.elementProps.onFocus) this.props.elementProps.onFocus(e);
-  },
+  };
 
-  _onBlur (e) {
+  _onBlur = (e) => {
     this.setState({
       focus: false
     });
 
     if (this.props.elementProps.onBlur) this.props.elementProps.onBlur(e);
-  },
+  };
 
-  render () {
+  render() {
     const { elementProps } = this.props;
     const styles = this.styles();
 
@@ -97,9 +93,9 @@ const Input = React.createClass({
         ) : null}
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return _merge({}, {
       wrapper: Object.assign({}, {
         padding: StyleConstants.Spacing.SMALL,
@@ -135,7 +131,7 @@ const Input = React.createClass({
         boxShadow: 'none'
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = Input;

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -38,7 +38,7 @@ class Input extends React.Component {
     focus: false
   };
 
-  componentDidMount() {
+  componentDidMount () {
     StylesUtil.checkForDeprecated(this.props);
 
     if (this.props.focusOnLoad && this.input) {
@@ -62,7 +62,7 @@ class Input extends React.Component {
     if (this.props.elementProps.onBlur) this.props.elementProps.onBlur(e);
   };
 
-  render() {
+  render () {
     const { elementProps } = this.props;
     const styles = this.styles();
 

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -9,8 +9,8 @@ const { Listbox, Option } = require('./accessibility/Listbox');
 
 const StyleConstants = require('../constants/Style');
 
-const SimpleSelect = React.createClass({
-  propTypes: {
+class SimpleSelect extends React.Component {
+  static propTypes = {
     'aria-label': PropTypes.string,
     hoverColor: PropTypes.string,
     iconSize: PropTypes.number,
@@ -22,19 +22,17 @@ const SimpleSelect = React.createClass({
     scrimClickOnSelect: PropTypes.bool,
     style: PropTypes.object,
     styles: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      'aria-label': '',
-      scrimClickOnSelect: false,
-      hoverColor: StyleConstants.Colors.PRIMARY,
-      items: [],
-      onScrimClick () {}
-    };
-  },
+  static defaultProps = {
+    'aria-label': '',
+    scrimClickOnSelect: false,
+    hoverColor: StyleConstants.Colors.PRIMARY,
+    items: [],
+    onScrimClick () {}
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('keydown', this._handleKeyDown);
 
     if (this.props.style) {
@@ -48,28 +46,28 @@ const SimpleSelect = React.createClass({
     if (this.props.menuStyles) {
       console.warn('The menuStyles prop is deprecated and will be removed in a future release. Please use styles.');
     }
-  },
+  }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('keydown', this._handleKeyDown);
-  },
+  }
 
-  _handleItemClick (item, e) {
+  _handleItemClick = (item, e) => {
     if (this.props.scrimClickOnSelect) {
       this.props.onScrimClick(e);
     }
 
     item.onClick(e, item);
-  },
+  };
 
-  _handleKeyDown (e) {
+  _handleKeyDown = (e) => {
     if (keycode(e) === 'esc') {
       e.preventDefault();
       this.props.onScrimClick();
     }
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -101,9 +99,9 @@ const SimpleSelect = React.createClass({
         <div onClick={this.props.onScrimClick} style={styles.scrim} />
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return _merge({}, {
       component: Object.assign({
         height: 0,
@@ -156,7 +154,7 @@ const SimpleSelect = React.createClass({
         zIndex: 9
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = Radium(SimpleSelect);

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -32,7 +32,7 @@ class SimpleSelect extends React.Component {
     onScrimClick () {}
   };
 
-  componentDidMount() {
+  componentDidMount () {
     window.addEventListener('keydown', this._handleKeyDown);
 
     if (this.props.style) {
@@ -48,7 +48,7 @@ class SimpleSelect extends React.Component {
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     window.removeEventListener('keydown', this._handleKeyDown);
   }
 
@@ -67,7 +67,7 @@ class SimpleSelect extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/SimpleSlider.js
+++ b/src/components/SimpleSlider.js
@@ -7,47 +7,43 @@ const browser = require('bowser');
 
 const StyleConstants = require('../constants/Style');
 
-const SimpleSlider = React.createClass({
-  propTypes: {
+class SimpleSlider extends React.Component {
+  static propTypes = {
     disabled: PropTypes.bool,
     onPercentChange: PropTypes.func.isRequired,
     percent: PropTypes.number.isRequired,
     selectedColor: PropTypes.string,
     styles: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      disabled: false,
-      selectedColor: StyleConstants.Colors.PRIMARY
-    };
-  },
+  static defaultProps = {
+    disabled: false,
+    selectedColor: StyleConstants.Colors.PRIMARY
+  };
 
-  getInitialState () {
-    return {
-      dragging: false,
-      leftPixels: 0,
-      width: 0
-    };
-  },
+  state = {
+    dragging: false,
+    leftPixels: 0,
+    width: 0
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     const component = ReactDOM.findDOMNode(this.rangeSelectorRef);
     const width = component.clientWidth;
     const leftPixels = this.props.percent * width;
 
     this.setState({ width, leftPixels });
-  },
+  }
 
-  componentWillReceiveProps (newProps) {
+  componentWillReceiveProps(newProps) {
     if (this.props.percent !== newProps.percent) {
       const leftPixels = newProps.percent * this.state.width;
 
       this.setState({ leftPixels });
     }
-  },
+  }
 
-  _getCursorStyle () {
+  _getCursorStyle = () => {
     if (this.props.disabled) {
       return 'not-allowed';
     } else if (browser.msie) {
@@ -55,9 +51,9 @@ const SimpleSlider = React.createClass({
     } else {
       return this.state.dragging ? 'grabbing' : 'grab';
     }
-  },
+  };
 
-  _handleMouseEvents (e) {
+  _handleMouseEvents = (e) => {
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const leftSpace = ReactDOM.findDOMNode(this.rangeSelectorRef).getBoundingClientRect().left;
     let currentPercent = (clientX - leftSpace) / this.state.width;
@@ -69,27 +65,27 @@ const SimpleSlider = React.createClass({
     }
 
     this.props.onPercentChange(currentPercent);
-  },
+  };
 
-  _handleDragStart () {
+  _handleDragStart = () => {
     this.setState({
       dragging: true
     });
-  },
+  };
 
-  _handleDragging (e) {
+  _handleDragging = (e) => {
     if (this.state.dragging) {
       this._handleMouseEvents(e);
     }
-  },
+  };
 
-  _handleDragEnd () {
+  _handleDragEnd = () => {
     this.setState({
       dragging: false
     });
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
     const { disabled } = this.props;
 
@@ -121,9 +117,9 @@ const SimpleSlider = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     const cursorStyle = this._getCursorStyle();
 
     return _merge({}, {
@@ -168,7 +164,7 @@ const SimpleSlider = React.createClass({
         zIndex: 1
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = Radium(SimpleSlider);

--- a/src/components/SimpleSlider.js
+++ b/src/components/SimpleSlider.js
@@ -27,7 +27,7 @@ class SimpleSlider extends React.Component {
     width: 0
   };
 
-  componentDidMount() {
+  componentDidMount () {
     const component = ReactDOM.findDOMNode(this.rangeSelectorRef);
     const width = component.clientWidth;
     const leftPixels = this.props.percent * width;
@@ -35,7 +35,7 @@ class SimpleSlider extends React.Component {
     this.setState({ width, leftPixels });
   }
 
-  componentWillReceiveProps(newProps) {
+  componentWillReceiveProps (newProps) {
     if (this.props.percent !== newProps.percent) {
       const leftPixels = newProps.percent * this.state.width;
 
@@ -85,7 +85,7 @@ class SimpleSlider extends React.Component {
     });
   };
 
-  render() {
+  render () {
     const styles = this.styles();
     const { disabled } = this.props;
 

--- a/src/components/Spin.js
+++ b/src/components/Spin.js
@@ -14,7 +14,7 @@ class Spin extends React.Component {
     speed: 1000
   };
 
-  componentDidMount() {
+  componentDidMount () {
     const el = ReactDOM.findDOMNode(this);
     const speed = this.props.speed;
     const spinDirection = this.props.direction === 'clockwise' ? -1 : 1;
@@ -31,7 +31,7 @@ class Spin extends React.Component {
     }, speed / 360);
   }
 
-  render() {
+  render () {
     return (
       <div className='mx-spin' style={{ display: 'inline-block' }}>
         {this.props.children}

--- a/src/components/Spin.js
+++ b/src/components/Spin.js
@@ -2,21 +2,19 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
-const Spin = React.createClass({
-  propTypes: {
+class Spin extends React.Component {
+  static propTypes = {
     children: PropTypes.node,
     direction: PropTypes.oneOf(['counterclockwise', 'clockwise']),
     speed: PropTypes.number //milliseconds, time it takes to make 1 full rotation
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      direction: 'clockwise',
-      speed: 1000
-    };
-  },
+  static defaultProps = {
+    direction: 'clockwise',
+    speed: 1000
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     const el = ReactDOM.findDOMNode(this);
     const speed = this.props.speed;
     const spinDirection = this.props.direction === 'clockwise' ? -1 : 1;
@@ -31,15 +29,15 @@ const Spin = React.createClass({
         rotation = 0;
       }
     }, speed / 360);
-  },
+  }
 
-  render () {
+  render() {
     return (
       <div className='mx-spin' style={{ display: 'inline-block' }}>
         {this.props.children}
       </div>
     );
   }
-});
+}
 
 module.exports = Spin;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -28,7 +28,7 @@ class Tabs extends React.Component {
     showMenu: false
   };
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps (nextProps) {
     if (nextProps.selectedTab !== this.state.selectedTab) {
       this.setState({
         selectedTab: nextProps.selectedTab
@@ -116,7 +116,7 @@ class Tabs extends React.Component {
     return tabItems;
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -6,8 +6,8 @@ const Icon = require('./Icon');
 const SimpleSelect = require('./SimpleSelect');
 const StyleConstants = require('../constants/Style');
 
-const Tabs = React.createClass({
-  propTypes: {
+class Tabs extends React.Component {
+  static propTypes = {
     activeTabStyles: PropTypes.object,
     brandColor: PropTypes.string,
     onTabSelect: PropTypes.func.isRequired,
@@ -15,53 +15,49 @@ const Tabs = React.createClass({
     showBottomBorder: PropTypes.bool,
     tabs: PropTypes.array.isRequired,
     useTabsInMobile: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      brandColor: StyleConstants.Colors.PRIMARY,
-      showBottomBorder: true,
-      useTabsInMobile: false
-    };
-  },
+  static defaultProps = {
+    brandColor: StyleConstants.Colors.PRIMARY,
+    showBottomBorder: true,
+    useTabsInMobile: false
+  };
 
-  getInitialState () {
-    return {
-      selectedTab: this.props.selectedTab || 0,
-      showMenu: false
-    };
-  },
+  state = {
+    selectedTab: this.props.selectedTab || 0,
+    showMenu: false
+  };
 
-  componentWillReceiveProps (nextProps) {
+  componentWillReceiveProps(nextProps) {
     if (nextProps.selectedTab !== this.state.selectedTab) {
       this.setState({
         selectedTab: nextProps.selectedTab
       });
     }
-  },
+  }
 
-  _toggleMenu () {
+  _toggleMenu = () => {
     this.setState({
       showMenu: !this.state.showMenu
     });
-  },
+  };
 
-  _handleTabClick (selectedTab) {
+  _handleTabClick = (selectedTab) => {
     this.props.onTabSelect(selectedTab);
     this._toggleMenu();
 
     this.setState({
       selectedTab
     });
-  },
+  };
 
-  _isLargeOrMediumWindowSize () {
+  _isLargeOrMediumWindowSize = () => {
     const windowSize = StyleConstants.getWindowSize();
 
     return windowSize === 'medium' || windowSize === 'large';
-  },
+  };
 
-  _renderTabs () {
+  _renderTabs = () => {
     const styles = this.styles();
     const selectedTabStyle = Object.assign({}, styles.activeTab, this.props.activeTabStyles);
 
@@ -78,9 +74,9 @@ const Tabs = React.createClass({
         </span>
       );
     });
-  },
+  };
 
-  _renderTabMenu () {
+  _renderTabMenu = () => {
     const selectedTabName = this.props.tabs[this.state.selectedTab];
     const styles = this.styles();
     const tabItems = this._buildTabItems();
@@ -103,9 +99,9 @@ const Tabs = React.createClass({
         ) : null}
       </div>
     );
-  },
+  };
 
-  _buildTabItems () {
+  _buildTabItems = () => {
     const tabItems = [];
 
     this.props.tabs.map((tab, index) => {
@@ -118,9 +114,9 @@ const Tabs = React.createClass({
     });
 
     return tabItems;
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -136,9 +132,9 @@ const Tabs = React.createClass({
         )}
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       // Block styles
       component: {
@@ -194,7 +190,7 @@ const Tabs = React.createClass({
         width: '100%'
       }
     };
-  }
-});
+  };
+}
 
 module.exports = Radium(Tabs);

--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -5,47 +5,43 @@ const _merge = require('lodash/merge');
 
 const StyleConstants = require('../constants/Style');
 
-const TextArea = React.createClass({
-  propTypes: {
+class TextArea extends React.Component {
+  static propTypes = {
     elementProps: PropTypes.object,
     primaryColor: PropTypes.string,
     rows: PropTypes.number,
     styles: PropTypes.object,
     valid: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      elementProps: {},
-      primaryColor: StyleConstants.Colors.PRIMARY,
-      rows: 5,
-      valid: true
-    };
-  },
+  static defaultProps = {
+    elementProps: {},
+    primaryColor: StyleConstants.Colors.PRIMARY,
+    rows: 5,
+    valid: true
+  };
 
-  getInitialState () {
-    return {
-      focus: false
-    };
-  },
+  state = {
+    focus: false
+  };
 
-  _onFocus () {
+  _onFocus = () => {
     this.textarea.focus();
 
     this.setState({
       focus: true
     });
-  },
+  };
 
-  _onBlur () {
+  _onBlur = () => {
     this.textarea.blur();
 
     this.setState({
       focus: false
     });
-  },
+  };
 
-  render () {
+  render() {
     const { elementProps, rows } = this.props;
     const styles = this.styles();
 
@@ -66,9 +62,9 @@ const TextArea = React.createClass({
         />
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return _merge({}, {
       component: {
         display: 'block'
@@ -96,7 +92,7 @@ const TextArea = React.createClass({
         boxShadow: 'none'
       }
     }, this.props.styles);
-  }
-});
+  };
+}
 
 module.exports = TextArea;

--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -41,7 +41,7 @@ class TextArea extends React.Component {
     });
   };
 
-  render() {
+  render () {
     const { elementProps, rows } = this.props;
     const styles = this.styles();
 

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -143,7 +143,7 @@ class HoveredDataPointGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  render() {
+  render () {
     const { adjustedHeight, hoveredDataPoint, rangeType, translation, xScaleValueFunction, yScaleValueFunction } = this.props;
     const hoveredDataPointXScaleValue = xScaleValueFunction(hoveredDataPoint.x);
     const hoveredDataPointYScaleValue = yScaleValueFunction(hoveredDataPoint.y);
@@ -234,7 +234,7 @@ class TimeBasedLineChart extends React.Component {
     zeroState: <div style={styles.zeroState}>No Data Found</div>
   };
 
-  constructor(props) {
+  constructor (props) {
     super(props);
     const adjustedWidth = props.width - props.margin.right - props.margin.left;
     const adjustedHeight = props.height - props.margin.top - props.margin.bottom;
@@ -245,11 +245,11 @@ class TimeBasedLineChart extends React.Component {
     };
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this._styleChart();
   }
 
-  componentWillReceiveProps(newProps) {
+  componentWillReceiveProps (newProps) {
     if (newProps.height !== null || newProps.width !== null || newProps.margin !== null) {
       const height = newProps.height || this.props.height;
       const width = newProps.width || this.props.width;
@@ -265,7 +265,7 @@ class TimeBasedLineChart extends React.Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._styleChart();
   }
 
@@ -506,7 +506,7 @@ class TimeBasedLineChart extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const { breakPointDate, breakPointLabel, data, height, lineColor, margin, rangeType, shadeBelowZero, shadeFutureOnGraph, showBreakPoint, showZeroLine, width, zeroState, yAxisFormatter } = this.props;
     const { adjustedHeight, adjustedWidth, hoveredDataPoint } = this.state;
 

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -129,23 +129,21 @@ const styles = {
   }
 };
 
-const HoveredDataPointGroup = React.createClass({
-  propTypes: {
+class HoveredDataPointGroup extends React.Component {
+  static propTypes = {
     adjustedHeight: PropTypes.number.isRequired,
     hoveredDataPoint: PropTypes.object.isRequired,
     rangeType: PropTypes.string.isRequired,
     translation: PropTypes.string,
     xScaleValueFunction: PropTypes.func.isRequired,
     yScaleValueFunction: PropTypes.func.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    translation: 'translate(0,0)'
+  };
 
-  render () {
+  render() {
     const { adjustedHeight, hoveredDataPoint, rangeType, translation, xScaleValueFunction, yScaleValueFunction } = this.props;
     const hoveredDataPointXScaleValue = xScaleValueFunction(hoveredDataPoint.x);
     const hoveredDataPointYScaleValue = yScaleValueFunction(hoveredDataPoint.y);
@@ -194,11 +192,11 @@ const HoveredDataPointGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 // Main Component
-const TimeBasedLineChart = React.createClass({
-  propTypes: {
+class TimeBasedLineChart extends React.Component {
+  static propTypes = {
     breakPointDate: PropTypes.number,
     breakPointLabel: PropTypes.string,
     data: PropTypes.array.isRequired,
@@ -215,44 +213,43 @@ const TimeBasedLineChart = React.createClass({
     width: PropTypes.number,
     yAxisFormatter: PropTypes.func,
     zeroState: PropTypes.node
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      breakPointDate: moment().startOf('day').unix(),
-      breakPointLabel: 'Today',
-      height: 400,
-      limitLineCircles: false,
-      lineColor: StyleConstants.Colors.PRIMARY,
-      margin: styles.chartMargins,
-      rangeType: 'day',
-      shadeBelowZero: false,
-      shadeFutureOnGraph: true,
-      showBreakPoint: true,
-      showZeroLine: false,
-      width: 550,
-      yAxisFormatter (d) {
-        return numeral(d).format('0.0a');
-      },
-      zeroState: <div style={styles.zeroState}>No Data Found</div>
-    };
-  },
+  static defaultProps = {
+    breakPointDate: moment().startOf('day').unix(),
+    breakPointLabel: 'Today',
+    height: 400,
+    limitLineCircles: false,
+    lineColor: StyleConstants.Colors.PRIMARY,
+    margin: styles.chartMargins,
+    rangeType: 'day',
+    shadeBelowZero: false,
+    shadeFutureOnGraph: true,
+    showBreakPoint: true,
+    showZeroLine: false,
+    width: 550,
+    yAxisFormatter (d) {
+      return numeral(d).format('0.0a');
+    },
+    zeroState: <div style={styles.zeroState}>No Data Found</div>
+  };
 
-  getInitialState () {
-    const adjustedWidth = this.props.width - this.props.margin.right - this.props.margin.left;
-    const adjustedHeight = this.props.height - this.props.margin.top - this.props.margin.bottom;
+  constructor(props) {
+    super(props);
+    const adjustedWidth = props.width - props.margin.right - props.margin.left;
+    const adjustedHeight = props.height - props.margin.top - props.margin.bottom;
 
-    return {
+    this.state = {
       adjustedHeight,
       adjustedWidth
     };
-  },
+  }
 
-  componentDidMount () {
+  componentDidMount() {
     this._styleChart();
-  },
+  }
 
-  componentWillReceiveProps (newProps) {
+  componentWillReceiveProps(newProps) {
     if (newProps.height !== null || newProps.width !== null || newProps.margin !== null) {
       const height = newProps.height || this.props.height;
       const width = newProps.width || this.props.width;
@@ -266,35 +263,35 @@ const TimeBasedLineChart = React.createClass({
         adjustedWidth
       });
     }
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._styleChart();
-  },
+  }
 
-  _yRangeContainsZero () {
+  _yRangeContainsZero = () => {
     const max = d3.max(this.props.data, d => d.y);
     const min = d3.min(this.props.data, d => d.y);
     const tickSpec = ChartUtils.getAxisTickSpecification(min, max);
 
     return tickSpec.min <= 0 && tickSpec.max >= 0;
-  },
+  };
 
   // Handle functions
-  _handleChartMouseLeave () {
+  _handleChartMouseLeave = () => {
     this.setState({
       hoveredDataPoint: null
     });
-  },
+  };
 
-  _handleChartMouseOver (hoveredDataPoint) {
+  _handleChartMouseOver = (hoveredDataPoint) => {
     this.setState({
       hoveredDataPoint
     });
-  },
+  };
 
   // Helper Functions
-  _getDataForLineCircles () {
+  _getDataForLineCircles = () => {
     if (this.props.limitLineCircles) {
       return this.props.data.filter((dataPoint, index) => {
         return index === 0 || index === this.props.data.length - 1 || dataPoint.x === this.props.breakPointDate;
@@ -302,9 +299,9 @@ const TimeBasedLineChart = React.createClass({
     }
 
     return this.props.data;
-  },
+  };
 
-  _getFormattedValue (value, type, format) {
+  _getFormattedValue = (value, type, format) => {
     let formattedValue = '';
 
     switch (type) {
@@ -320,57 +317,57 @@ const TimeBasedLineChart = React.createClass({
     }
 
     return formattedValue;
-  },
+  };
 
   // Translation Helpers
-  _getLineTranslation () {
+  _getLineTranslation = () => {
     return 'translate(' + this.props.margin.left + ', 10)';
-  },
+  };
 
-  _getZeroLabelTranslation () {
+  _getZeroLabelTranslation = () => {
     return 'translate(' + this.props.margin.left + ', 14)';
-  },
+  };
 
-  _getTimeAxisTranslation () {
+  _getTimeAxisTranslation = () => {
     const offSet = 10;
     const x = this.props.margin.left;
     const y = this.props.height - this.props.margin.bottom - offSet;
 
     return 'translate(' + x + ',' + y + ')';
-  },
+  };
 
-  _getVerticalLineTranslation () {
+  _getVerticalLineTranslation = () => {
     return 'translate(' + this.props.margin.left + ', -10)';
-  },
+  };
 
-  _getYAxisTranslation () {
+  _getYAxisTranslation = () => {
     const offSet = 10;
     const y = this.props.margin.top - offSet;
 
     return 'translate(' + this.props.margin.left + ',' + y + ')';
-  },
+  };
 
   // Position Helpers
-  _getSliceWidth () {
+  _getSliceWidth = () => {
     return Math.floor(this.state.adjustedWidth / this.props.data.length);
-  },
+  };
 
-  _getXScaleFunction () {
+  _getXScaleFunction = () => {
     const maxDate = this.props.data[this.props.data.length - 1].x;
     const minDate = this.props.data[0].x;
 
     return d3.time.scale()
       .range([0, this.state.adjustedWidth])
       .domain([minDate, maxDate]);
-  },
+  };
 
-  _getXScaleValue (value) {
+  _getXScaleValue = (value) => {
     const xScale = this._getXScaleFunction();
 
     return xScale(value);
-  },
+  };
 
-  _getYScaleFunction () {
+  _getYScaleFunction = () => {
     const max = d3.max(this.props.data, d => d.y);
     const min = d3.min(this.props.data, d => d.y);
     const tickSpec = ChartUtils.getAxisTickSpecification(min, max);
@@ -378,57 +375,57 @@ const TimeBasedLineChart = React.createClass({
     return d3.scale.linear()
       .range([this.state.adjustedHeight, 0])
       .domain([tickSpec.min, tickSpec.max]);
-  },
+  };
 
-  _getYScaleValue (value) {
+  _getYScaleValue = (value) => {
     const yScale = this._getYScaleFunction();
 
     return yScale(value);
-  },
+  };
 
-  _getShadedRectangleHeight () {
+  _getShadedRectangleHeight = () => {
     const calculatedHeight = this.state.adjustedHeight - this._getShadedRectangleYValue();
 
     return calculatedHeight < 0 ? 0 : calculatedHeight;
-  },
+  };
 
-  _getShadedRectangleWidth () {
+  _getShadedRectangleWidth = () => {
     const calculatedWidth = this.state.adjustedWidth - this._getShadedRectangleXValue();
 
     return calculatedWidth < 0 ? 0 : calculatedWidth;
-  },
+  };
 
-  _getShadedRectangleXValue () {
+  _getShadedRectangleXValue = () => {
     const breakPointXValue = this._getXScaleValue(this.props.breakPointDate);
 
     return breakPointXValue < 0 ? 0 : breakPointXValue;
-  },
+  };
 
-  _getShadedRectangleYValue () {
+  _getShadedRectangleYValue = () => {
     return this._getYScaleValue(0);
-  },
+  };
 
-  _getZeroLabelXValue () {
+  _getZeroLabelXValue = () => {
     const data = this.props.data;
     const maxDate = data.length ? data[data.length - 1].x : 0;
     const offSet = 15;
 
     return this._getXScaleValue(maxDate + this.props.margin.right) + offSet;
-  },
+  };
 
-  _getZeroLabelYValue () {
+  _getZeroLabelYValue = () => {
     return this._getYScaleValue(0);
-  },
+  };
 
-  _getZeroLineData () {
+  _getZeroLineData = () => {
     const data = this.props.data;
     const maxDate = data.length ? data[data.length - 1].x : 0;
     const minDate = data.length ? data[0].x : 0;
 
     return [{ x: minDate, y: 0 }, { x: maxDate, y: 0 }];
-  },
+  };
 
-  _styleChart () {
+  _styleChart = () => {
     const chart = d3.select(this.chart);
 
     // Style x axis labels
@@ -485,10 +482,10 @@ const TimeBasedLineChart = React.createClass({
 
     chart.select('text.zero-line-label')
       .style(styles.zeroLineLabel);
-  },
+  };
 
   // Render functions
-  _renderHoveredDataPointDetails () {
+  _renderHoveredDataPointDetails = () => {
     if (this.props.hoveredDataPointDetails && this.state.hoveredDataPoint) {
       return this.props.hoveredDataPointDetails.map((item, index) => {
         const value = this.state.hoveredDataPoint[item.key];
@@ -507,9 +504,9 @@ const TimeBasedLineChart = React.createClass({
     } else {
       return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const { breakPointDate, breakPointLabel, data, height, lineColor, margin, rangeType, shadeBelowZero, shadeFutureOnGraph, showBreakPoint, showZeroLine, width, zeroState, yAxisFormatter } = this.props;
     const { adjustedHeight, adjustedWidth, hoveredDataPoint } = this.state;
 
@@ -648,6 +645,6 @@ const TimeBasedLineChart = React.createClass({
       </div>
     );
   }
-});
+}
 
 module.exports = Radium(TimeBasedLineChart);

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -32,7 +32,7 @@ class ToggleSwitch extends React.Component {
     this.props.onToggle(event);
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -4,8 +4,8 @@ const Radium = require('radium');
 const StyleConstants = require('../constants/Style');
 const Icon = require('./Icon');
 
-const ToggleSwitch = React.createClass({
-  propTypes: {
+class ToggleSwitch extends React.Component {
+  static propTypes = {
     checked: PropTypes.bool,
     falseIcon: PropTypes.string,
     leftLabel: PropTypes.string,
@@ -15,26 +15,24 @@ const ToggleSwitch = React.createClass({
     showLabels: PropTypes.bool,
     styles: PropTypes.object,
     trueIcon: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      checked: false,
-      falseIcon: 'close-skinny',
-      leftLabel: 'Off',
-      onToggle () {},
-      rightLabel: 'On',
-      showLabels: false,
-      showIcons: true,
-      trueIcon: 'check-skinny'
-    };
-  },
+  static defaultProps = {
+    checked: false,
+    falseIcon: 'close-skinny',
+    leftLabel: 'Off',
+    onToggle () {},
+    rightLabel: 'On',
+    showLabels: false,
+    showIcons: true,
+    trueIcon: 'check-skinny'
+  };
 
-  _handleToggle (event) {
+  _handleToggle = (event) => {
     this.props.onToggle(event);
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -60,9 +58,9 @@ const ToggleSwitch = React.createClass({
         ) : null}
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return Object.assign({}, {
       component: {
         alignItems: 'center',
@@ -123,8 +121,7 @@ const ToggleSwitch = React.createClass({
         backgroundColor: StyleConstants.Colors.ASH
       }
     }, this.props.styles);
-  }
-
-});
+  };
+}
 
 module.exports = Radium(ToggleSwitch);

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -73,7 +73,7 @@ class Tooltip extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const styles = this.styles();
 
     return (

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -5,43 +5,39 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const Tooltip = React.createClass({
-  propTypes: {
+class Tooltip extends React.Component {
+  static propTypes = {
     icon: PropTypes.string,
     iconSize: PropTypes.number,
     placement: PropTypes.oneOf(['left', 'top', 'right', 'bottom']),
     style: PropTypes.object,
     tooltipStyle: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      icon: 'info',
-      iconSize: 20,
-      placement: 'top',
-      tooltipStyle: {}
-    };
-  },
+  static defaultProps = {
+    icon: 'info',
+    iconSize: 20,
+    placement: 'top',
+    tooltipStyle: {}
+  };
 
-  getInitialState () {
-    return {
-      showTooltip: false
-    };
-  },
+  state = {
+    showTooltip: false
+  };
 
-  _handleInfoMouseEnter () {
+  _handleInfoMouseEnter = () => {
     this.setState({
       showTooltip: true
     });
-  },
+  };
 
-  _handleInfoMouseLeave () {
+  _handleInfoMouseLeave = () => {
     this.setState({
       showTooltip: false
     });
-  },
+  };
 
-  _getPosition () {
+  _getPosition = () => {
     const offSet = this.props.iconSize + 5;
     const width = this.props.tooltipStyle.width || 200;
 
@@ -75,9 +71,9 @@ const Tooltip = React.createClass({
       default:
         return null;
     }
-  },
+  };
 
-  render () {
+  render() {
     const styles = this.styles();
 
     return (
@@ -97,9 +93,9 @@ const Tooltip = React.createClass({
         />
       </div>
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       component: Object.assign({}, {
         display: 'inline-block',
@@ -127,7 +123,7 @@ const Tooltip = React.createClass({
         this._getPosition(),
         this.props.tooltipStyle)
     };
-  }
-});
+  };
+}
 
 module.exports = Tooltip;

--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -7,64 +7,60 @@ const Icon = require('./Icon');
 
 const StyleConstants = require('../constants/Style');
 
-const TypeAhead = React.createClass({
-  propTypes: {
+class TypeAhead extends React.Component {
+  static propTypes = {
     items: PropTypes.array,
     onItemRemove: PropTypes.func,
     onItemSelect: PropTypes.func,
     placeholderText: PropTypes.string,
     preSelectedItems: PropTypes.array
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      items: [],
-      onItemRemove () {},
-      onItemSelect () {},
-      placeholderText: 'Select Filters',
-      preSelectedItems: []
-    };
-  },
+  static defaultProps = {
+    items: [],
+    onItemRemove () {},
+    onItemSelect () {},
+    placeholderText: 'Select Filters',
+    preSelectedItems: []
+  };
 
-  getInitialState () {
-    return {
-      highlightedValue: null,
-      isOpen: false,
-      searchString: '',
-      selectedItems: this.props.preSelectedItems
-    };
-  },
+  state = {
+    highlightedValue: null,
+    isOpen: false,
+    searchString: '',
+    selectedItems: this.props.preSelectedItems
+  };
 
-  _getFilteredItems () {
+  _getFilteredItems = () => {
     return this.props.items.filter(item => {
       return this.state.selectedItems.indexOf(item) === -1 &&
              item.toLowerCase().indexOf(this.state.searchString.toLowerCase()) > -1;
     });
-  },
+  };
 
-  _handleBlur () {
+  _handleBlur = () => {
     this.setState({
       highlightedValue: null,
       isOpen: false,
       searchString: ''
     });
-  },
+  };
 
-  _handleFocus () {
+  _handleFocus = () => {
     this.setState({
       isOpen: true
     });
 
     ReactDOM.findDOMNode(this.input).focus();
-  },
+  };
 
-  _handleItemMouseOver () {
+  _handleItemMouseOver = () => {
     this.setState({
       highlightedValue: null
     });
-  },
+  };
 
-  _handleSelectAll () {
+  _handleSelectAll = () => {
     this.props.onItemSelect(null, this.props.items);
 
     this.setState({
@@ -72,9 +68,9 @@ const TypeAhead = React.createClass({
       searchString: '',
       selectedItems: this.props.items
     });
-  },
+  };
 
-  _handleClearAll () {
+  _handleClearAll = () => {
     this.props.onItemSelect(null, []);
 
     this.setState({
@@ -82,9 +78,9 @@ const TypeAhead = React.createClass({
       searchString: '',
       selectedItems: []
     });
-  },
+  };
 
-  _handleItemSelect (item) {
+  _handleItemSelect = (item) => {
     //add to selectedItems
     const selectedItems = this.state.selectedItems;
 
@@ -99,9 +95,9 @@ const TypeAhead = React.createClass({
     });
 
     ReactDOM.findDOMNode(this.input).focus();
-  },
+  };
 
-  _handleItemRemove (item) {
+  _handleItemRemove = (item) => {
     const selectedItems = this.state.selectedItems.filter(selectedItem => {
       return selectedItem !== item;
     });
@@ -113,9 +109,9 @@ const TypeAhead = React.createClass({
     });
 
     ReactDOM.findDOMNode(this.input).focus();
-  },
+  };
 
-  _handleInputKeyDown (e) {
+  _handleInputKeyDown = (e) => {
     const searchString = e.target.value;
     const highlightedValue = this.state.highlightedValue;
     const selectedItems = this.state.selectedItems;
@@ -189,9 +185,9 @@ const TypeAhead = React.createClass({
 
       ReactDOM.findDOMNode(this.input).blur();
     }
-  },
+  };
 
-  _scrollList (nextIndex, scrollDirection) {
+  _scrollList = (nextIndex, scrollDirection) => {
     const filteredItems = this._getFilteredItems();
     const ul = ReactDOM.findDOMNode(this.optionList);
     const skipClearSelectAll = 2;
@@ -214,15 +210,15 @@ const TypeAhead = React.createClass({
         ul.scrollTop = filteredItems.length * activeLi.clientHeight;
       }
     }
-  },
+  };
 
-  _handleInputChange (e) {
+  _handleInputChange = (e) => {
     this.setState({
       searchString: e.target.value
     });
-  },
+  };
 
-  _renderSelectedItems () {
+  _renderSelectedItems = () => {
     return this.state.selectedItems.map((item, index) => {
       return (
         <div className='mx-typeahead-selected' key={index} style={styles.itemTag}>
@@ -237,9 +233,9 @@ const TypeAhead = React.createClass({
           />
         </div>);
     });
-  },
+  };
 
-  _renderItemList () {
+  _renderItemList = () => {
     return (
       <div
         className='mx-typeahead-option-list'
@@ -289,9 +285,9 @@ const TypeAhead = React.createClass({
         })}
       </div>
     );
-  },
+  };
 
-  render () {
+  render() {
     return (
       <div
         className='mx-typeahead'
@@ -320,7 +316,7 @@ const TypeAhead = React.createClass({
       </div>
     );
   }
-});
+}
 
 const styles = {
   component: {

--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -287,7 +287,7 @@ class TypeAhead extends React.Component {
     );
   };
 
-  render() {
+  render () {
     return (
       <div
         className='mx-typeahead'

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -20,47 +20,39 @@ const _findIndex = require('lodash/findIndex');
  *     <Option ...>Bar</Option>
  *   </Listbox>
  */
-const Listbox = React.createClass({
-  propTypes: {
+class Listbox extends React.Component {
+  static propTypes = {
     'aria-label': PropTypes.string.isRequired,
     useGlobalKeyHandler: PropTypes.bool
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      useGlobalKeyHandler: false
-    };
-  },
+  static defaultProps = {
+    useGlobalKeyHandler: false
+  };
 
-  getInitialState () {
-    return {
-      focusedIndex: this._getSelectedOptionIndex()
-    };
-  },
-
-  componentDidMount () {
+  componentDidMount() {
     this._eventTarget = this.props.useGlobalKeyHandler ? window : this.component;
     this._eventTarget.addEventListener('keydown', this._handleKeyDown);
     this._focusOption();
-  },
+  }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this._eventTarget.removeEventListener('keydown', this._handleKeyDown);
-  },
+  }
 
-  _getChildren () {
+  _getChildren = () => {
     return React.Children.toArray(this.props.children);
-  },
+  };
 
-  _getSelectedOptionIndex () {
+  _getSelectedOptionIndex = () => {
     const children = this._getChildren();
     const focusedIndex = _findIndex(children, child => child.props.isSelected);
 
     // default to first
     return focusedIndex === -1 ? 0 : focusedIndex;
-  },
+  };
 
-  _handleKeyDown (e) {
+  _handleKeyDown = (e) => {
     switch (keycode(e)) {
       case 'up':
         e.preventDefault();
@@ -76,30 +68,34 @@ const Listbox = React.createClass({
         e.target.click();
         break;
     }
-  },
+  };
 
-  _focusOption () {
+  _focusOption = () => {
     const option = this.component.children[this.state.focusedIndex];
 
     if (option) setTimeout(() => option.focus());
-  },
+  };
 
-  _focusPrevious () {
+  _focusPrevious = () => {
     // go to the end if at the beginning
     const focusedIndex = this.state.focusedIndex === 0 ? this._getChildren().length : this.state.focusedIndex;
 
     this.setState({ focusedIndex: focusedIndex - 1 }, this._focusOption);
-  },
+  };
 
-  _focusNext () {
+  _focusNext = () => {
     // go to the beginning if at the end
     const focusedIndex = this.state.focusedIndex === this._getChildren().length - 1 ? -1 : this.state.focusedIndex;
 
     // focus next
     this.setState({ focusedIndex: focusedIndex + 1 }, this._focusOption);
-  },
+  };
 
-  render () {
+  state = {
+    focusedIndex: this._getSelectedOptionIndex()
+  };
+
+  render() {
     return (
       <div
         aria-label={this.props['aria-label']}
@@ -116,7 +112,7 @@ const Listbox = React.createClass({
       </div>
     );
   }
-});
+}
 
 /**
  * Option

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -30,6 +30,14 @@ class Listbox extends React.Component {
     useGlobalKeyHandler: false
   };
 
+  constructor () {
+    super();
+
+    this.state = {
+      focusedIndex: this._getSelectedOptionIndex()
+    };
+  }
+
   componentDidMount () {
     this._eventTarget = this.props.useGlobalKeyHandler ? window : this.component;
     this._eventTarget.addEventListener('keydown', this._handleKeyDown);
@@ -89,10 +97,6 @@ class Listbox extends React.Component {
 
     // focus next
     this.setState({ focusedIndex: focusedIndex + 1 }, this._focusOption);
-  };
-
-  state = {
-    focusedIndex: this._getSelectedOptionIndex()
   };
 
   render () {

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -30,13 +30,13 @@ class Listbox extends React.Component {
     useGlobalKeyHandler: false
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._eventTarget = this.props.useGlobalKeyHandler ? window : this.component;
     this._eventTarget.addEventListener('keydown', this._handleKeyDown);
     this._focusOption();
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     this._eventTarget.removeEventListener('keydown', this._handleKeyDown);
   }
 
@@ -95,7 +95,7 @@ class Listbox extends React.Component {
     focusedIndex: this._getSelectedOptionIndex()
   };
 
-  render() {
+  render () {
     return (
       <div
         aria-label={this.props['aria-label']}

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -30,8 +30,8 @@ class Listbox extends React.Component {
     useGlobalKeyHandler: false
   };
 
-  constructor () {
-    super();
+  constructor (props) {
+    super(props);
 
     this.state = {
       focusedIndex: this._getSelectedOptionIndex()

--- a/src/components/d3/AxisGroup.js
+++ b/src/components/d3/AxisGroup.js
@@ -18,11 +18,11 @@ class AxisGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._renderAxis();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._renderAxis();
   }
 
@@ -41,7 +41,7 @@ class AxisGroup extends React.Component {
     d3.select(this.axisGroup).call(axisFunction);
   };
 
-  render() {
+  render () {
     return (
       <g
         className={this.props.axis + '-axis'}

--- a/src/components/d3/AxisGroup.js
+++ b/src/components/d3/AxisGroup.js
@@ -4,31 +4,29 @@ const d3 = require('d3');
 
 const ChartUtils = require('../../utils/Chart');
 
-const AxisGroup = React.createClass({
-  propTypes: {
+class AxisGroup extends React.Component {
+  static propTypes = {
     axis: PropTypes.string.isRequired,
     axisFormatFunction: PropTypes.func.isRequired,
     data: PropTypes.array.isRequired,
     orientation: PropTypes.string.isRequired,
     scaleFunction: PropTypes.func.isRequired,
     translation: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    translation: 'translate(0,0)'
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._renderAxis();
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._renderAxis();
-  },
+  }
 
-  _renderAxis () {
+  _renderAxis = () => {
     const max = d3.max(this.props.data, d => d[this.props.axis]);
     const min = d3.min(this.props.data, d => d[this.props.axis]);
     const { tickValues } = ChartUtils.getAxisTickSpecification(min, max);
@@ -41,9 +39,9 @@ const AxisGroup = React.createClass({
       .tickValues(tickValues);
 
     d3.select(this.axisGroup).call(axisFunction);
-  },
+  };
 
-  render () {
+  render() {
     return (
       <g
         className={this.props.axis + '-axis'}
@@ -52,6 +50,6 @@ const AxisGroup = React.createClass({
       />
     );
   }
-});
+}
 
 module.exports = AxisGroup;

--- a/src/components/d3/BarTimeXAxis.js
+++ b/src/components/d3/BarTimeXAxis.js
@@ -25,11 +25,11 @@ class BarTimeXAxis extends React.Component {
     transform: 'translate(0,0)'
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._renderAxis();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._renderAxis();
   }
 
@@ -60,7 +60,7 @@ class BarTimeXAxis extends React.Component {
       .style(style.path);
   };
 
-  render() {
+  render () {
     return (
       <g
         className='x-bar-time-axis'

--- a/src/components/d3/BarTimeXAxis.js
+++ b/src/components/d3/BarTimeXAxis.js
@@ -7,8 +7,8 @@ const _merge = require('lodash/merge');
 
 const StyleConstants = require('../../constants/Style');
 
-const BarTimeXAxis = React.createClass({
-  propTypes: {
+class BarTimeXAxis extends React.Component {
+  static propTypes = {
     style: PropTypes.object,
     tickRange: PropTypes.array,
     tickSize: PropTypes.number,
@@ -16,26 +16,24 @@ const BarTimeXAxis = React.createClass({
     timeAxisFormat: PropTypes.string.isRequired,
     transform: PropTypes.string,
     xScaleFunction: PropTypes.func.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      style: {},
-      tickSize: 6,
-      tickValues: null,
-      transform: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    style: {},
+    tickSize: 6,
+    tickValues: null,
+    transform: 'translate(0,0)'
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._renderAxis();
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._renderAxis();
-  },
+  }
 
-  _renderAxis () {
+  _renderAxis = () => {
     const timeAxisFunction = d3.svg.axis()
       .scale(this.props.xScaleFunction)
       .tickValues(this.props.tickValues)
@@ -47,9 +45,9 @@ const BarTimeXAxis = React.createClass({
     d3.select(this.timeAxis).call(timeAxisFunction);
 
     this._styleChart();
-  },
+  };
 
-  _styleChart () {
+  _styleChart = () => {
     const style = _merge({}, this.styles(), this.props.style);
     const axis = d3.select(this.timeAxis);
 
@@ -60,9 +58,9 @@ const BarTimeXAxis = React.createClass({
     // Style x axis path
     axis.selectAll('path')
       .style(style.path);
-  },
+  };
 
-  render () {
+  render() {
     return (
       <g
         className='x-bar-time-axis'
@@ -70,9 +68,9 @@ const BarTimeXAxis = React.createClass({
         transform={this.props.transform}
       />
     );
-  },
+  }
 
-  styles () {
+  styles = () => {
     return {
       text: {
         fill: StyleConstants.Colors.ASH,
@@ -86,7 +84,7 @@ const BarTimeXAxis = React.createClass({
         fill: 'none'
       }
     };
-  }
-});
+  };
+}
 
 module.exports = BarTimeXAxis;

--- a/src/components/d3/BreakPointGroup.js
+++ b/src/components/d3/BreakPointGroup.js
@@ -16,7 +16,7 @@ class BreakPointGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  render() {
+  render () {
     const { adjustedHeight, adjustedWidth, breakPointDate, breakPointLabel, margin, translation, xScaleValueFunction } = this.props;
     const breakPointXValue = xScaleValueFunction(breakPointDate);
     const breakPointLabelOffSet = 10;

--- a/src/components/d3/BreakPointGroup.js
+++ b/src/components/d3/BreakPointGroup.js
@@ -1,8 +1,8 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const BreakPointGroup = React.createClass({
-  propTypes: {
+class BreakPointGroup extends React.Component {
+  static propTypes = {
     adjustedHeight: PropTypes.number.isRequired,
     adjustedWidth: PropTypes.number.isRequired,
     breakPointDate: PropTypes.number.isRequired,
@@ -10,15 +10,13 @@ const BreakPointGroup = React.createClass({
     margin: PropTypes.object.isRequired,
     translation: PropTypes.string,
     xScaleValueFunction: PropTypes.func.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    translation: 'translate(0,0)'
+  };
 
-  render () {
+  render() {
     const { adjustedHeight, adjustedWidth, breakPointDate, breakPointLabel, margin, translation, xScaleValueFunction } = this.props;
     const breakPointXValue = xScaleValueFunction(breakPointDate);
     const breakPointLabelOffSet = 10;
@@ -45,6 +43,6 @@ const BreakPointGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 module.exports = BreakPointGroup;

--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -3,8 +3,8 @@ const React = require('react');
 
 const StyleConstants = require('../../constants/Style');
 
-const CirclesGroup = React.createClass({
-  propTypes: {
+class CirclesGroup extends React.Component {
+  static propTypes = {
     adjustedHeight: PropTypes.number.isRequired,
     circleColor: PropTypes.string,
     circleOverlayRadius: PropTypes.number,
@@ -17,38 +17,36 @@ const CirclesGroup = React.createClass({
     useCircleOverlay: PropTypes.bool,
     xScaleValueFunction: PropTypes.func.isRequired,
     yScaleValueFunction: PropTypes.func.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      circleColor: StyleConstants.Colors.CHARCOAL,
-      circleOverlayRadius: 6,
-      circleRadius: 3,
-      onCircleClick: () => {},
-      shouldAnimate: true,
-      strokeWidth: 2,
-      translation: 'translate(0,0)',
-      useCircleOverlay: false
-    };
-  },
+  static defaultProps = {
+    circleColor: StyleConstants.Colors.CHARCOAL,
+    circleOverlayRadius: 6,
+    circleRadius: 3,
+    onCircleClick: () => {},
+    shouldAnimate: true,
+    strokeWidth: 2,
+    translation: 'translate(0,0)',
+    useCircleOverlay: false
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._animateCircles();
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._animateCircles();
-  },
+  }
 
-  _animateCircles () {
+  _animateCircles = () => {
     if (this.props.shouldAnimate) {
       d3.select(this.circleGroup).selectAll('.circle').data(this.props.data).transition().attr('cy', d => {
         return this.props.yScaleValueFunction(d.y);
       });
     }
-  },
+  };
 
-  render () {
+  render() {
     const { adjustedHeight, circleOverlayRadius, circleRadius, data, shouldAnimate, translation, useCircleOverlay, xScaleValueFunction, yScaleValueFunction } = this.props;
     const preventCircleOverlapCutOff = 45;
 
@@ -99,6 +97,6 @@ const CirclesGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 module.exports = CirclesGroup;

--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -30,11 +30,11 @@ class CirclesGroup extends React.Component {
     useCircleOverlay: false
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._animateCircles();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._animateCircles();
   }
 
@@ -46,7 +46,7 @@ class CirclesGroup extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const { adjustedHeight, circleOverlayRadius, circleRadius, data, shouldAnimate, translation, useCircleOverlay, xScaleValueFunction, yScaleValueFunction } = this.props;
     const preventCircleOverlapCutOff = 45;
 

--- a/src/components/d3/GridLinesGroup.js
+++ b/src/components/d3/GridLinesGroup.js
@@ -20,11 +20,11 @@ class GridLinesGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._renderGridLines();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._renderGridLines();
   }
 
@@ -44,7 +44,7 @@ class GridLinesGroup extends React.Component {
     d3.select(this.gridLines).call(gridLinesFunction);
   };
 
-  render() {
+  render () {
     return (
       <g
         className={this.props.axis + '-grid-line'}

--- a/src/components/d3/GridLinesGroup.js
+++ b/src/components/d3/GridLinesGroup.js
@@ -5,32 +5,30 @@ const d3 = require('d3');
 
 const ChartUtils = require('../../utils/Chart');
 
-const GridLinesGroup = React.createClass({
-  propTypes: {
+class GridLinesGroup extends React.Component {
+  static propTypes = {
     axis: PropTypes.string.isRequired,
     data: PropTypes.array.isRequired,
     orientation: PropTypes.string,
     scaleFunction: PropTypes.func.isRequired,
     tickSize: PropTypes.number.isRequired,
     translation: PropTypes.string
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      orientation: 'left',
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    orientation: 'left',
+    translation: 'translate(0,0)'
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._renderGridLines();
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._renderGridLines();
-  },
+  }
 
-  _renderGridLines () {
+  _renderGridLines = () => {
     const max = d3.max(this.props.data, d => d[this.props.axis]);
     const min = d3.min(this.props.data, d => d[this.props.axis]);
     const { tickValues } = ChartUtils.getAxisTickSpecification(min, max);
@@ -44,9 +42,9 @@ const GridLinesGroup = React.createClass({
       .tickValues(tickValues);
 
     d3.select(this.gridLines).call(gridLinesFunction);
-  },
+  };
 
-  render () {
+  render() {
     return (
       <g
         className={this.props.axis + '-grid-line'}
@@ -55,6 +53,6 @@ const GridLinesGroup = React.createClass({
       />
     );
   }
-});
+}
 
 module.exports = GridLinesGroup;

--- a/src/components/d3/LineGroup.js
+++ b/src/components/d3/LineGroup.js
@@ -26,7 +26,7 @@ class LineGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  componentWillMount() {
+  componentWillMount () {
     const flatLine = d3.svg.line()
       .x(d => {
         return this.props.xScaleValueFunction(d.x);
@@ -49,11 +49,11 @@ class LineGroup extends React.Component {
     });
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this._animateLine();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._animateLine();
   }
 
@@ -63,7 +63,7 @@ class LineGroup extends React.Component {
     }
   };
 
-  render() {
+  render () {
     const { data, dashLine, lineColor, shouldAnimate, strokeWidth, translation } = this.props;
 
     return (

--- a/src/components/d3/LineGroup.js
+++ b/src/components/d3/LineGroup.js
@@ -5,8 +5,8 @@ const d3 = require('d3');
 
 const StyleConstants = require('../../constants/Style');
 
-const LineGroup = React.createClass({
-  propTypes: {
+class LineGroup extends React.Component {
+  static propTypes = {
     adjustedHeight: PropTypes.number.isRequired,
     dashLine: PropTypes.bool,
     data: PropTypes.array.isRequired,
@@ -16,19 +16,17 @@ const LineGroup = React.createClass({
     translation: PropTypes.string,
     xScaleValueFunction: PropTypes.func.isRequired,
     yScaleValueFunction: PropTypes.func.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      dashLine: false,
-      lineColor: StyleConstants.Colors.CHARCOAL,
-      shouldAnimate: true,
-      strokeWidth: 2,
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    dashLine: false,
+    lineColor: StyleConstants.Colors.CHARCOAL,
+    shouldAnimate: true,
+    strokeWidth: 2,
+    translation: 'translate(0,0)'
+  };
 
-  componentWillMount () {
+  componentWillMount() {
     const flatLine = d3.svg.line()
       .x(d => {
         return this.props.xScaleValueFunction(d.x);
@@ -49,23 +47,23 @@ const LineGroup = React.createClass({
       flatLine,
       line
     });
-  },
+  }
 
-  componentDidMount () {
+  componentDidMount() {
     this._animateLine();
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._animateLine();
-  },
+  }
 
-  _animateLine () {
+  _animateLine = () => {
     if (this.props.shouldAnimate) {
       d3.select(this.chartLine).transition().attr('d', this.state.line(this.props.data));
     }
-  },
+  };
 
-  render () {
+  render() {
     const { data, dashLine, lineColor, shouldAnimate, strokeWidth, translation } = this.props;
 
     return (
@@ -81,6 +79,6 @@ const LineGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 module.exports = LineGroup;

--- a/src/components/d3/ShadedAreaRectangleGroup.js
+++ b/src/components/d3/ShadedAreaRectangleGroup.js
@@ -3,8 +3,8 @@ const React = require('react');
 
 const StyleConstants = require('../../constants/Style');
 
-const ShadedAreaRectangleGroup = React.createClass({
-  propTypes: {
+class ShadedAreaRectangleGroup extends React.Component {
+  static propTypes = {
     fillColor: PropTypes.string,
     fillOpacity: PropTypes.number,
     height: PropTypes.number.isRequired,
@@ -12,17 +12,15 @@ const ShadedAreaRectangleGroup = React.createClass({
     width: PropTypes.number.isRequired,
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      fillColor: StyleConstants.Colors.FOG,
-      fillOpacity: 0.1,
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    fillColor: StyleConstants.Colors.FOG,
+    fillOpacity: 0.1,
+    translation: 'translate(0,0)'
+  };
 
-  render () {
+  render() {
     return (
       <g className='shaded-area'>
         <rect
@@ -37,6 +35,6 @@ const ShadedAreaRectangleGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 module.exports = ShadedAreaRectangleGroup;

--- a/src/components/d3/ShadedAreaRectangleGroup.js
+++ b/src/components/d3/ShadedAreaRectangleGroup.js
@@ -20,7 +20,7 @@ class ShadedAreaRectangleGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  render() {
+  render () {
     return (
       <g className='shaded-area'>
         <rect

--- a/src/components/d3/ShadedHatchPatternRectangleGroup.js
+++ b/src/components/d3/ShadedHatchPatternRectangleGroup.js
@@ -3,24 +3,22 @@ const React = require('react');
 
 const StyleConstants = require('../../constants/Style');
 
-const ShadedHatchPatternRectangleGroup = React.createClass({
-  propTypes: {
+class ShadedHatchPatternRectangleGroup extends React.Component {
+  static propTypes = {
     fillColor: PropTypes.string,
     height: PropTypes.number.isRequired,
     translation: PropTypes.string,
     width: PropTypes.number.isRequired,
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      fillColor: StyleConstants.Colors.FOG,
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    fillColor: StyleConstants.Colors.FOG,
+    translation: 'translate(0,0)'
+  };
 
-  render () {
+  render() {
     return (
       <g className='shaded-hatch-pattern'>
         <pattern
@@ -46,6 +44,6 @@ const ShadedHatchPatternRectangleGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 module.exports = ShadedHatchPatternRectangleGroup;

--- a/src/components/d3/ShadedHatchPatternRectangleGroup.js
+++ b/src/components/d3/ShadedHatchPatternRectangleGroup.js
@@ -18,7 +18,7 @@ class ShadedHatchPatternRectangleGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  render() {
+  render () {
     return (
       <g className='shaded-hatch-pattern'>
         <pattern

--- a/src/components/d3/SlicesGroup.js
+++ b/src/components/d3/SlicesGroup.js
@@ -11,7 +11,7 @@ class SlicesGroup extends React.Component {
     xScaleValueFunction: PropTypes.func.isRequired
   };
 
-  render() {
+  render () {
     return (
       <g className='slices'>
         {this.props.data.map((dataPoint, index) => {

--- a/src/components/d3/SlicesGroup.js
+++ b/src/components/d3/SlicesGroup.js
@@ -1,17 +1,17 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const SlicesGroup = React.createClass({
-  propTypes: {
+class SlicesGroup extends React.Component {
+  static propTypes = {
     adjustedHeight: PropTypes.number.isRequired,
     data: PropTypes.array.isRequired,
     handleChartMouseOver: PropTypes.func.isRequired,
     sliceWidth: PropTypes.number.isRequired,
     translation: PropTypes.string.isRequired,
     xScaleValueFunction: PropTypes.func.isRequired
-  },
+  };
 
-  render () {
+  render() {
     return (
       <g className='slices'>
         {this.props.data.map((dataPoint, index) => {
@@ -31,6 +31,6 @@ const SlicesGroup = React.createClass({
       </g>
     );
   }
-});
+}
 
 module.exports = SlicesGroup;

--- a/src/components/d3/TimeXAxisGroup.js
+++ b/src/components/d3/TimeXAxisGroup.js
@@ -4,31 +4,29 @@ const React = require('react');
 const d3 = require('d3');
 const moment = require('moment');
 
-const TimeXAxisGroup = React.createClass({
-  propTypes: {
+class TimeXAxisGroup extends React.Component {
+  static propTypes = {
     ticks: PropTypes.array.isRequired,
     tickSize: PropTypes.number,
     timeAxisFormat: PropTypes.string.isRequired,
     translation: PropTypes.string,
     xScaleFunction: PropTypes.func.isRequired
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      tickSize: 6,
-      translation: 'translate(0,0)'
-    };
-  },
+  static defaultProps = {
+    tickSize: 6,
+    translation: 'translate(0,0)'
+  };
 
-  componentDidMount () {
+  componentDidMount() {
     this._renderAxis();
-  },
+  }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._renderAxis();
-  },
+  }
 
-  _renderAxis () {
+  _renderAxis = () => {
     const timeAxisFunction = d3.svg.axis()
     .scale(this.props.xScaleFunction())
     .tickSize(this.props.tickSize, this.props.tickSize)
@@ -38,9 +36,9 @@ const TimeXAxisGroup = React.createClass({
     });
 
     d3.select(this.timeAxis).call(timeAxisFunction);
-  },
+  };
 
-  render () {
+  render() {
     return (
       <g
         className='time-axis'
@@ -49,6 +47,6 @@ const TimeXAxisGroup = React.createClass({
       />
     );
   }
-});
+}
 
 module.exports = TimeXAxisGroup;

--- a/src/components/d3/TimeXAxisGroup.js
+++ b/src/components/d3/TimeXAxisGroup.js
@@ -18,11 +18,11 @@ class TimeXAxisGroup extends React.Component {
     translation: 'translate(0,0)'
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._renderAxis();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate () {
     this._renderAxis();
   }
 
@@ -38,7 +38,7 @@ class TimeXAxisGroup extends React.Component {
     d3.select(this.timeAxis).call(timeAxisFunction);
   };
 
-  render() {
+  render () {
     return (
       <g
         className='time-axis'

--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -7,22 +7,20 @@ const defaultShape = {
   small: PropTypes.number
 };
 
-const Column = React.createClass({
-  propTypes: {
+class Column extends React.Component {
+  static propTypes = {
     offset: PropTypes.shape(defaultShape),
     relative: PropTypes.bool,
     span: PropTypes.shape(defaultShape)
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      offset: {},
-      relative: true,
-      span: { large: 12 }
-    };
-  },
+  static defaultProps = {
+    offset: {},
+    relative: true,
+    span: { large: 12 }
+  };
 
-  getColumnWidths () {
+  getColumnWidths = () => {
     const colWidths = [];
     const { large, medium, small } = this.props.span;
 
@@ -46,9 +44,9 @@ const Column = React.createClass({
     }
 
     return colWidths;
-  },
+  };
 
-  getColumnOffsets () {
+  getColumnOffsets = () => {
     const offsets = [];
     const small = this.props.offset.small;
     const medium = this.props.offset.medium;
@@ -68,9 +66,9 @@ const Column = React.createClass({
     }
 
     return offsets;
-  },
+  };
 
-  render () {
+  render() {
     let className = [];
 
     // Column widths
@@ -85,6 +83,6 @@ const Column = React.createClass({
       </div>
     );
   }
-});
+}
 
 module.exports = Column;

--- a/src/components/grid/Column.js
+++ b/src/components/grid/Column.js
@@ -68,7 +68,7 @@ class Column extends React.Component {
     return offsets;
   };
 
-  render() {
+  render () {
     let className = [];
 
     // Column widths

--- a/src/components/grid/Container.js
+++ b/src/components/grid/Container.js
@@ -11,7 +11,7 @@ class Container extends React.Component {
     fluid: true
   };
 
-  render() {
+  render () {
     return (
       <div className={'container' + (this.props.fluid ? '-fluid' : '')} style={Object.assign({}, this.props.styles, { boxSizing: 'border-box' })}>
         {this.props.children}

--- a/src/components/grid/Container.js
+++ b/src/components/grid/Container.js
@@ -1,25 +1,23 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const Container = React.createClass({
-  propTypes: {
+class Container extends React.Component {
+  static propTypes = {
     fluid: PropTypes.bool,
     styles: PropTypes.object
-  },
+  };
 
-  getDefaultProps () {
-    return {
-      fluid: true
-    };
-  },
+  static defaultProps = {
+    fluid: true
+  };
 
-  render () {
+  render() {
     return (
       <div className={'container' + (this.props.fluid ? '-fluid' : '')} style={Object.assign({}, this.props.styles, { boxSizing: 'border-box' })}>
         {this.props.children}
       </div>
     );
   }
-});
+}
 
 module.exports = Container;

--- a/src/components/grid/Row.js
+++ b/src/components/grid/Row.js
@@ -1,7 +1,7 @@
 const React = require('react');
 
 class Row extends React.Component {
-  render() {
+  render () {
     return (
       <div className={'row'} style={{ boxSizing: 'border-box' }}>
         {this.props.children}

--- a/src/components/grid/Row.js
+++ b/src/components/grid/Row.js
@@ -1,13 +1,13 @@
 const React = require('react');
 
-const Row = React.createClass({
-  render () {
+class Row extends React.Component {
+  render() {
     return (
       <div className={'row'} style={{ boxSizing: 'border-box' }}>
         {this.props.children}
       </div>
     );
   }
-});
+}
 
 module.exports = Row;


### PR DESCRIPTION
Class extends syntax conversion for all components in `/src/components`. Everything here was pretty straightforward - had to do a little bit of manual work in `Listbox` and `DatePickerFullScreen` - check out my last two commits. 

Basically, using a static `state` wont work if we reference props or other class functions from state, so I used the `constructor()` 

Clicked through the docs and tested each component out. 

