### PR TITLE
Calendar week fix

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -149,9 +149,7 @@ class Calendar extends React.Component {
             );
           })}
         </div>
-        <div style={styles.calendarTable}>
-          {this._renderMonthTable()}
-        </div>
+        {this._renderMonthTable()}
       </div>
     );
   }
@@ -207,12 +205,6 @@ class Calendar extends React.Component {
       },
 
       //Calenday table
-      calendarTable: {
-        // alignItems: 'center',
-        // display: 'flex',
-        // flexWrap: 'wrap',
-        // justifyContent: 'space-around'
-      },
       calendarDay: {
         alignItems: 'center',
         borderRadius: 3,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -164,8 +164,7 @@ class Calendar extends React.Component {
         borderRadius: 3,
         boxSizing: 'border-box',
         marginTop: 10,
-        padding: 20,
-        width: 600
+        padding: 20
       }, this.props.style),
 
       //Calendar Header
@@ -209,10 +208,10 @@ class Calendar extends React.Component {
 
       //Calenday table
       calendarTable: {
-        alignItems: 'center',
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: 'space-around'
+        // alignItems: 'center',
+        // display: 'flex',
+        // flexWrap: 'wrap',
+        // justifyContent: 'space-around'
       },
       calendarDay: {
         alignItems: 'center',

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -86,7 +86,7 @@ class Calendar extends React.Component {
 
     return weeks.map(week => {
       return (
-        <div>
+        <div style={{ display: 'flex' }}>
           {week.map(day => {
             const isCurrentMonth = day.isSame(moment.unix(this.state.currentDate), 'month');
             const isSelectedDay = day.isSame(moment.unix(this.props.selectedDate), 'day');
@@ -165,7 +165,6 @@ class Calendar extends React.Component {
         boxSizing: 'border-box',
         marginTop: 10,
         padding: 20
-        //width: 250
       }, this.props.style),
 
       //Calendar Header

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -55,39 +55,62 @@ class Calendar extends React.Component {
     });
   };
 
-  _renderMonthTable = () => {
-    const styles = this.styles();
-    const days = [];
-    let startDate = moment.unix(this.state.currentDate).startOf('month').startOf('week');
+  _getWeeks = () => {
+    const startDate = moment.unix(this.state.currentDate).startOf('month').startOf('week');
     const endDate = moment.unix(this.state.currentDate).endOf('month').endOf('week');
+    const weeks = [];
+    let days = [];
 
     while (moment(startDate).isBefore(endDate)) {
-      const isCurrentMonth = startDate.isSame(moment.unix(this.state.currentDate), 'month');
-      const isSelectedDay = startDate.isSame(moment.unix(this.props.selectedDate), 'day');
-      const isToday = startDate.isSame(moment(), 'day');
-      const disabledDay = this.props.minimumDate ? startDate.isBefore(moment.unix(this.props.minimumDate), 'day') : null;
+      const day = startDate.clone();
 
-      const day = (
-        <div
-          key={startDate}
-          onClick={disabledDay ? null : this._handleDateSelect.bind(null, startDate.unix())}
-          style={Object.assign({},
-            styles.calendarDay,
-            isCurrentMonth && styles.currentMonth,
-            disabledDay && styles.calendarDayDisabled,
-            isToday && styles.today,
-            isSelectedDay && styles.selectedDay
-          )}
-        >
-          {startDate.date()}
-        </div>
-      );
+      if (days.length < 7) {
+        days.push(day);
+      } else {
+        weeks.push(days);
+        days = [];
+      }
 
-      days.push(day);
-      startDate = startDate.add(1, 'd');
+      startDate.add(1, 'd');
     }
 
-    return days;
+    console.log(weeks)
+
+    return weeks;
+  };
+
+  _renderMonthTable = () => {
+    const styles = this.styles();
+    const weeks = this._getWeeks();
+
+    return weeks.map(week => {
+      return (
+        <div>
+          {week.map(day => {
+            const isCurrentMonth = day.isSame(moment.unix(this.state.currentDate), 'month');
+            const isSelectedDay = day.isSame(moment.unix(this.props.selectedDate), 'day');
+            const isToday = day.isSame(moment(), 'day');
+            const disabledDay = this.props.minimumDate ? day.isBefore(moment.unix(this.props.minimumDate), 'day') : null;
+
+            return (
+              <div
+                key={day}
+                onClick={disabledDay ? null : this._handleDateSelect.bind(null, day.unix())}
+                style={Object.assign({},
+                  styles.calendarDay,
+                  isCurrentMonth && styles.currentMonth,
+                  disabledDay && styles.calendarDayDisabled,
+                  isToday && styles.today,
+                  isSelectedDay && styles.selectedDay
+                )}
+              >
+                {day.date()}
+              </div>
+            );
+          })}
+        </div>
+      );
+    });
   };
 
   render () {
@@ -140,8 +163,8 @@ class Calendar extends React.Component {
         borderRadius: 3,
         boxSizing: 'border-box',
         marginTop: 10,
-        padding: 20,
-        width: 250
+        padding: 20
+        //width: 250
       }, this.props.style),
 
       //Calendar Header

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -58,23 +58,24 @@ class Calendar extends React.Component {
   _getWeeks = () => {
     const startDate = moment.unix(this.state.currentDate).startOf('month').startOf('week');
     const endDate = moment.unix(this.state.currentDate).endOf('month').endOf('week');
+    const weekLength = 7;
     const weeks = [];
     let days = [];
 
     while (moment(startDate).isBefore(endDate)) {
       const day = startDate.clone();
 
-      if (days.length < 7) {
+      if (days.length < weekLength) {
         days.push(day);
+        startDate.add(1, 'd');
       } else {
-        weeks.push(days);
         days = [];
       }
 
-      startDate.add(1, 'd');
+      if (days.length === weekLength) {
+        weeks.push(days);
+      }
     }
-
-    console.log(weeks)
 
     return weeks;
   };

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -86,7 +86,7 @@ class Calendar extends React.Component {
 
     return weeks.map(week => {
       return (
-        <div style={{ display: 'flex' }}>
+        <div style={styles.calendarWeek}>
           {week.map(day => {
             const isCurrentMonth = day.isSame(moment.unix(this.state.currentDate), 'month');
             const isSelectedDay = day.isSame(moment.unix(this.props.selectedDate), 'day');
@@ -140,7 +140,7 @@ class Calendar extends React.Component {
             type='caret-right'
           />
         </div>
-        <div style={styles.calendarWeek}>
+        <div style={styles.calendarWeekHeader}>
           {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => {
             return (
               <div key={i} style={styles.calendarWeekDay}>
@@ -164,7 +164,8 @@ class Calendar extends React.Component {
         borderRadius: 3,
         boxSizing: 'border-box',
         marginTop: 10,
-        padding: 20
+        padding: 20,
+        width: 600
       }, this.props.style),
 
       //Calendar Header
@@ -185,19 +186,25 @@ class Calendar extends React.Component {
       },
 
       //Calendar week
-      calendarWeek: {
+      calendarWeekHeader: {
         alignItems: 'center',
         color: StyleConstants.Colors.ASH,
         display: 'flex',
+        flex: '1 1 100%',
         fontFamily: StyleConstants.Fonts.SEMIBOLD,
         fontSize: StyleConstants.FontSizes.SMALL,
         height: 30,
-        justifyContent: 'space-around',
+        justifyContent: 'center',
         marginBottom: 2
       },
       calendarWeekDay: {
         textAlign: 'center',
         width: 35
+      },
+      calendarWeek: {
+        display: 'flex',
+        flex: '1 1 100%',
+        justifyContent: 'center'
       },
 
       //Calenday table


### PR DESCRIPTION
Fixes: https://github.com/mxenabled/mx-react-components/issues/587

We were using the component width to set the number of days in a week which was causing the calendar to render weeks with too many or too few days. This PR restricts the week to a constant 7 days, preventing display issues when different CSS is applied. The calendar is now mostly responsive but enough width must be provided for the weeks to render. By default, there is no width.

## Before
![](https://cloud.githubusercontent.com/assets/1916697/26644055/b9909b1e-45f0-11e7-83ea-5c88b6567458.png)

## After (defualt, no width)
![screen shot 2017-06-01 at 2 54 10 pm](https://cloud.githubusercontent.com/assets/1916697/26700622/455323e8-46db-11e7-9b4d-0e1642cb6e8b.png)

## Narrow width - 200px
![screen shot 2017-06-01 at 2 53 40 pm](https://cloud.githubusercontent.com/assets/1916697/26700646/5adace32-46db-11e7-98d2-e04e3d76c9b5.png)

## Wide width - 600px
![screen shot 2017-06-01 at 2 53 56 pm](https://cloud.githubusercontent.com/assets/1916697/26700670/71afcc0c-46db-11e7-928c-2506d1384a4a.png)

