### PR TITLE
Add theme to Button

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -41,6 +41,7 @@ const Spin = require('components/SpinDocs');
 const Styles = require('components/StylesDocs');
 const Tabs = require('components/TabsDocs');
 const TextArea = require('components/TextAreaDocs');
+const Theme = require('components/ThemeDocs');
 const TimeBasedLineChart = require('components/TimeBasedLineChartDocs');
 const ToggleSwitch = require('components/ToggleSwitchDocs');
 const TypeAhead = require('components/TypeAheadDocs');
@@ -103,6 +104,7 @@ ReactDOM.render((
         <Route component={Styles} path='styles' />
         <Route component={Tabs} path='tabs' />
         <Route component={TextArea} path='textarea' />
+        <Route component={Theme} path='theme' />
         <Route component={TimeBasedLineChart} path='time-based-line-chart' />
         <Route component={ToggleSwitch} path='toggle-switch' />
         <Route component={TypeAhead} path='type-ahead' />

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const { Link } = require('react-router');
 
 const { Button, Styles } = require('mx-react-components');
 
@@ -23,6 +24,11 @@ class ButtonDocs extends React.Component {
   };
 
   render () {
+    const customTheme = {
+      GRAY_300: '#ffc0bc',
+      PRIMARY: '#6C3F6F'
+    };
+
     return (
       <div>
         <h1>
@@ -72,6 +78,11 @@ class ButtonDocs extends React.Component {
             Loading (spinner only)
           </Button>
         </div>
+        <h4>Custom Theme</h4>
+        <div className='flex'>
+          <Button theme={customTheme}>Primary</Button>
+          <Button style={style} theme={customTheme} type='disabled'>Disabled</Button>
+        </div>
 
         <h3>Usage</h3>
         <h5>actionText <label>String</label></h5>
@@ -88,9 +99,9 @@ class ButtonDocs extends React.Component {
         <p>Default: false</p>
         <p>A boolean that is toggled when the button is clicked and when the item is finished loading..</p>
 
-        <h5>primaryColor <label>String</label></h5>
-        <p>Default: Styles.Colors.PRIMARY</p>
-        <p>The primary color used with the button styles.</p>
+        <h5>theme <label>Object</label></h5>
+        <p>Default: See Colors in <Link to='/components/styles'>Styles</Link></p>
+        <p>Customize any of the colors used in Button.</p>
 
         <h5>type <label>String</label></h5>
         <p>Default: 'primary'</p>
@@ -99,7 +110,7 @@ class ButtonDocs extends React.Component {
         <h3>Example</h3>
         <Markdown>
   {`
-    <Button aria-label='Submit Form' primaryColor='#333333' type='secondary' />
+    <Button aria-label='Submit Form' theme={{ PRIMARY: '#333333' }} type='secondary' />
   `}
         </Markdown>
       </div>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -106,8 +106,7 @@ class ButtonDocs extends React.Component {
         <p>A boolean that is toggled when the button is clicked and when the item is finished loading..</p>
 
         <h5>theme <label>Object</label></h5>
-        <p>Default: See Colors in <Link to='/components/styles'>Styles</Link></p>
-        <p>Customize the component&apos;s colors.</p>
+        <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
 
         <h5>type <label>String</label></h5>
         <p>Default: 'primary'</p>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -118,7 +118,7 @@ class ButtonDocs extends React.Component {
         <h3>Example</h3>
         <Markdown>
   {`
-    <Button aria-label='Submit Form' theme={{ PRIMARY: '#333333' }} type='secondary' />
+    <Button aria-label='Submit Form' theme={{ Colors: { PRIMARY: '#333333' } }} type='secondary' />
   `}
         </Markdown>
       </div>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -5,6 +5,17 @@ const { Button, Styles } = require('mx-react-components');
 
 const Markdown = require('components/Markdown');
 
+const buttonStyle = {
+  margin: '0 10px'
+};
+
+const customTheme = {
+  Colors: {
+    GRAY_300: '#ffc0bc',
+    PRIMARY: '#6C3F6F'
+  }
+};
+
 class ButtonDocs extends React.Component {
   state = {
     buttonIsActive: false,
@@ -24,11 +35,6 @@ class ButtonDocs extends React.Component {
   };
 
   render () {
-    const customTheme = {
-      GRAY_300: '#ffc0bc',
-      PRIMARY: '#6C3F6F'
-    };
-
     return (
       <div>
         <h1>
@@ -39,11 +45,11 @@ class ButtonDocs extends React.Component {
         <h3>Demo</h3>
         <div className='flex'>
           <Button>Primary</Button>
-          <Button style={style} type='primaryOutline'>Primary Outline</Button>
-          <Button style={style} type='secondary'>Secondary</Button>
-          <Button style={style} type='base'>Base</Button>
-          <Button style={style} type='neutral'>Neutral</Button>
-          <Button style={style} type='disabled'>Disabled</Button>
+          <Button style={buttonStyle} type='primaryOutline'>Primary Outline</Button>
+          <Button style={buttonStyle} type='secondary'>Secondary</Button>
+          <Button style={buttonStyle} type='base'>Base</Button>
+          <Button style={buttonStyle} type='neutral'>Neutral</Button>
+          <Button style={buttonStyle} type='disabled'>Disabled</Button>
         </div>
         <div
           className='flex'
@@ -54,12 +60,12 @@ class ButtonDocs extends React.Component {
             width: 150
           }}
         >
-          <Button style={style} type='primaryInverse'>Primary Inverse</Button>
+          <Button style={buttonStyle} type='primaryInverse'>Primary Inverse</Button>
         </div>
         <br /><br />
         <div className='flex'>
           <Button icon='add'>Icon</Button>
-          <Button aria-label='delete' icon='delete' style={style} />
+          <Button aria-label='delete' icon='delete' style={buttonStyle} />
         </div>
         <br /><br />
         <div className='flex'>
@@ -73,7 +79,7 @@ class ButtonDocs extends React.Component {
           <Button
             isActive={this.state.spinnerIsActive}
             onClick={this._handleSpinnerClick}
-            style={style}
+            style={buttonStyle}
           >
             Loading (spinner only)
           </Button>
@@ -81,7 +87,7 @@ class ButtonDocs extends React.Component {
         <h4>Custom Theme</h4>
         <div className='flex'>
           <Button theme={customTheme}>Primary</Button>
-          <Button style={style} theme={customTheme} type='disabled'>Disabled</Button>
+          <Button style={buttonStyle} theme={customTheme} type='disabled'>Disabled</Button>
         </div>
 
         <h3>Usage</h3>
@@ -117,9 +123,5 @@ class ButtonDocs extends React.Component {
     );
   }
 }
-
-const style = {
-  margin: '0 10px'
-};
 
 module.exports = ButtonDocs;

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -3,6 +3,7 @@ const { Link } = require('react-router');
 
 const { Button, Styles } = require('mx-react-components');
 
+const Code = require('components/Code');
 const Markdown = require('components/Markdown');
 
 const buttonStyle = {
@@ -92,25 +93,27 @@ class ButtonDocs extends React.Component {
 
         <h3>Usage</h3>
         <h5>actionText <label>String</label></h5>
-        <p>The button text when isActive is true. If not defined, a spinner without text is shown.</p>
+        <p>The button text when <Code>isActive</Code> is <Code>true</Code>. If not defined, a spinner without text is shown.</p>
 
         <h5>aria-label <label>String</label></h5>
-        <p>If defined, adds an aria-label attribute equal to the supplied value on the button element for accessibility.</p>
+        <p>If defined, adds an <Code>aria-label</Code> attribute equal to the supplied value on the button element for accessibility.</p>
         <p><a href='https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute'>aria-label documentation</a></p>
 
         <h5>icon <label>String</label></h5>
-        <p>This can be any of the Icon component values. If defined, an icon will be shown to the left of the button content.</p>
+        <p>This can be any of the <Code>Icon</Code> component values. If defined, an icon will be shown to the left of the button content.</p>
 
         <h5>isActive <label>Boolean</label></h5>
-        <p>Default: false</p>
-        <p>A boolean that is toggled when the button is clicked and when the item is finished loading..</p>
+        <p>Default: <Code>false</Code></p>
+        <p>When <Code>true</Code> the <Code>Button</Code> will show either the <Code>actionText</Code> or a spinner.</p>
 
         <h5>theme <label>Object</label></h5>
         <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
 
         <h5>type <label>String</label></h5>
-        <p>Default: 'primary'</p>
-        <p>This sets the button type. Available options are 'primary', 'primaryOutline', 'primaryInverse', 'secondary', 'base', 'neutral', and 'disabled'. Setting the type to `disabled` also prevents onClick events from firing.</p>
+        <p>Default: <Code>'primary'</Code></p>
+        <p>This sets the button type. Available options are:</p>
+        <code>['primary', 'primaryOutline', 'primaryInverse', 'secondary', 'base', 'neutral', 'disabled']</code>
+        <p>Setting the type to <Code>disabled</Code> also prevents onClick events from firing.</p>
 
         <h3>Example</h3>
         <Markdown>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -101,7 +101,7 @@ class ButtonDocs extends React.Component {
 
         <h5>theme <label>Object</label></h5>
         <p>Default: See Colors in <Link to='/components/styles'>Styles</Link></p>
-        <p>Customize any of the colors used in Button.</p>
+        <p>Customize the component&apos;s colors.</p>
 
         <h5>type <label>String</label></h5>
         <p>Default: 'primary'</p>

--- a/docs/components/Code.js
+++ b/docs/components/Code.js
@@ -1,0 +1,6 @@
+const React = require('react');
+
+const Code = (props) =>
+  <code {...props} style={{ display: 'inline', padding: 3 }}>{props.children}</code>;
+
+module.exports = Code;

--- a/docs/components/Components.js
+++ b/docs/components/Components.js
@@ -206,8 +206,9 @@ class Components extends React.Component {
             <h3>Responsive Grid</h3>
             <Link to='/components/row-column'>Row & Column</Link>
 
-            <h3>Helpers</h3>
+            <h3>Customization</h3>
             <Link to='/components/styles'>Styles</Link>
+            <Link to='/components/theme'>Theme</Link>
           </div>
         </div>
 

--- a/docs/components/StylesDocs.js
+++ b/docs/components/StylesDocs.js
@@ -44,7 +44,7 @@ class StylesDocs extends React.Component {
           <label>Contains values that are used throughout mx-react-components. Exposing it makes it easy to use the same colors, font sizes, fonts, etc throughout any application.</label>
         </h1>
 
-        <h3>Usage</h3>
+        <h3>Constants</h3>
 
         <h5>Neutral Colors</h5>
         <ColorsList colors={[
@@ -131,6 +131,8 @@ class StylesDocs extends React.Component {
             Styles.BreakPoints.small: 320
           `}
         </Markdown>
+
+        <h3>Utilities</h3>
 
         <h5>Adjust Color</h5>
         <p>Takes a HEX color and adjust amount and returns a HEX value of the new color. Negative numbers darken whereas positive numbers lighten the color.</p>

--- a/docs/components/StylesDocs.js
+++ b/docs/components/StylesDocs.js
@@ -3,6 +3,7 @@ const React = require('react');
 
 const { Styles } = require('mx-react-components');
 
+const Code = require('components/Code');
 const Markdown = require('components/Markdown');
 const StyleUtils = require('utils/Style');
 
@@ -91,7 +92,7 @@ class StylesDocs extends React.Component {
         </Markdown>
 
         <h5>Fonts</h5>
-        <p>In order to leverage the ProximaNova fonts, you will need to include those fonts in your application using @font_face and make sure the names match.</p>
+        <p>In order to leverage the ProximaNova fonts, you will need to include those fonts in your application using <Code>@font_face</Code> and make sure the names match.</p>
 
         <Markdown lang='js'>
           {`
@@ -180,7 +181,7 @@ class StylesDocs extends React.Component {
 
 
         <h5>Get Window Size</h5>
-        <p>Returns the <code style={{ display: 'inline', padding: 3 }}>Styles.BreakPoints</code> key for the current window width.</p>
+        <p>Returns the <Code>Styles.BreakPoints</Code> key for the current window width.</p>
         <Markdown lang='js'>
           {`
             StyleUtils.getWindowSize(Styles.BreakPoints) // e.g. returns 'large'

--- a/docs/components/ThemeDocs.js
+++ b/docs/components/ThemeDocs.js
@@ -1,0 +1,39 @@
+const React = require('react');
+const { Link } = require('react-router');
+
+const { Button } = require('mx-react-components');
+
+const Code = require('components/Code');
+const Markdown = require('components/Markdown');
+
+class ThemeDocs extends React.Component {
+  render () {
+    return (
+      <div>
+        <h1>
+          Theme
+          <label>Custom themes for mx-react-components.</label>
+        </h1>
+
+        <h3>Basic Usage</h3>
+        <p>The most common theming use case is to modify <Code>Colors.PRIMARY</Code>. For example:</p>
+        <Markdown lang='js'>
+          {`
+    <Button theme={{ Colors: { PRIMARY: '#6C3F6F' } }}>Click me!</Button>
+          `}
+        </Markdown>
+        <p><Button theme={{ Colors: { PRIMARY: '#b421c4' } }}>Click me!</Button></p>
+
+        <h3>Advanced Usage</h3>
+        <p>
+          For more complex theming please view the source code of the component and look for how the <Code>theme</Code> prop is used.
+          See <Link to='/components/styles'>Styles</Link> for the full list of theme-able constants.
+        </p>
+        <p>Here's a link to the <Code>Button</Code> component's source to get you started:</p>
+        <p><a href='https://github.com/mxenabled/mx-react-components/blob/master/src/components/Button.js'>https://github.com/mxenabled/mx-react-components/blob/master/src/components/Button.js</a></p>
+      </div>
+    );
+  }
+}
+
+module.exports = ThemeDocs;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -6,7 +6,7 @@ const Icon = require('./Icon');
 const Spin = require('./Spin');
 
 const StyleConstants = require('../constants/Style');
-const { buttonTypes } = require('../constants/App');
+const { buttonTypes, themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
 const { deprecatePrimaryColor } = require('../utils/Deprecation');
@@ -21,7 +21,7 @@ class Button extends React.Component {
     onClick: PropTypes.func,
     primaryColor: PropTypes.string,
     style: PropTypes.object,
-    theme: PropTypes.object,
+    theme: themeShape,
     type: PropTypes.oneOf(buttonTypes)
   };
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -21,13 +21,14 @@ class Button extends React.Component {
     onClick: PropTypes.func,
     primaryColor: PropTypes.string,
     style: PropTypes.object,
+    theme: PropTypes.object,
     type: PropTypes.oneOf(buttonTypes)
   };
 
   static defaultProps = {
     onClick () {},
     isActive: false,
-    primaryColor: StyleConstants.Colors.PRIMARY,
+    theme: StyleConstants,
     type: 'primary'
   };
 
@@ -85,6 +86,8 @@ class Button extends React.Component {
   }
 
   styles = () => {
+    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
+
     return {
       component: Object.assign({
         borderRadius: 2,
@@ -108,123 +111,123 @@ class Button extends React.Component {
         lineHeight: '20px'
       },
       primary: {
-        backgroundColor: StyleConstants.Colors.PRIMARY,
-        borderColor: StyleConstants.Colors.PRIMARY,
-        color: StyleConstants.Colors.WHITE,
-        fill: StyleConstants.Colors.WHITE,
+        backgroundColor: theme.PRIMARY,
+        borderColor: theme.PRIMARY,
+        color: theme.WHITE,
+        fill: theme.WHITE,
         transition: 'all .2s ease-in',
 
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -15),
-          borderColor: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -15),
+          backgroundColor: StyleUtils.adjustColor(theme.PRIMARY, -15),
+          borderColor: StyleUtils.adjustColor(theme.PRIMARY, -15),
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -30),
-          borderColor: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -30),
+          backgroundColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
+          borderColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
           transition: 'all .2s ease-in'
         }
       },
       primaryOutline: {
         backgroundColor: 'transparent',
-        borderColor: StyleConstants.Colors.PRIMARY,
-        color: StyleConstants.Colors.PRIMARY,
-        fill: StyleConstants.Colors.PRIMARY,
+        borderColor: theme.PRIMARY,
+        color: theme.PRIMARY,
+        fill: theme.PRIMARY,
         transition: 'all .2s ease-in',
 
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleConstants.Colors.PRIMARY,
-          color: StyleConstants.Colors.WHITE,
-          fill: StyleConstants.Colors.WHITE,
+          backgroundColor: theme.PRIMARY,
+          color: theme.WHITE,
+          fill: theme.WHITE,
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -30),
-          borderColor: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -30),
-          color: StyleConstants.Colors.WHITE,
-          fill: StyleConstants.Colors.WHITE,
+          backgroundColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
+          borderColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
+          color: theme.WHITE,
+          fill: theme.WHITE,
           transition: 'all .2s ease-in'
         }
       },
       primaryInverse: {
-        backgroundColor: StyleConstants.Colors.WHITE,
-        borderColor: StyleConstants.Colors.WHITE,
-        color: StyleConstants.Colors.PRIMARY,
-        fill: StyleConstants.Colors.PRIMARY,
+        backgroundColor: theme.WHITE,
+        borderColor: theme.WHITE,
+        color: theme.PRIMARY,
+        fill: theme.PRIMARY,
         transition: 'all .2s ease-in',
 
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.WHITE, -15),
-          borderColor: StyleUtils.adjustColor(StyleConstants.Colors.WHITE, -15),
+          backgroundColor: StyleUtils.adjustColor(theme.WHITE, -15),
+          borderColor: StyleUtils.adjustColor(theme.WHITE, -15),
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.WHITE, -30),
-          borderColor: StyleUtils.adjustColor(StyleConstants.Colors.WHITE, -30),
+          backgroundColor: StyleUtils.adjustColor(theme.WHITE, -30),
+          borderColor: StyleUtils.adjustColor(theme.WHITE, -30),
           transition: 'all .2s ease-in'
         }
       },
       secondary: {
         backgroundColor: 'transparent',
-        borderColor: StyleConstants.Colors.GRAY_500,
-        color: StyleConstants.Colors.GRAY_500,
-        fill: StyleConstants.Colors.GRAY_500,
+        borderColor: theme.GRAY_500,
+        color: theme.GRAY_500,
+        fill: theme.GRAY_500,
         transition: 'all .2s ease-in',
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleConstants.Colors.GRAY_500,
-          borderColor: StyleConstants.Colors.GRAY_500,
-          color: StyleConstants.Colors.WHITE,
-          fill: StyleConstants.Colors.WHITE,
+          backgroundColor: theme.GRAY_500,
+          borderColor: theme.GRAY_500,
+          color: theme.WHITE,
+          fill: theme.WHITE,
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.GRAY_500, -30),
-          borderColor: StyleUtils.adjustColor(StyleConstants.Colors.GRAY_500, -30),
-          color: StyleConstants.Colors.WHITE,
-          fill: StyleConstants.Colors.WHITE,
+          backgroundColor: StyleUtils.adjustColor(theme.GRAY_500, -30),
+          borderColor: StyleUtils.adjustColor(theme.GRAY_500, -30),
+          color: theme.WHITE,
+          fill: theme.WHITE,
           transition: 'all .2s ease-in'
         }
       },
       base: {
         backgroundColor: 'transparent',
-        color: StyleConstants.Colors.PRIMARY,
-        fill: StyleConstants.Colors.PRIMARY,
+        color: theme.PRIMARY,
+        fill: theme.PRIMARY,
         transition: 'all .2s ease-in',
         borderColor: 'transparent',
         borderRadius: 2,
         borderWidth: 1,
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          color: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -8),
-          fill: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -8),
+          color: StyleUtils.adjustColor(theme.PRIMARY, -8),
+          fill: StyleUtils.adjustColor(theme.PRIMARY, -8),
           transition: 'all .2s ease-in',
-          borderColor: StyleConstants.Colors.GRAY_300
+          borderColor: theme.GRAY_300
         },
         ':active': {
-          color: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -16),
-          fill: StyleUtils.adjustColor(StyleConstants.Colors.PRIMARY, -16),
+          color: StyleUtils.adjustColor(theme.PRIMARY, -16),
+          fill: StyleUtils.adjustColor(theme.PRIMARY, -16),
           transition: 'all .2s ease-in',
-          backgroundColor: StyleConstants.Colors.GRAY_100
+          backgroundColor: theme.GRAY_100
         }
       },
       neutral: {
         backgroundColor: 'transparent',
-        borderColor: StyleConstants.Colors.GRAY_300,
+        borderColor: theme.GRAY_300,
         borderRadius: 2,
         borderWidth: 1,
-        color: StyleConstants.Colors.PRIMARY,
-        fill: StyleConstants.Colors.PRIMARY,
+        color: theme.PRIMARY,
+        fill: theme.PRIMARY,
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleConstants.Colors.GRAY_100
+          backgroundColor: theme.GRAY_100
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(StyleConstants.Colors.GRAY_100, -15)
+          backgroundColor: StyleUtils.adjustColor(theme.GRAY_100, -15)
         }
       },
       disabled: {
         backgroundColor: 'transparent',
-        borderColor: StyleConstants.Colors.GRAY_300,
-        color: StyleConstants.Colors.GRAY_300,
-        fill: StyleConstants.Colors.GRAY_300
+        borderColor: theme.GRAY_300,
+        color: theme.GRAY_300,
+        fill: theme.GRAY_300
       },
       icon: {
         marginLeft: this._hasVisibleChildren() ? -4 : 0,

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -36,8 +36,8 @@ class Button extends React.Component {
     deprecatePrimaryColor(this.props);
   }
 
-  _isLargeOrMediumWindowSize = () => {
-    const windowSize = StyleUtils.getWindowSize(StyleConstants.BreakPoints);
+  _windowSizeIsSmall = (theme) => {
+    const windowSize = StyleUtils.getWindowSize(theme.BreakPoints);
 
     return windowSize === 'medium' || windowSize === 'large';
   };
@@ -91,6 +91,7 @@ class Button extends React.Component {
 
   styles = () => {
     const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
+    const windowSizeIsSmall = this._windowSizeIsSmall(theme);
 
     return {
       component: Object.assign({
@@ -101,8 +102,8 @@ class Button extends React.Component {
         boxSizing: 'border-box',
         display: 'inline-block',
         padding: '4px 14px',
-        fontSize: StyleConstants.FontSizes.MEDIUM,
-        fontFamily: StyleConstants.Fonts.SEMIBOLD,
+        fontSize: theme.FontSizes.MEDIUM,
+        fontFamily: theme.Fonts.SEMIBOLD,
         cursor: this.props.type === 'disabled' ? 'default' : 'pointer',
         transition: 'all .2s ease-in',
         minWidth: 16,
@@ -121,7 +122,7 @@ class Button extends React.Component {
         fill: theme.Colors.WHITE,
         transition: 'all .2s ease-in',
 
-        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+        ':hover': windowSizeIsSmall ? null : {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -15),
           borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -15),
           transition: 'all .2s ease-in'
@@ -139,7 +140,7 @@ class Button extends React.Component {
         fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
 
-        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+        ':hover': windowSizeIsSmall ? null : {
           backgroundColor: theme.Colors.PRIMARY,
           color: theme.Colors.WHITE,
           fill: theme.Colors.WHITE,
@@ -160,7 +161,7 @@ class Button extends React.Component {
         fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
 
-        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+        ':hover': windowSizeIsSmall ? null : {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.WHITE, -15),
           borderColor: StyleUtils.adjustColor(theme.Colors.WHITE, -15),
           transition: 'all .2s ease-in'
@@ -177,7 +178,7 @@ class Button extends React.Component {
         color: theme.Colors.GRAY_500,
         fill: theme.Colors.GRAY_500,
         transition: 'all .2s ease-in',
-        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+        ':hover': windowSizeIsSmall ? null : {
           backgroundColor: theme.Colors.GRAY_500,
           borderColor: theme.Colors.GRAY_500,
           color: theme.Colors.WHITE,
@@ -200,7 +201,7 @@ class Button extends React.Component {
         borderColor: 'transparent',
         borderRadius: 2,
         borderWidth: 1,
-        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+        ':hover': windowSizeIsSmall ? null : {
           color: StyleUtils.adjustColor(theme.Colors.PRIMARY, -8),
           fill: StyleUtils.adjustColor(theme.Colors.PRIMARY, -8),
           transition: 'all .2s ease-in',
@@ -220,7 +221,7 @@ class Button extends React.Component {
         borderWidth: 1,
         color: theme.Colors.PRIMARY,
         fill: theme.Colors.PRIMARY,
-        ':hover': !this._isLargeOrMediumWindowSize() ? null : {
+        ':hover': windowSizeIsSmall ? null : {
           backgroundColor: theme.Colors.GRAY_100
         },
         ':active': {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -115,123 +115,123 @@ class Button extends React.Component {
         lineHeight: '20px'
       },
       primary: {
-        backgroundColor: theme.PRIMARY,
-        borderColor: theme.PRIMARY,
-        color: theme.WHITE,
-        fill: theme.WHITE,
+        backgroundColor: theme.Colors.PRIMARY,
+        borderColor: theme.Colors.PRIMARY,
+        color: theme.Colors.WHITE,
+        fill: theme.Colors.WHITE,
         transition: 'all .2s ease-in',
 
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleUtils.adjustColor(theme.PRIMARY, -15),
-          borderColor: StyleUtils.adjustColor(theme.PRIMARY, -15),
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -15),
+          borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -15),
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
-          borderColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
+          borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
           transition: 'all .2s ease-in'
         }
       },
       primaryOutline: {
         backgroundColor: 'transparent',
-        borderColor: theme.PRIMARY,
-        color: theme.PRIMARY,
-        fill: theme.PRIMARY,
+        borderColor: theme.Colors.PRIMARY,
+        color: theme.Colors.PRIMARY,
+        fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
 
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: theme.PRIMARY,
-          color: theme.WHITE,
-          fill: theme.WHITE,
+          backgroundColor: theme.Colors.PRIMARY,
+          color: theme.Colors.WHITE,
+          fill: theme.Colors.WHITE,
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
-          borderColor: StyleUtils.adjustColor(theme.PRIMARY, -30),
-          color: theme.WHITE,
-          fill: theme.WHITE,
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
+          borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
+          color: theme.Colors.WHITE,
+          fill: theme.Colors.WHITE,
           transition: 'all .2s ease-in'
         }
       },
       primaryInverse: {
-        backgroundColor: theme.WHITE,
-        borderColor: theme.WHITE,
-        color: theme.PRIMARY,
-        fill: theme.PRIMARY,
+        backgroundColor: theme.Colors.WHITE,
+        borderColor: theme.Colors.WHITE,
+        color: theme.Colors.PRIMARY,
+        fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
 
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: StyleUtils.adjustColor(theme.WHITE, -15),
-          borderColor: StyleUtils.adjustColor(theme.WHITE, -15),
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.WHITE, -15),
+          borderColor: StyleUtils.adjustColor(theme.Colors.WHITE, -15),
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(theme.WHITE, -30),
-          borderColor: StyleUtils.adjustColor(theme.WHITE, -30),
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.WHITE, -30),
+          borderColor: StyleUtils.adjustColor(theme.Colors.WHITE, -30),
           transition: 'all .2s ease-in'
         }
       },
       secondary: {
         backgroundColor: 'transparent',
-        borderColor: theme.GRAY_500,
-        color: theme.GRAY_500,
-        fill: theme.GRAY_500,
+        borderColor: theme.Colors.GRAY_500,
+        color: theme.Colors.GRAY_500,
+        fill: theme.Colors.GRAY_500,
         transition: 'all .2s ease-in',
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: theme.GRAY_500,
-          borderColor: theme.GRAY_500,
-          color: theme.WHITE,
-          fill: theme.WHITE,
+          backgroundColor: theme.Colors.GRAY_500,
+          borderColor: theme.Colors.GRAY_500,
+          color: theme.Colors.WHITE,
+          fill: theme.Colors.WHITE,
           transition: 'all .2s ease-in'
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(theme.GRAY_500, -30),
-          borderColor: StyleUtils.adjustColor(theme.GRAY_500, -30),
-          color: theme.WHITE,
-          fill: theme.WHITE,
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.GRAY_500, -30),
+          borderColor: StyleUtils.adjustColor(theme.Colors.GRAY_500, -30),
+          color: theme.Colors.WHITE,
+          fill: theme.Colors.WHITE,
           transition: 'all .2s ease-in'
         }
       },
       base: {
         backgroundColor: 'transparent',
-        color: theme.PRIMARY,
-        fill: theme.PRIMARY,
+        color: theme.Colors.PRIMARY,
+        fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
         borderColor: 'transparent',
         borderRadius: 2,
         borderWidth: 1,
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          color: StyleUtils.adjustColor(theme.PRIMARY, -8),
-          fill: StyleUtils.adjustColor(theme.PRIMARY, -8),
+          color: StyleUtils.adjustColor(theme.Colors.PRIMARY, -8),
+          fill: StyleUtils.adjustColor(theme.Colors.PRIMARY, -8),
           transition: 'all .2s ease-in',
-          borderColor: theme.GRAY_300
+          borderColor: theme.Colors.GRAY_300
         },
         ':active': {
-          color: StyleUtils.adjustColor(theme.PRIMARY, -16),
-          fill: StyleUtils.adjustColor(theme.PRIMARY, -16),
+          color: StyleUtils.adjustColor(theme.Colors.PRIMARY, -16),
+          fill: StyleUtils.adjustColor(theme.Colors.PRIMARY, -16),
           transition: 'all .2s ease-in',
-          backgroundColor: theme.GRAY_100
+          backgroundColor: theme.Colors.GRAY_100
         }
       },
       neutral: {
         backgroundColor: 'transparent',
-        borderColor: theme.GRAY_300,
+        borderColor: theme.Colors.GRAY_300,
         borderRadius: 2,
         borderWidth: 1,
-        color: theme.PRIMARY,
-        fill: theme.PRIMARY,
+        color: theme.Colors.PRIMARY,
+        fill: theme.Colors.PRIMARY,
         ':hover': !this._isLargeOrMediumWindowSize() ? null : {
-          backgroundColor: theme.GRAY_100
+          backgroundColor: theme.Colors.GRAY_100
         },
         ':active': {
-          backgroundColor: StyleUtils.adjustColor(theme.GRAY_100, -15)
+          backgroundColor: StyleUtils.adjustColor(theme.Colors.GRAY_100, -15)
         }
       },
       disabled: {
         backgroundColor: 'transparent',
-        borderColor: theme.GRAY_300,
-        color: theme.GRAY_300,
-        fill: theme.GRAY_300
+        borderColor: theme.Colors.GRAY_300,
+        color: theme.Colors.GRAY_300,
+        fill: theme.Colors.GRAY_300
       },
       icon: {
         marginLeft: this._hasVisibleChildren() ? -4 : 0,

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -2,14 +2,14 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
+const Icon = require('./Icon');
 const Spin = require('./Spin');
 
 const StyleConstants = require('../constants/Style');
-const StyleUtils = require('../utils/Style');
-
-const Icon = require('../components/Icon');
-
 const { buttonTypes } = require('../constants/App');
+
+const StyleUtils = require('../utils/Style');
+const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class Button extends React.Component {
   static propTypes = {
@@ -31,6 +31,10 @@ class Button extends React.Component {
     theme: StyleConstants,
     type: 'primary'
   };
+
+  componentDidMount () {
+    deprecatePrimaryColor(this.props);
+  }
 
   _isLargeOrMediumWindowSize = () => {
     const windowSize = StyleUtils.getWindowSize(StyleConstants.BreakPoints);

--- a/src/constants/App.js
+++ b/src/constants/App.js
@@ -1,3 +1,15 @@
+const PropTypes = require('prop-types');
+
+const StyleConstants = require('./Style');
+
+const shapeForObject = (obj, propType) =>
+  PropTypes.shape(
+    Object.keys(obj).reduce((shape, key) => {
+      shape[key] = propType;
+      return shape;
+    }, {})
+  );
+
 module.exports = {
   buttonTypes: [
     'base',
@@ -945,5 +957,9 @@ module.exports = {
       displayValue: 'wedding',
       value: 'wedding'
     }
-  ]
+  ],
+
+  themeShape: PropTypes.shape({
+    Colors: shapeForObject(StyleConstants.Colors, PropTypes.string)
+  })
 };

--- a/src/utils/Deprecation.js
+++ b/src/utils/Deprecation.js
@@ -1,0 +1,7 @@
+module.exports = {
+  deprecatePrimaryColor (props) {
+    if (props.primaryColor) {
+      console.warn('primaryColor is deprecated and will be removed in a future release. Use theme instead.');
+    }
+  }
+};

--- a/src/utils/Style.js
+++ b/src/utils/Style.js
@@ -74,7 +74,7 @@ const StyleUtils = {
    * @returns {Object}
    */
   mergeTheme (theme, primaryColor) {
-    return Object.assign({}, StyleConstants.Colors, theme, primaryColor && { PRIMARY: primaryColor });
+    return Object.assign({}, StyleConstants.Colors, primaryColor && { PRIMARY: primaryColor }, theme);
   }
 };
 

--- a/src/utils/Style.js
+++ b/src/utils/Style.js
@@ -1,3 +1,5 @@
+const StyleConstants = require('../constants/Style');
+
 const StyleUtils = {
   adjustColor (col, amt) {
     let color = col;
@@ -62,6 +64,17 @@ const StyleUtils = {
     }
 
     return windowSize;
+  },
+
+  /**
+   * Abstraction to simplify merging theme colors.
+   *
+   * @param {Object} theme - Override keys in StyleConstants.Colors
+   * @param {String} primaryColor - Will be deprecated in a future release once it has been replaced by `theme` in each component
+   * @returns {Object}
+   */
+  mergeTheme (theme, primaryColor) {
+    return Object.assign({}, StyleConstants.Colors, theme, primaryColor && { PRIMARY: primaryColor });
   }
 };
 

--- a/src/utils/Style.js
+++ b/src/utils/Style.js
@@ -1,3 +1,5 @@
+const _merge = require('lodash/merge');
+
 const StyleConstants = require('../constants/Style');
 
 const StyleUtils = {
@@ -69,12 +71,14 @@ const StyleUtils = {
   /**
    * Abstraction to simplify merging theme colors.
    *
-   * @param {Object} theme - Override keys in StyleConstants.Colors
-   * @param {String} primaryColor - Will be deprecated in a future release once it has been replaced by `theme` in each component
+   * @param {Object} theme - Override keys in StyleConstants
+   * @param {String} primaryColor - Deprecated, will be removed in a future release once it has been replaced by `theme` in each component
    * @returns {Object}
    */
   mergeTheme (theme, primaryColor) {
-    return Object.assign({}, StyleConstants.Colors, primaryColor && { PRIMARY: primaryColor }, theme);
+    const primaryColorTheme = primaryColor && { Colors: { PRIMARY: primaryColor } };
+
+    return _merge({}, StyleConstants, primaryColorTheme, theme);
   }
 };
 


### PR DESCRIPTION
_Targets: `joe/theme-master` branch for #588_

This introduces a pattern for adding a `theme` prop to a component while keeping the `primaryColor` prop in place but deprecated.

Here's an example of the demo with themed buttons:

![screen shot 2017-06-07 at 10 09 06 am](https://user-images.githubusercontent.com/4348/26889553-d4e6f018-4b6b-11e7-9603-65d8484faa3e.png)
