### PR TITLE
Rachel/input type

### DIFF
--- a/docs/components/DisplayInputDocs.js
+++ b/docs/components/DisplayInputDocs.js
@@ -82,10 +82,6 @@ class DisplayInputDocs extends React.Component {
         <h5>hint <label>String</label></h5>
         <p>Hint text to display to user on input hover.</p>
 
-        <h5>inputType <label>String</label></h5>
-        <p>Default: 'text'</p>
-        <p>Used to customize the HTML input type.</p>
-
         <h5>isFocused <label>Boolean</label></h5>
         <p>When providing custom children use this to indicate that the component has focus.</p>
 

--- a/docs/components/DisplayInputDocs.js
+++ b/docs/components/DisplayInputDocs.js
@@ -82,6 +82,10 @@ class DisplayInputDocs extends React.Component {
         <h5>hint <label>String</label></h5>
         <p>Hint text to display to user on input hover.</p>
 
+        <h5>inputType <label>String</label></h5>
+        <p>Default: 'text'</p>
+        <p>Used to customize the HTML input type.</p>
+
         <h5>isFocused <label>Boolean</label></h5>
         <p>When providing custom children use this to indicate that the component has focus.</p>
 

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -28,7 +28,9 @@ class DisplayInput extends React.Component {
   };
 
   static defaultProps = {
-    elementProps: {},
+    elementProps: {
+      type: 'text'
+    },
     isFocused: false,
     primaryColor: StyleConstants.Colors.PRIMARY,
     valid: true
@@ -88,6 +90,7 @@ class DisplayInput extends React.Component {
                     id={this._inputId}
                     key='input'
                     style={styles.input}
+                    type='text'
                   />
                 </div>
               )}

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -90,7 +90,6 @@ class DisplayInput extends React.Component {
                     id={this._inputId}
                     key='input'
                     style={styles.input}
-                    type='text'
                   />
                 </div>
               )}

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -14,7 +14,6 @@ class DisplayInput extends React.Component {
     childrenStyle: PropTypes.object,
     elementProps: PropTypes.object,
     hint: PropTypes.string,
-    inputType: PropTypes.string,
     isFocused: PropTypes.bool,
     label: PropTypes.string,
     labelStyle: PropTypes.object,

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -30,7 +30,6 @@ class DisplayInput extends React.Component {
 
   static defaultProps = {
     elementProps: {},
-    inputType: 'text',
     isFocused: false,
     primaryColor: StyleConstants.Colors.PRIMARY,
     valid: true
@@ -90,7 +89,6 @@ class DisplayInput extends React.Component {
                     id={this._inputId}
                     key='input'
                     style={styles.input}
-                    type={this.props.inputType}
                   />
                 </div>
               )}

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -14,6 +14,7 @@ class DisplayInput extends React.Component {
     childrenStyle: PropTypes.object,
     elementProps: PropTypes.object,
     hint: PropTypes.string,
+    inputType: PropTypes.string,
     isFocused: PropTypes.bool,
     label: PropTypes.string,
     labelStyle: PropTypes.object,
@@ -29,6 +30,7 @@ class DisplayInput extends React.Component {
 
   static defaultProps = {
     elementProps: {},
+    inputType: 'text',
     isFocused: false,
     primaryColor: StyleConstants.Colors.PRIMARY,
     valid: true
@@ -88,7 +90,7 @@ class DisplayInput extends React.Component {
                     id={this._inputId}
                     key='input'
                     style={styles.input}
-                    type='text'
+                    type={this.props.inputType}
                   />
                 </div>
               )}


### PR DESCRIPTION
The `DisplayInput` component was setting the HTML input prop to text. Removing this will allow us to set the type of the HTML input as part of `elementProps`.