### PR TITLE
Add theme to d3 components for TimeBasedLineChart

### DIFF
--- a/src/components/d3/BarTimeXAxis.js
+++ b/src/components/d3/BarTimeXAxis.js
@@ -5,11 +5,14 @@ const d3 = require('d3');
 const moment = require('moment');
 const _merge = require('lodash/merge');
 
-const StyleConstants = require('../../constants/Style');
+const { themeShape } = require('../../constants/App');
+
+const StyleUtils = require('../../utils/Style');
 
 class BarTimeXAxis extends React.Component {
   static propTypes = {
     style: PropTypes.object,
+    theme: themeShape,
     tickRange: PropTypes.array,
     tickSize: PropTypes.number,
     tickValues: PropTypes.array,
@@ -48,7 +51,8 @@ class BarTimeXAxis extends React.Component {
   };
 
   _styleChart = () => {
-    const style = _merge({}, this.styles(), this.props.style);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
+    const style = _merge({}, this.styles(theme), this.props.style);
     const axis = d3.select(this.timeAxis);
 
     // Style x axis labels
@@ -70,16 +74,16 @@ class BarTimeXAxis extends React.Component {
     );
   }
 
-  styles = () => {
+  styles = (theme) => {
     return {
       text: {
-        fill: StyleConstants.Colors.GRAY_500,
+        fill: theme.Colors.GRAY_500,
         stroke: 'none',
-        'font-size': StyleConstants.FontSizes.MEDIUM,
+        'font-size': theme.FontSizes.MEDIUM,
         'text-anchor': 'middle'
       },
       path: {
-        stroke: StyleConstants.Colors.GRAY_300,
+        stroke: theme.Colors.GRAY_300,
         'stroke-width': 1,
         fill: 'none'
       }

--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -1,7 +1,9 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const StyleConstants = require('../../constants/Style');
+const { themeShape } = require('../../constants/App');
+
+const StyleUtils = require('../../utils/Style');
 
 class CirclesGroup extends React.Component {
   static propTypes = {
@@ -13,6 +15,7 @@ class CirclesGroup extends React.Component {
     onCircleClick: PropTypes.func,
     shouldAnimate: PropTypes.bool,
     strokeWidth: PropTypes.number,
+    theme: themeShape,
     translation: PropTypes.string,
     useCircleOverlay: PropTypes.bool,
     xScaleValueFunction: PropTypes.func.isRequired,
@@ -20,7 +23,6 @@ class CirclesGroup extends React.Component {
   };
 
   static defaultProps = {
-    circleColor: StyleConstants.Colors.GRAY_700,
     circleOverlayRadius: 6,
     circleRadius: 3,
     onCircleClick: () => {},
@@ -49,6 +51,8 @@ class CirclesGroup extends React.Component {
   render () {
     const { adjustedHeight, circleOverlayRadius, circleRadius, data, shouldAnimate, translation, useCircleOverlay, xScaleValueFunction, yScaleValueFunction } = this.props;
     const preventCircleOverlapCutOff = 45;
+    const theme = StyleUtils.mergeTheme(this.props.theme);
+    const circleColor = this.props.circleColor || theme.Colors.GRAY_700;
 
     return (
       <g
@@ -67,14 +71,14 @@ class CirclesGroup extends React.Component {
                   className='circle'
                   cx={cx}
                   cy={cy}
-                  fill={StyleConstants.Colors.WHITE}
+                  fill={theme.Colors.WHITE}
                   onClick={() => {
                     if (!useCircleOverlay) {
                       this.props.onCircleClick(item);
                     }
                   }}
                   r={circleRadius}
-                  stroke={this.props.circleColor}
+                  stroke={circleColor}
                   style={{ 'strokeWidth': this.props.strokeWidth }}
                 />
                 {useCircleOverlay && (
@@ -82,7 +86,7 @@ class CirclesGroup extends React.Component {
                     className='circle-overlay'
                     cx={cx}
                     cy={yScaleValueFunction(item.y)}
-                    fill={StyleConstants.Colors.WHITE}
+                    fill={theme.Colors.WHITE}
                     onClick={() => {
                       this.props.onCircleClick(item);
                     }}

--- a/src/components/d3/LineGroup.js
+++ b/src/components/d3/LineGroup.js
@@ -3,7 +3,9 @@ const React = require('react');
 
 const d3 = require('d3');
 
-const StyleConstants = require('../../constants/Style');
+const { themeShape } = require('../../constants/App');
+
+const StyleUtils = require('../../utils/Style');
 
 class LineGroup extends React.Component {
   static propTypes = {
@@ -13,6 +15,7 @@ class LineGroup extends React.Component {
     lineColor: PropTypes.string,
     shouldAnimate: PropTypes.bool,
     strokeWidth: PropTypes.number,
+    theme: themeShape,
     translation: PropTypes.string,
     xScaleValueFunction: PropTypes.func.isRequired,
     yScaleValueFunction: PropTypes.func.isRequired
@@ -20,7 +23,6 @@ class LineGroup extends React.Component {
 
   static defaultProps = {
     dashLine: false,
-    lineColor: StyleConstants.Colors.GRAY_700,
     shouldAnimate: true,
     strokeWidth: 2,
     translation: 'translate(0,0)'
@@ -64,7 +66,9 @@ class LineGroup extends React.Component {
   };
 
   render () {
-    const { data, dashLine, lineColor, shouldAnimate, strokeWidth, translation } = this.props;
+    const theme = StyleUtils.mergeTheme(this.props.theme);
+    const lineColor = this.props.lineColor || theme.Colors.GRAY_700;
+    const { data, dashLine, shouldAnimate, strokeWidth, translation } = this.props;
 
     return (
       <g className='chart-line-group' transform={translation}>

--- a/src/components/d3/ShadedAreaRectangleGroup.js
+++ b/src/components/d3/ShadedAreaRectangleGroup.js
@@ -1,13 +1,16 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const StyleConstants = require('../../constants/Style');
+const { themeShape } = require('../../constants/App');
+
+const StyleUtils = require('../../utils/Style');
 
 class ShadedAreaRectangleGroup extends React.Component {
   static propTypes = {
     fillColor: PropTypes.string,
     fillOpacity: PropTypes.number,
     height: PropTypes.number.isRequired,
+    theme: themeShape,
     translation: PropTypes.string,
     width: PropTypes.number.isRequired,
     x: PropTypes.number.isRequired,
@@ -15,16 +18,18 @@ class ShadedAreaRectangleGroup extends React.Component {
   };
 
   static defaultProps = {
-    fillColor: StyleConstants.Colors.GRAY_300,
     fillOpacity: 0.1,
     translation: 'translate(0,0)'
   };
 
   render () {
+    const theme = StyleUtils.mergeTheme(this.props.theme);
+    const fillColor = this.props.fillColor || theme.Colors.GRAY_300;
+
     return (
       <g className='shaded-area'>
         <rect
-          fill={this.props.fillColor}
+          fill={fillColor}
           fillOpacity={this.props.fillOpacity}
           height={this.props.height}
           transform={this.props.translation}

--- a/src/components/d3/ShadedHatchPatternRectangleGroup.js
+++ b/src/components/d3/ShadedHatchPatternRectangleGroup.js
@@ -1,12 +1,15 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const StyleConstants = require('../../constants/Style');
+const { themeShape } = require('../../constants/App');
+
+const StyleUtils = require('../../utils/Style');
 
 class ShadedHatchPatternRectangleGroup extends React.Component {
   static propTypes = {
     fillColor: PropTypes.string,
     height: PropTypes.number.isRequired,
+    theme: themeShape,
     translation: PropTypes.string,
     width: PropTypes.number.isRequired,
     x: PropTypes.number.isRequired,
@@ -14,11 +17,13 @@ class ShadedHatchPatternRectangleGroup extends React.Component {
   };
 
   static defaultProps = {
-    fillColor: StyleConstants.Colors.GRAY_300,
     translation: 'translate(0,0)'
   };
 
   render () {
+    const theme = StyleUtils.mergeTheme(this.props.theme);
+    const fillColor = this.props.fillColor || theme.Colors.GRAY_300;
+
     return (
       <g className='shaded-hatch-pattern'>
         <pattern
@@ -29,7 +34,7 @@ class ShadedHatchPatternRectangleGroup extends React.Component {
         >
           <path
             d='M-1,1 l2,-2 M0,4 l4,-4 M3,5 l2,-2'
-            stroke={this.props.fillColor}
+            stroke={fillColor}
             strokeWidth={1}
           />
         </pattern>


### PR DESCRIPTION
_Targets: `joe/theme-master` branch for #588_

Add theme to d3 components for `TimeBasedLineChart`.

- LineGroup
- ShadedAreaRectangleGroup
- ShadedHatchPatternRectangleGroup
- BarTimeXAxis
- CirclesGroup

`TimeBasedLineChart` was converted in #621 