### PR TITLE
Fix bug where a custom input id was ignored

### DIFF
--- a/docs/components/DisplayInputDocs.js
+++ b/docs/components/DisplayInputDocs.js
@@ -51,6 +51,7 @@ class DisplayInputDocs extends React.Component {
         <h3>Demo</h3>
         <DisplayInput
           elementProps={{
+            id: 'input-id',
             onBlur: this._handleInputStatusMessage,
             onFocus: this._handleInputFocus,
             onMouseOut: this._handleInputHideHint,

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -36,7 +36,7 @@ class DisplayInput extends React.Component {
 
   componentWillMount () {
     this._labelId = _uniqueId('DI');
-    this._inputId = _uniqueId('DI');
+    this._inputId = this.props.elementProps.id || _uniqueId('DI');
   }
 
   _isLargeOrMediumWindowSize = () => {


### PR DESCRIPTION
Passing `id` with `elementProps` was being ignored (introduced in https://github.com/mxenabled/mx-react-components/pull/559). This fixes the problem by checking for an id before generating a unique id to use with the `label`.