### PR TITLE
Deprecate useTabsInMobile prop and tabs menu type for small screens

### DIFF
--- a/docs/components/TabsDocs.js
+++ b/docs/components/TabsDocs.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const { Link } = require('react-router');
 
 const { Tabs } = require('mx-react-components');
 
@@ -34,7 +35,6 @@ class TabsDocs extends React.Component {
           onTabSelect={this._handleTabSelect}
           selectedTab={this.state.selectedTab}
           tabs={['Donuts', 'Ice Cream', 'Bacon', 'Chicken']}
-          useTabsInMobile={true}
         />
 
         <h3>Usage</h3>
@@ -64,9 +64,8 @@ class TabsDocs extends React.Component {
         <p>Default: PRIMARY</p>
         <p><em>(required)</em> Array of values that you want respresented as tabs. Each item in the array should be a string. The "onTabClick" function will be called when you click on each one.</p>
 
-        <h5>useTabsInMobile <label>Boolean</label></h5>
-        <p>Default: false</p>
-        <p>When true, this will override the default and show tabs in mobile instead of a menu screen.</p>
+        <h5>DEPRECATED: useTabsInMobile <label>Boolean</label></h5>
+        <p>Deprecated. For dropdown style tabs please use <Link to='/components/select'>Select</Link> instead.</p>
 
         <h3>Example</h3>
         <Markdown>

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -23,8 +23,7 @@ class Tabs extends React.Component {
   };
 
   state = {
-    selectedTab: this.props.selectedTab || 0,
-    showMenu: false
+    selectedTab: this.props.selectedTab || 0
   };
 
   componentWillMount () {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -76,9 +76,11 @@ class Tabs extends React.Component {
         width: '100%'
       },
       tabsContainer: {
+        borderBottom: this.props.showBottomBorder ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
+        boxSizing: 'border-box',
         display: 'flex',
         justifyContent: this.props.alignment === 'left' ? 'flex-start' : 'center',
-        borderBottom: this.props.showBottomBorder ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
+        overflowX: 'scroll',
         width: '100%'
       }
     };
@@ -125,6 +127,7 @@ class TabWithoutRadium extends React.Component {
         fontSize: StyleConstants.FontSizes.MEDIUM,
         fontStyle: StyleConstants.Fonts.SEMIBOLD,
         padding: StyleConstants.Spacing.MEDIUM,
+        whiteSpace: 'nowrap',
 
         ':hover': {
           color: StyleConstants.Colors.CHARCOAL

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -2,8 +2,6 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
-const Icon = require('./Icon');
-const SimpleSelect = require('./SimpleSelect');
 const StyleConstants = require('../constants/Style');
 
 class Tabs extends React.Component {
@@ -21,14 +19,19 @@ class Tabs extends React.Component {
   static defaultProps = {
     alignment: 'left',
     brandColor: StyleConstants.Colors.PRIMARY,
-    showBottomBorder: true,
-    useTabsInMobile: false
+    showBottomBorder: true
   };
 
   state = {
     selectedTab: this.props.selectedTab || 0,
     showMenu: false
   };
+
+  componentWillMount () {
+    if (this.props.hasOwnProperty('useTabsInMobile')) {
+      console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release.');
+    }
+  }
 
   componentWillReceiveProps (nextProps) {
     if (nextProps.selectedTab !== this.state.selectedTab) {
@@ -38,75 +41,21 @@ class Tabs extends React.Component {
     }
   }
 
-  _toggleMenu = () => {
-    this.setState({
-      showMenu: !this.state.showMenu
-    });
-  };
-
   _handleTabClick = (selectedTab) => {
     this.props.onTabSelect(selectedTab);
-    this._toggleMenu();
 
     this.setState({
       selectedTab
     });
   };
 
-  _isLargeOrMediumWindowSize = () => {
-    const windowSize = StyleConstants.getWindowSize();
-
-    return windowSize === 'medium' || windowSize === 'large';
-  };
-
-  _renderTabMenu = () => {
-    const selectedTabName = this.props.tabs[this.state.selectedTab];
-    const styles = this.styles();
-    const tabItems = this._buildTabItems();
-
-    return (
-      <div onClick={this._toggleMenu} style={styles.menuWrapper} >
-        {selectedTabName}
-        <Icon
-          size={20}
-          style={{ fill: this.props.brandColor }}
-          type={!this.state.showMenu ? 'caret-down' : 'caret-up' }
-        />
-        {this.state.showMenu ? (
-          <SimpleSelect
-            hoverColor={this.props.brandColor}
-            items={tabItems}
-            onScrimClick={this._toggleMenu}
-            showItems={this.state.showMenu}
-          />
-        ) : null}
-      </div>
-    );
-  };
-
-  _buildTabItems = () => {
-    const tabItems = [];
-
-    this.props.tabs.map((tab, index) => {
-      tabItems.push({
-        onClick: () => {
-          this._handleTabClick(index);
-        },
-        text: tab
-      });
-    });
-
-    return tabItems;
-  };
-
   render () {
     const styles = this.styles();
-    const useTabs = this._isLargeOrMediumWindowSize() || this.props.useTabsInMobile;
-    const componentStyles = Object.assign({}, styles.component, (useTabs && styles.tabsContainer), this.props.style);
+    const componentStyles = Object.assign({}, styles.component, styles.tabsContainer, this.props.style);
 
     return (
       <div style={componentStyles}>
-        {useTabs ? this.props.tabs.map((tab, index) =>
+        {this.props.tabs.map((tab, index) =>
           <Tab
             isActive={this.state.selectedTab === index}
             key={tab}
@@ -115,7 +64,7 @@ class Tabs extends React.Component {
           >
             {tab}
           </Tab>
-        ) : this._renderTabMenu()}
+        )}
       </div>
     );
   }
@@ -126,14 +75,6 @@ class Tabs extends React.Component {
       component: {
         display: 'block',
         width: '100%'
-      },
-      menuWrapper: {
-        alignItems: 'center',
-        boxSizing: 'border-box',
-        color: this.props.brandColor,
-        lineHeight: '20px',
-        fontSize: StyleConstants.FontSizes.MEDIUM,
-        fontStyle: StyleConstants.Fonts.SEMIBOLD
       },
       tabsContainer: {
         display: 'flex',


### PR DESCRIPTION
Showing the `Select`-like menu when the screen is small was a poorly documented feature and surprising behavior. These changes remove that extra feature and deprecate the `useTabsInMobile` prop making Tabs simpler and more focused by pushing the decision of whether to show a `Select` or `Tabs` to the container.

I discussed this with @jmophoto and we thought it would be best to remove this surprising behavior and let the user decide when to switch between tab types.

This was originally part of #583 