### PR TITLE
Adds OTHER as a category color in Style constants

### DIFF
--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -52,6 +52,7 @@ module.exports = {
     INCOME: '#133F49',
     INVESTMENTS: '#FF7070',
     KIDS: '#82D196',
+    OTHER: '#959CA6',
     PETS: '#85507B',
     PERSONAL_CARE: '#338B7A',
     SHOPPING: '#CF5F84',


### PR DESCRIPTION
The other category color was missing from the Style constants Colors and we need it in place internally for theme calculation so this adds it here.  I made the same as the ASH color per instruction from Derek.