### PR TITLE
yarn && yarn upgrade all the things

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/Index.js",
   "scripts": {
     "release": "eslint src && babel src --out-dir dist",
-    "dev": "cd docs && yarn && open 'http://localhost:8080' && NODE_ENV=development webpack-dev-server --inline --hot --host 0.0.0.0",
-    "docs:release": "cd docs && rm -rf node_modules && yarn && NODE_ENV=production webpack --progress && git add -A && git commit -m \"Docs Version: $(node -p 'require(\"../package.json\").version')\"",
+    "dev": "yarn && yarn upgrade && cd docs && yarn && yarn upgrade && open 'http://localhost:8080' && NODE_ENV=development webpack-dev-server --inline --hot --host 0.0.0.0",
+    "docs:release": "yarn && cd docs && yarn && NODE_ENV=production webpack --progress && git add -A && git commit -m \"Docs Version: $(node -p 'require(\"../package.json\").version')\"",
     "test": "eslint src"
   },
   "repository": {


### PR DESCRIPTION
We have 2 package.json files, one for the project and one for the docs. I think `yarn dev` should run `yarn && yarn upgrade` for both and `yarn docs:release` should run `yarn` for both. This will ensure that the `yarn.lock` files stay up to date.