### PR TITLE
Add a 'pill' type to Tabs [INHERITANCE]

### DIFF
--- a/docs/components/TabsDocs.js
+++ b/docs/components/TabsDocs.js
@@ -17,6 +17,8 @@ class TabsDocs extends React.Component {
   };
 
   render () {
+    const tabs = ['Donuts', 'Ice Cream', 'Bacon', 'Chicken'];
+
     return (
       <div>
         <h1>
@@ -25,19 +27,29 @@ class TabsDocs extends React.Component {
         </h1>
 
         <h3>Demo</h3>
+
         <Tabs
           onTabSelect={this._handleTabSelect}
           selectedTab={this.state.selectedTab}
-          tabs={['Donuts', 'Ice Cream', 'Bacon', 'Chicken']}
+          tabs={tabs}
         />
+
         <Tabs
           alignment='center'
           onTabSelect={this._handleTabSelect}
           selectedTab={this.state.selectedTab}
-          tabs={['Donuts', 'Ice Cream', 'Bacon', 'Chicken']}
+          tabs={tabs}
+        />
+
+        <Tabs
+          onTabSelect={this._handleTabSelect}
+          selectedTab={this.state.selectedTab}
+          tabs={tabs}
+          type='pill'
         />
 
         <h3>Usage</h3>
+
         <h5>activeTabStyles<label>Object</label></h5>
         <p>Styles for the active tab.</p>
 
@@ -64,22 +76,43 @@ class TabsDocs extends React.Component {
         <p>Default: PRIMARY</p>
         <p><em>(required)</em> Array of values that you want respresented as tabs. Each item in the array should be a string. The "onTabClick" function will be called when you click on each one.</p>
 
+        <h5>type <label>One of: ['standard', 'pill']</label></h5>
+        <p>Default: standard</p>
+        <p></p>
+
         <h5>DEPRECATED: useTabsInMobile <label>Boolean</label></h5>
         <p>Deprecated. For dropdown style tabs please use <Link to='/components/select'>Select</Link> instead.</p>
 
         <h3>Example</h3>
         <Markdown>
           {`
-            _handleTabSelect (selectedTab) {
-                 this.setState({
-                   selectedTab
-                 });
-             },
+            const tabs = ['Donuts', 'Ice Cream', 'Bacon', 'Chicken'];
+            const _handleTabSelect = (selectedTab) => {
+              this.setState({
+                selectedTab
+              });
+             };
+
+            ...
 
             <Tabs
               onTabSelect={this._handleTabSelect}
               selectedTab={this.state.selectedTab}
-              tabs={['Donuts', 'Ice Cream', 'Bacon', 'Chicken']}
+              tabs={tabs}
+            />
+
+            <Tabs
+              alignment='center'
+              onTabSelect={this._handleTabSelect}
+              selectedTab={this.state.selectedTab}
+              tabs={tabs}
+            />
+
+            <Tabs
+              onTabSelect={this._handleTabSelect}
+              selectedTab={this.state.selectedTab}
+              tabs={tabs}
+              type='pill'
             />
           `}
         </Markdown>

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -4,27 +4,26 @@ const Radium = require('radium');
 
 const StyleConstants = require('../constants/Style');
 
-class Tabs extends React.Component {
+class StandardTabs extends React.Component {
   static propTypes = {
     activeTabStyles: PropTypes.object,
-    alignment: PropTypes.oneOf(['left', 'center']),
     brandColor: PropTypes.string,
     onTabSelect: PropTypes.func.isRequired,
     selectedTab: PropTypes.number,
-    showBottomBorder: PropTypes.bool,
-    tabs: PropTypes.array.isRequired,
-    useTabsInMobile: PropTypes.bool
+    tabs: PropTypes.array.isRequired
   };
 
   static defaultProps = {
-    alignment: 'left',
-    brandColor: StyleConstants.Colors.PRIMARY,
-    showBottomBorder: true
+    brandColor: StyleConstants.Colors.PRIMARY
   };
 
-  state = {
-    selectedTab: this.props.selectedTab || 0
-  };
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      selectedTab: this.props.selectedTab || 0
+    };
+  }
 
   componentWillMount () {
     if (this.props.hasOwnProperty('useTabsInMobile')) {
@@ -40,25 +39,22 @@ class Tabs extends React.Component {
     }
   }
 
-  _handleTabClick = (selectedTab) => {
+  handleTabSelect (selectedTab) {
     this.props.onTabSelect(selectedTab);
 
     this.setState({
       selectedTab
     });
-  };
+  }
 
   render () {
-    const styles = this.styles();
-    const componentStyles = Object.assign({}, styles.component, styles.tabsContainer, this.props.style);
-
     return (
-      <div style={componentStyles}>
+      <div>
         {this.props.tabs.map((tab, index) =>
           <Tab
             isActive={this.state.selectedTab === index}
             key={tab}
-            onClick={this._handleTabClick.bind(null, index)}
+            onClick={this.handleTabSelect.bind(this, index)}
             styles={{ activeTab: this.props.activeTabStyles }}
           >
             {tab}
@@ -67,24 +63,6 @@ class Tabs extends React.Component {
       </div>
     );
   }
-
-  styles = () => {
-    return {
-      // Block styles
-      component: {
-        display: 'block',
-        width: '100%'
-      },
-      tabsContainer: {
-        borderBottom: this.props.showBottomBorder ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
-        boxSizing: 'border-box',
-        display: 'flex',
-        justifyContent: this.props.alignment === 'left' ? 'flex-start' : 'center',
-        overflowX: 'scroll',
-        width: '100%'
-      }
-    };
-  };
 }
 
 class TabWithoutRadium extends React.Component {
@@ -147,5 +125,47 @@ class TabWithoutRadium extends React.Component {
 }
 
 const Tab = Radium(TabWithoutRadium);
+
+const TabsTypes = {
+  standard: StandardTabs
+};
+
+const Tabs = ({
+  alignment = 'left',
+  showBottomBorder = true,
+  style,
+  type = 'standard',
+  useTabsInMobile,
+  ...props
+}) => {
+  if (typeof useTabsInMobile !== 'undefined') {
+    console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release. Please use `type=\'menu\'`.');
+  }
+
+  const componentStyle = Object.assign({
+    borderBottom: showBottomBorder ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
+    boxSizing: 'border-box',
+    display: 'flex',
+    justifyContent: alignment === 'left' ? 'flex-start' : 'center',
+    overflowX: 'scroll',
+    width: '100%'
+  }, style);
+  const TabsComponent = TabsTypes[type];
+
+  if (!TabsComponent) throw new Error(`Unknown Tabs type: ${type}`);
+
+  return (
+    <div style={componentStyle}>
+      <TabsComponent {...props} />
+    </div>
+  );
+};
+
+Tabs.propTypes = {
+  alignment: PropTypes.oneOf(['left', 'center']),
+  showBottomBorder: PropTypes.bool,
+  type: PropTypes.oneOf(Object.keys(TabsTypes)),
+  useTabsInMobile: PropTypes.bool
+};
 
 module.exports = Tabs;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -2,6 +2,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
+const ButtonGroup = require('./ButtonGroup');
 const StyleConstants = require('../constants/Style');
 
 class StandardTabs extends React.Component {
@@ -126,8 +127,73 @@ class TabWithoutRadium extends React.Component {
 
 const Tab = Radium(TabWithoutRadium);
 
+class PillTabs extends StandardTabs {
+  render () {
+    const styles = this.styles();
+
+    return (
+      <div style={styles.component}>
+        <ButtonGroup
+          buttons={this.props.tabs.map((tab, index) => ({
+            'aria-label': tab,
+            onClick: (this.state.selectedTab === index ? null : this.handleTabSelect.bind(this, index)),
+            style: Object.assign({}, styles.tab, this.state.selectedTab === index && styles.selected),
+            text: tab
+          }))}
+          style={styles.buttonGroup}
+          type='neutral'
+        />
+      </div>
+    );
+  }
+
+  styles = () => {
+    return {
+      component: {
+        margin: StyleConstants.Spacing.SMALL
+      },
+      tab: {
+        backgroundColor: StyleConstants.Colors.PORCELAIN,
+        borderColor: StyleConstants.Colors.FOG,
+        outline: 'none',
+
+        ':hover': {
+          backgroundColor: this.props.brandColor,
+          color: StyleConstants.Colors.WHITE,
+          fill: StyleConstants.Colors.WHITE
+        },
+        ':focus': {
+          backgroundColor: this.props.brandColor,
+          color: StyleConstants.Colors.WHITE,
+          fill: StyleConstants.Colors.WHITE
+        },
+        ':active': {
+          backgroundColor: StyleConstants.adjustColor(this.props.brandColor, -15)
+        }
+      },
+      selected: {
+        backgroundColor: StyleConstants.Colors.WHITE,
+        color: this.props.brandColor,
+        cursor: 'default',
+
+        ':hover': {
+          backgroundColor: 'transparent'
+        },
+        ':focus': {
+          backgroundColor: StyleConstants.Colors.WHITE,
+          color: this.props.brandColor
+        },
+        ':active': {
+          backgroundColor: 'transparent'
+        }
+      }
+    };
+  }
+}
+
 const TabsTypes = {
-  standard: StandardTabs
+  standard: StandardTabs,
+  pill: PillTabs
 };
 
 const Tabs = ({
@@ -139,7 +205,7 @@ const Tabs = ({
   ...props
 }) => {
   if (typeof useTabsInMobile !== 'undefined') {
-    console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release. Please use `type=\'menu\'`.');
+    console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release.');
   }
 
   const componentStyle = Object.assign({

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -26,12 +26,6 @@ class StandardTabs extends React.Component {
     };
   }
 
-  componentWillMount () {
-    if (this.props.hasOwnProperty('useTabsInMobile')) {
-      console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release.');
-    }
-  }
-
   componentWillReceiveProps (nextProps) {
     if (nextProps.selectedTab !== this.state.selectedTab) {
       this.setState({


### PR DESCRIPTION
INHERITANCE style (see discussion in #583)

----

This adds the missing `pill` type to `Tabs` as described in the Aggro Design System (see #567).

Other notable changes include:
- Add a `type` prop
- Extract `StandardTabs` from `Tabs`
- `Tabs` is now a wrapping component that chooses which style to render based on the `type` prop

Closes https://github.com/mxenabled/mx-react-components/issues/567

