### PR TITLE
Add a 'pill' type to Tabs [COMPOSITION 1]

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,64 +1,18 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
+const _pick = require('lodash/pick');
 
 const ButtonGroup = require('./ButtonGroup');
 const StyleConstants = require('../constants/Style');
 
-class StandardTabs extends React.Component {
-  static propTypes = {
-    activeTabStyles: PropTypes.object,
-    brandColor: PropTypes.string,
-    onTabSelect: PropTypes.func.isRequired,
-    selectedTab: PropTypes.number,
-    tabs: PropTypes.array.isRequired
-  };
-
-  static defaultProps = {
-    brandColor: StyleConstants.Colors.PRIMARY
-  };
-
-  constructor (props) {
-    super(props);
-
-    this.state = {
-      selectedTab: this.props.selectedTab || 0
-    };
-  }
-
-  componentWillReceiveProps (nextProps) {
-    if (nextProps.selectedTab !== this.state.selectedTab) {
-      this.setState({
-        selectedTab: nextProps.selectedTab
-      });
-    }
-  }
-
-  handleTabSelect (selectedTab) {
-    this.props.onTabSelect(selectedTab);
-
-    this.setState({
-      selectedTab
-    });
-  }
-
-  render () {
-    return (
-      <div>
-        {this.props.tabs.map((tab, index) =>
-          <Tab
-            isActive={this.state.selectedTab === index}
-            key={tab}
-            onClick={this.handleTabSelect.bind(this, index)}
-            styles={{ activeTab: this.props.activeTabStyles }}
-          >
-            {tab}
-          </Tab>
-        )}
-      </div>
-    );
-  }
-}
+const TabsPropTypes = {
+  activeTabStyles: PropTypes.object,
+  brandColor: PropTypes.string,
+  onTabSelect: PropTypes.func.isRequired,
+  selectedTab: PropTypes.number,
+  tabs: PropTypes.array.isRequired
+};
 
 class TabWithoutRadium extends React.Component {
   static propTypes = {
@@ -121,111 +75,161 @@ class TabWithoutRadium extends React.Component {
 
 const Tab = Radium(TabWithoutRadium);
 
-class PillTabs extends StandardTabs {
-  render () {
-    const styles = this.styles();
+const StandardTabs = (props) => (
+  <div>
+    {props.tabs.map((tab, index) =>
+      <Tab
+        isActive={props.selectedTab === index}
+        key={tab}
+        onClick={props.onTabSelect.bind(this, index)}
+        styles={{ activeTab: props.activeTabStyles }}
+      >
+        {tab}
+      </Tab>
+     )}
+  </div>
+);
 
-    return (
-      <div style={styles.component}>
-        <ButtonGroup
-          buttons={this.props.tabs.map((tab, index) => ({
-            'aria-label': tab,
-            onClick: (this.state.selectedTab === index ? null : this.handleTabSelect.bind(this, index)),
-            style: Object.assign({}, styles.tab, this.state.selectedTab === index && styles.selected),
-            text: tab
-          }))}
-          style={styles.buttonGroup}
-          type='neutral'
-        />
-      </div>
-    );
-  }
+StandardTabs.propTypes = TabsPropTypes;
 
-  styles = () => {
-    return {
-      component: {
-        margin: StyleConstants.Spacing.SMALL
+const PillTabs = (props) => {
+  const styles = {
+    component: {
+      margin: StyleConstants.Spacing.SMALL
+    },
+    tab: {
+      backgroundColor: StyleConstants.Colors.PORCELAIN,
+      borderColor: StyleConstants.Colors.FOG,
+      outline: 'none',
+
+      ':hover': {
+        backgroundColor: props.brandColor,
+        color: StyleConstants.Colors.WHITE,
+        fill: StyleConstants.Colors.WHITE
       },
-      tab: {
-        backgroundColor: StyleConstants.Colors.PORCELAIN,
-        borderColor: StyleConstants.Colors.FOG,
-        outline: 'none',
-
-        ':hover': {
-          backgroundColor: this.props.brandColor,
-          color: StyleConstants.Colors.WHITE,
-          fill: StyleConstants.Colors.WHITE
-        },
-        ':focus': {
-          backgroundColor: this.props.brandColor,
-          color: StyleConstants.Colors.WHITE,
-          fill: StyleConstants.Colors.WHITE
-        },
-        ':active': {
-          backgroundColor: StyleConstants.adjustColor(this.props.brandColor, -15)
-        }
+      ':focus': {
+        backgroundColor: props.brandColor,
+        color: StyleConstants.Colors.WHITE,
+        fill: StyleConstants.Colors.WHITE
       },
-      selected: {
-        backgroundColor: StyleConstants.Colors.WHITE,
-        color: this.props.brandColor,
-        cursor: 'default',
-
-        ':hover': {
-          backgroundColor: 'transparent'
-        },
-        ':focus': {
-          backgroundColor: StyleConstants.Colors.WHITE,
-          color: this.props.brandColor
-        },
-        ':active': {
-          backgroundColor: 'transparent'
-        }
+      ':active': {
+        backgroundColor: StyleConstants.adjustColor(props.brandColor, -15)
       }
-    };
-  }
-}
+    },
+    selected: {
+      backgroundColor: StyleConstants.Colors.WHITE,
+      color: props.brandColor,
+      cursor: 'default',
+
+      ':hover': {
+        backgroundColor: 'transparent'
+      },
+      ':focus': {
+        backgroundColor: StyleConstants.Colors.WHITE,
+        color: props.brandColor
+      },
+      ':active': {
+        backgroundColor: 'transparent'
+      }
+    }
+  };
+
+  return (
+    <div style={styles.component}>
+      <ButtonGroup
+        buttons={props.tabs.map((tab, index) => ({
+          'aria-label': tab,
+          onClick: (props.selectedTab === index ? null : props.onTabSelect.bind(this, index)),
+          style: Object.assign({}, styles.tab, props.selectedTab === index && styles.selected),
+          text: tab
+        }))}
+        style={styles.buttonGroup}
+        type='neutral'
+      />
+    </div>
+  );
+};
+
+PillTabs.propTypes = TabsPropTypes;
 
 const TabsTypes = {
   standard: StandardTabs,
   pill: PillTabs
 };
 
-const Tabs = ({
-  alignment = 'left',
-  showBottomBorder = true,
-  style,
-  type = 'standard',
-  useTabsInMobile,
-  ...props
-}) => {
-  if (typeof useTabsInMobile !== 'undefined') {
-    console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release.');
+class TabsWrapper extends React.Component {
+  static propTypes = Object.assign({
+    alignment: PropTypes.oneOf(['left', 'center']),
+    showBottomBorder: PropTypes.bool,
+    type: PropTypes.oneOf(Object.keys(TabsTypes)),
+    useTabsInMobile: PropTypes.bool
+  }, TabsPropTypes);
+
+  static defaultProps = {
+    alignment: 'left',
+    brandColor: StyleConstants.Colors.PRIMARY,
+    showBottomBorder: true,
+    type: 'standard'
+  };
+
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      selectedTab: this.props.selectedTab || 0
+    };
   }
 
-  const componentStyle = Object.assign({
-    borderBottom: showBottomBorder ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
-    boxSizing: 'border-box',
-    display: 'flex',
-    justifyContent: alignment === 'left' ? 'flex-start' : 'center',
-    overflowX: 'scroll',
-    width: '100%'
-  }, style);
-  const TabsComponent = TabsTypes[type];
+  componentWillMount () {
+    if (this.props.hasOwnProperty('useTabsInMobile')) {
+      console.warn('The useTabsInMobile prop is deprecated and will be removed in a future release.');
+    }
+  }
 
-  if (!TabsComponent) throw new Error(`Unknown Tabs type: ${type}`);
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.selectedTab !== this.state.selectedTab) {
+      this.setState({
+        selectedTab: nextProps.selectedTab
+      });
+    }
+  }
 
-  return (
-    <div style={componentStyle}>
-      <TabsComponent {...props} />
-    </div>
-  );
-};
+  handleTabSelect (selectedTab) {
+    this.props.onTabSelect(selectedTab);
 
-Tabs.propTypes = {
-  alignment: PropTypes.oneOf(['left', 'center']),
-  showBottomBorder: PropTypes.bool,
-  type: PropTypes.oneOf(Object.keys(TabsTypes)),
-  useTabsInMobile: PropTypes.bool
-};
+    this.setState({
+      selectedTab
+    });
+  }
 
-module.exports = Tabs;
+  render () {
+    const componentStyle = Object.assign({
+      borderBottom: this.props.showBottomBorder ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
+      boxSizing: 'border-box',
+      display: 'flex',
+      justifyContent: this.props.alignment === 'left' ? 'flex-start' : 'center',
+      overflowX: 'scroll',
+      width: '100%'
+    }, this.props.style);
+    const TabsComponent = TabsTypes[this.props.type];
+
+    if (!TabsComponent) throw new Error(`Unknown Tabs type: ${this.props.type}`);
+
+    const tabsProps = Object.assign(
+      _pick(this.props, Object.keys(TabsPropTypes)),
+      {
+        onTabSelect: this.handleTabSelect.bind(this), // delegate for keeping state
+        selectedTab: this.props.selectedTab
+      }
+    );
+
+
+    return (
+      <div style={componentStyle}>
+        <TabsComponent {...tabsProps} />
+      </div>
+    );
+  }
+}
+
+module.exports = TabsWrapper;


### PR DESCRIPTION
COMPOSITION style (see discussion in #583)
`TabsWrapper` manages tab state, styles, and type selection

I wasn't satisfied with this version so I created an alternative that I like better: #606

----

This adds the missing `pill` type to `Tabs` as described in the Aggro Design System (see #567).

Other notable changes include:
- Add a `type` prop
- Extract `StandardTabs` from `Tabs`
- `Tabs` is now a wrapping component that chooses which style to render based on the `type` prop

Closes https://github.com/mxenabled/mx-react-components/issues/567
