### PR TITLE
Select accessibility updates

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,8 +1,9 @@
 const _isEqual = require('lodash/isEqual');
-const React = require('react');
-const ReactDOM = require('react-dom');
+const keycode = require('keycode');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
+const React = require('react');
+const ReactDOM = require('react-dom');
 
 const Icon = require('./Icon');
 
@@ -93,11 +94,11 @@ class Select extends React.Component {
   _handleInputKeyDown = (e) => {
     const highlightedValue = this.state.highlightedValue;
 
-    if (e.keyCode === 13 && highlightedValue) {
+    if (keycode(e) === 'enter' && highlightedValue) {
       this._handleOptionClick(highlightedValue);
     }
 
-    if (e.keyCode === 40) {
+    if (keycode(e) === 'down') {
       e.preventDefault();
 
       const nextIndex = this.props.options.indexOf(highlightedValue) + 1;
@@ -111,7 +112,7 @@ class Select extends React.Component {
       }
     }
 
-    if (e.keyCode === 38) {
+    if (keycode(e) === 'up') {
       e.preventDefault();
 
       const previousIndex = this.props.options.indexOf(highlightedValue) - 1;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -10,18 +10,24 @@ const { Listbox, Option } = require('./accessibility/Listbox');
 
 const StyleConstants = require('../constants/Style');
 
+const optionShape = PropTypes.shape({
+  displayValue: PropTypes.any.isRequired,
+  icon: PropTypes.any,
+  value: PropTypes.any.isRequired
+});
+
 class Select extends React.Component {
   static propTypes = {
     dropdownStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     onChange: PropTypes.func,
-    options: PropTypes.array,
+    options: PropTypes.arrayOf(optionShape),
     optionsStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     optionStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     optionTextStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     placeholderText: PropTypes.string,
     primaryColor: PropTypes.string,
     scrimStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-    selected: PropTypes.object,
+    selected: optionShape,
     selectedStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     valid: PropTypes.bool
   };

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -288,7 +288,7 @@ class Select extends React.Component {
           borderRadius: '0 0 3px 3px',
           left: -1,
           right: -1,
-          marginTop: 10,
+          margin: '8px 0 0 0',
           padding: 0,
           minWidth: '100%',
           position: 'absolute',

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -46,7 +46,6 @@ class Select extends React.Component {
         e.preventDefault();
         e.stopPropagation();
         this._close();
-        this.component.focus();
         break;
       case 'enter':
       case 'space':

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -37,8 +37,7 @@ class Select extends React.Component {
   state = {
     highlightedValue: null,
     isOpen: false,
-    selected: false,
-    hoverItem: null
+    selected: false
   };
 
   _handleKeyDown = (e) => {
@@ -46,7 +45,7 @@ class Select extends React.Component {
       case 'esc':
         e.preventDefault();
         e.stopPropagation();
-        this._handleScrimClick();
+        this._close();
         this.component.focus();
         break;
       case 'enter':
@@ -54,41 +53,27 @@ class Select extends React.Component {
         if (this.state.isOpen) return;
         e.preventDefault();
         e.stopPropagation();
-        this._toggle();
+        this._open();
         break;
     }
   };
 
-  _handleScrimClick = () => {
-    this.setState({
-      isOpen: false,
-      hoverItem: null
-    });
+  _close = () => {
+    this.setState({ isOpen: false });
     this.component.focus();
   };
 
-  _handleOptionClick = (option) => {
-    this.setState({
-      selected: option,
-      isOpen: false,
-      hoverItem: null
-    });
-    this.component.focus();
-    this.props.onChange(option);
+  _open = () => {
+    this.setState({ isOpen: true });
   };
 
-  _handleOptionMouseOver = (option) => {
-    this.setState({
-      hoverItem: option.value
+  _handleOptionClick = (option, e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({ selected: option }, () => {
+      this._close();
+      this.props.onChange(option);
     });
-  };
-
-  _handleSelectChange = (e) => {
-    const selectedOption = this.props.options.filter(option => {
-      return option.value + '' === e.target.value;
-    })[0];
-
-    this._handleOptionClick(selectedOption);
   };
 
   _scrollListDown = (nextIndex) => {
@@ -111,12 +96,6 @@ class Select extends React.Component {
     }
   };
 
-  _toggle = () => {
-    this.setState({
-      isOpen: !this.state.isOpen
-    });
-  };
-
   _renderScrim = () => {
     if (this.state.isOpen) {
       const styles = this.styles();
@@ -124,7 +103,7 @@ class Select extends React.Component {
       return (
         <div
           className='mx-select-scrim'
-          onClick={this._handleScrimClick}
+          onClick={this._close}
           style={[styles.scrim, this.props.scrimStyle]}
         />
       );
@@ -160,7 +139,6 @@ class Select extends React.Component {
                   key={option.displayValue + option.value}
                   label={option.displayValue}
                   onClick={this._handleOptionClick.bind(null, option)}
-                  onMouseOver={this._handleOptionMouseOver.bind(null, option)}
                   style={Object.assign({},
                     styles.option,
                     this.props.optionStyle,
@@ -194,7 +172,7 @@ class Select extends React.Component {
     return (
       <div className='mx-select' style={Object.assign({}, this.props.style, { position: 'relative' })}>
         <div className='mx-select-custom'
-          onClick={this._toggle}
+          onClick={this._open}
           onKeyDown={this._handleKeyDown}
           ref={ref => this.component = ref}
           style={styles.component}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -41,18 +41,6 @@ class Select extends React.Component {
     hoverItem: null
   };
 
-  getBackgroundColor = (option) => {
-    if (option.value === this.state.hoverItem) {
-      return {
-        backgroundColor: this.props.primaryColor,
-        color: StyleConstants.Colors.WHITE,
-        fill: StyleConstants.Colors.WHITE
-      };
-    } else {
-      return null;
-    }
-  };
-
   _handleKeyDown = (e) => {
     switch (keycode(e)) {
       case 'esc':
@@ -177,8 +165,7 @@ class Select extends React.Component {
                   style={Object.assign({},
                     styles.option,
                     this.props.optionStyle,
-                    _isEqual(option, this.state.selected) ? styles.activeItem : null,
-                    this.getBackgroundColor(option)
+                    _isEqual(option, this.state.selected) ? styles.activeOption : null
                   )}
                 >
                   {option.icon ? (
@@ -236,6 +223,12 @@ class Select extends React.Component {
   }
 
   styles = () => {
+    const focusedOption = {
+      backgroundColor: this.props.primaryColor,
+      color: StyleConstants.Colors.WHITE,
+      fill: StyleConstants.Colors.WHITE
+    };
+
     return {
       component: Object.assign({},
         {
@@ -265,10 +258,6 @@ class Select extends React.Component {
           justifyContent: 'space-between',
           position: 'relative'
         }, this.props.selectedStyle),
-      activeItem: {
-        fill: this.props.primaryColor,
-        color: this.props.primaryColor
-      },
       invalid: {
         borderColor: StyleConstants.Colors.STRAWBERRY
       },
@@ -290,14 +279,22 @@ class Select extends React.Component {
           maxHeight: 260,
           overflow: 'auto'
         }, this.props.optionsStyle),
+      activeOption: {
+        fill: this.props.primaryColor,
+        color: this.props.primaryColor
+      },
       option: {
         display: 'flex',
         alignItems: 'center',
         color: StyleConstants.Colors.CHARCOAL,
         cursor: 'pointer',
         backgroundColor: StyleConstants.Colors.WHITE,
+        outline: 'none',
         padding: 10,
-        whiteSpace: 'nowrap'
+        whiteSpace: 'nowrap',
+
+        ':focus': focusedOption,
+        ':hover': focusedOption
       },
       optionIcon: {
         marginRight: 5

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -34,11 +34,14 @@ class Select extends React.Component {
     valid: true
   };
 
-  state = {
-    highlightedValue: null,
-    isOpen: false,
-    selected: false
-  };
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      isOpen: false,
+      selected: props.selected
+    };
+  }
 
   _handleKeyDown = (e) => {
     switch (keycode(e)) {

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -51,11 +51,10 @@ class Select extends React.Component {
         break;
       case 'enter':
       case 'space':
-        if (e.target === this.component) {
-          e.preventDefault();
-          e.stopPropagation();
-          this._toggle();
-        }
+        if (this.state.isOpen) return;
+        e.preventDefault();
+        e.stopPropagation();
+        this._toggle();
         break;
     }
   };

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -247,8 +247,7 @@ class Select extends React.Component {
           fontSize: StyleConstants.FontSizes.MEDIUM,
           padding: '8px 10px',
           position: 'relative',
-          boxSizing: 'border-box',
-          outline: 'none'
+          boxSizing: 'border-box'
         }, this.props.dropdownStyle),
       select: {
         position: 'absolute',

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -293,6 +293,7 @@ class Select extends React.Component {
       option: {
         display: 'flex',
         alignItems: 'center',
+        color: StyleConstants.Colors.CHARCOAL,
         cursor: 'pointer',
         backgroundColor: StyleConstants.Colors.WHITE,
         padding: 10,

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -43,6 +43,12 @@ class Select extends React.Component {
     };
   }
 
+  componentWillReceiveProps (newProps) {
+    if (!_isEqual(nextProps.selected, this.props.selected)) {
+      this.setState({ selected: newProps.selected });
+    }
+  }
+
   _handleKeyDown = (e) => {
     switch (keycode(e)) {
       case 'esc':

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -64,15 +64,18 @@ class Listbox extends React.Component {
     switch (keycode(e)) {
       case 'up':
         e.preventDefault();
+        e.stopPropagation();
         this._focusPrevious();
         break;
       case 'down':
         e.preventDefault();
+        e.stopPropagation();
         this._focusNext();
         break;
       case 'enter':
       case 'space':
         e.preventDefault();
+        e.stopPropagation();
         e.target.click();
         break;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,7 +189,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-cli@^6.24.0, babel-cli@^6.6.5:
+babel-cli@^6.6.5:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.24.1.tgz#207cd705bba61489b2ea41b5312341cf6aca2283"
   dependencies:
@@ -218,7 +218,7 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.24.0, babel-core@^6.24.1:
+babel-core@^6.0.0, babel-core@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
   dependencies:
@@ -406,10 +406,6 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-exports@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
-
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -432,7 +428,7 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
+babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
 
@@ -504,14 +500,6 @@ babel-plugin-transform-class-properties@^6.22.0, babel-plugin-transform-class-pr
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
-
-babel-plugin-transform-decorators-legacy@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
-  dependencies:
-    babel-plugin-syntax-decorators "^6.1.18"
-    babel-runtime "^6.2.0"
-    babel-template "^6.3.0"
 
 babel-plugin-transform-decorators@^6.24.1:
   version "6.24.1"
@@ -614,7 +602,7 @@ babel-plugin-transform-es2015-modules-amd@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.24.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz#d3e310b40ef664a36622200097c6d440298f2bfe"
   dependencies:
@@ -789,7 +777,7 @@ babel-polyfill@^6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-es2015@^6.0.0, babel-preset-es2015@^6.24.0:
+babel-preset-es2015@^6.0.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -824,7 +812,7 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
-babel-preset-react@^6.0.0, babel-preset-react@^6.23.0:
+babel-preset-react@^6.0.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
   dependencies:
@@ -843,7 +831,7 @@ babel-preset-stage-0@^6.22.0:
     babel-plugin-transform-function-bind "^6.22.0"
     babel-preset-stage-1 "^6.24.1"
 
-babel-preset-stage-1@^6.22.0, babel-preset-stage-1@^6.24.1:
+babel-preset-stage-1@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz#7692cd7dcd6849907e6ae4a0a85589cfb9e2bfb0"
   dependencies:
@@ -882,14 +870,14 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.24.1, babel-template@^6.3.0:
+babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -2217,13 +2205,9 @@ iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
 
 ieee754@^1.1.4:
   version "1.1.8"


### PR DESCRIPTION
* Use `Listbox` for the options' accessibility
* Handle `esc` to close
* Handle `enter`/`space` to open (when Select is focused)
* Give visual indication that the component is focused
* Use css hover instead of state
* Fix propagation bug with `Listbox`

Here's a demo of using only the keyboard to interact with `Select`:

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/4348/25757197/d746d6ce-3186-11e7-855e-905aef3eccbd.gif)
