### PR TITLE
Update FileUpload to validate extensions and show errors

### DIFF
--- a/docs/components/FileUploadDocs.js
+++ b/docs/components/FileUploadDocs.js
@@ -27,7 +27,16 @@ class FileUploadDocs extends React.Component {
         <div style={{ cursor: 'pointer', textAlign: 'center', width: '80%', margin: 'auto' }}>
           <FileUpload
             allowedFileTypes={['image/jpeg', 'text/csv', 'image/png', 'gif']}
-
+            imageValidation={{
+              exactHeight: 200,
+              exactWidth: 400,
+              maxHeight: 400,
+              maxWidth: 800,
+              minHeight: 100,
+              minWidth: 200,
+              ratioHeight: 1,
+              ratioWidth: 2
+            }}
             maxFileSize={3000}
             onFileAdd={this._handleFileChange}
             onFileRemove={this._handleFileChange}

--- a/docs/components/FileUploadDocs.js
+++ b/docs/components/FileUploadDocs.js
@@ -26,21 +26,11 @@ class FileUploadDocs extends React.Component {
         <h3>Demo</h3>
         <div style={{ cursor: 'pointer', textAlign: 'center', width: '80%', margin: 'auto' }}>
           <FileUpload
-            allowedFileTypes={['image/jpeg', 'text/csv', 'image/png']}
-            imageValidation={{
-              exactHeight: 200,
-              exactWidth: 400,
-              maxHeight: 400,
-              maxWidth: 800,
-              minHeight: 100,
-              minWidth: 200,
-              ratioHeight: 1,
-              ratioWidth: 2
-            }}
+            allowedFileTypes={['image/jpeg', 'text/csv', 'image/png', 'gif']}
+
             maxFileSize={3000}
             onFileAdd={this._handleFileChange}
             onFileRemove={this._handleFileChange}
-            onFileValidation={this._handleFileValidation}
             uploadedFile={this.state.uploadedFile}
           >
             Click Here to Upload File (demo).
@@ -100,7 +90,7 @@ class FileUploadDocs extends React.Component {
     }
 
     <FileUpload
-      allowedFileTypes={['image/jpeg', 'text/csv', 'image/png']}
+      allowedFileTypes={['image/jpeg', 'text/csv', 'image/png', 'gif']}
       imageValidation={{
         exactHeight: 200,
         exactWidth: 400,
@@ -114,7 +104,6 @@ class FileUploadDocs extends React.Component {
       maxFileSize={3000}
       onFileAdd={this._handleFileChange}
       onFileRemove={this._handleFileChange}
-      onFileValidation={this._handleFileValidation}
       uploadedFile={this.state.uploadedFile}
     />
   `}

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -233,10 +233,8 @@ class FileUpload extends React.Component {
     }
 
     if (this.props.onFileValidation) {
-      return this.props.onFileValidation(failedValidationTypes);
-    }
-
-    if (failedValidationTypes.length) {
+      this.props.onFileValidation(failedValidationTypes);
+    } else if (failedValidationTypes.length) {
       this.setState({
         dragging: false,
         failedValidationTypes

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -224,7 +224,7 @@ class FileUpload extends React.Component {
       failedValidationTypes.push('file_size');
     }
 
-    if (isInvalidFileType && isInvalidFileExtension) {
+    if (isInvalidFileType || isInvalidFileExtension) {
       failedValidationTypes.push('file_type');
     }
 
@@ -242,9 +242,9 @@ class FileUpload extends React.Component {
         failedValidationTypes
       });
 
-      return this.props.onFileRemove(this.props.uploadedFile);
+      this.props.onFileRemove(this.props.uploadedFile);
     } else {
-      return this.props.onFileAdd(file);
+      this.props.onFileAdd(file);
     }
   };
 
@@ -280,7 +280,7 @@ class FileUpload extends React.Component {
                   type='secondary'
                 />
               </div>
-            ) : null }
+            ) : null}
           </div>
         ) : (
           <div style={styles.dropzoneChild}>
@@ -295,7 +295,7 @@ class FileUpload extends React.Component {
                   this.state.failedValidationTypes.map(validationType => {
                     return (<div style={styles.invalidMessage}>{this._getDefaultValidationMessage(validationType)}</div>);
                   })
-              ) : null }
+              ) : null}
                 {this.props.children}
               </div>
             )}

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -31,7 +31,8 @@ class FileUpload extends React.Component {
 
   state = {
     dragging: false,
-    imageSource: null
+    imageSource: null,
+    failedValidationTypes: []
   };
 
   componentDidMount () {
@@ -48,6 +49,43 @@ class FileUpload extends React.Component {
         this._validateFile(result.file, result.width, result.height);
       });
     }
+  }
+
+  _getDefaultValidationMessage (validationType) {
+    let validationMessage = 'Selected file did not meet requirements';
+
+    switch (validationType) {
+      case 'exact_height':
+        validationMessage = 'Image requires an exact height of ' + this.props.imageValidation.exactHeight + ' pixels';
+        break;
+      case 'exact_width':
+        validationMessage = 'Image requires an exact width of ' + this.props.imageValidation.exactWidth + ' pixels';
+        break;
+      case 'file_size':
+        validationMessage = 'File size is too large. Must be ' + this.props.maxFileSize + 'k or less.';
+        break;
+      case 'file_type':
+        validationMessage = 'Unpermitted File Type. Must be one of: ' + this.props.allowedFileTypes.join(', ');
+        break;
+      case 'image_ratio':
+        validationMessage = 'Image ratio must be ' + this.props.imageValidation.ratioHeight + 'px/' + this.props.imageValidation.ratioWidth + 'px';
+        break;
+      case 'max_height':
+        validationMessage = 'Maximum Image height of ' + this.props.imageValidation.maxHeight + ' exceeded';
+        break;
+      case 'max_width':
+        validationMessage = 'Maximum Image width of ' + this.props.imageValidation.maxWidth + ' exceeded';
+        break;
+      case 'min_height':
+        validationMessage = 'Image must have minimum heigh of ' + this.props.imageValidation.minHeight + ' pixels';
+        break;
+      case 'min_width':
+        validationMessage = 'Image must have minimum width of ' + this.props.imageValidation.minWidth + ' pixels';
+        break;
+      default:
+        break;
+    }
+    return validationMessage;
   }
 
   _handleFileSelect = (e) => {
@@ -140,66 +178,73 @@ class FileUpload extends React.Component {
   };
 
   _validateImageDimensions = (width, height) => {
-    const validationMessages = [];
+    const failedImageValidationTypes = [];
 
-    if (this.props.onFileValidation && this.props.imageValidation) {
+    if (this.props.imageValidation) {
       if (this.props.imageValidation.exactHeight && this.props.imageValidation.exactHeight !== height) {
-        validationMessages.push('exact_height');
+        failedImageValidationTypes.push('exact_height');
       }
 
       if (this.props.imageValidation.exactWidth && this.props.imageValidation.exactWidth !== width) {
-        validationMessages.push('exact_width');
+        failedImageValidationTypes.push('exact_width');
       }
 
       if (this.props.imageValidation.maxHeight && this.props.imageValidation.maxHeight < height) {
-        validationMessages.push('max_height');
+        failedImageValidationTypes.push('max_height');
       }
 
       if (this.props.imageValidation.maxWidth && this.props.imageValidation.maxWidth < width) {
-        validationMessages.push('max_width');
+        failedImageValidationTypes.push('max_width');
       }
 
       if (this.props.imageValidation.minHeight && this.props.imageValidation.minHeight > height) {
-        validationMessages.push('min_height');
+        failedImageValidationTypes.push('min_height');
       }
 
       if (this.props.imageValidation.minWidth && this.props.imageValidation.minWidth > width) {
-        validationMessages.push('min_width');
+        failedImageValidationTypes.push('min_width');
       }
 
       if (this.props.imageValidation.ratioHeight && this.props.imageValidation.ratioWidth && (this.props.imageValidation.ratioHeight / this.props.imageValidation.ratioWidth !== height / width)) {
-        validationMessages.push('image_ratio');
+        failedImageValidationTypes.push('image_ratio');
       }
     }
 
-    return validationMessages;
+    return failedImageValidationTypes;
   };
 
   _validateFile = (file, width = null, height = null) => {
-    const validationMessages = this._validateImageDimensions(width, height);
+    let failedValidationTypes = [];
+    const fileExt = file.name.split('.').pop();
     const isTooBig = this.props.maxFileSize < file.size / 1000;
-    const isInvalidType = this.props.allowedFileTypes && this.props.allowedFileTypes.indexOf(file.type) < 0;
+    const isInvalidFileType = this.props.allowedFileTypes && this.props.allowedFileTypes.indexOf(file.type) < 0;
+    const isInvalidFileExtension = this.props.allowedFileTypes && this.props.allowedFileTypes.indexOf(fileExt) < 0;
 
-    if (this.props.onFileValidation) {
-      if (isTooBig) {
-        validationMessages.push('file_size');
-      }
-
-      if (isInvalidType) {
-        validationMessages.push('file_type');
-      }
-
-      this.props.onFileValidation(validationMessages);
+    if (isTooBig) {
+      failedValidationTypes.push('file_size');
     }
 
-    if (validationMessages.length) {
+    if (isInvalidFileType && isInvalidFileExtension) {
+      failedValidationTypes.push('file_type');
+    }
+
+    if (failedValidationTypes.indexOf('file_type') < 0 && failedValidationTypes.indexOf('file_size') < 0) {
+      failedValidationTypes = failedValidationTypes.concat(this._validateImageDimensions(width, height));
+    }
+
+    if (this.props.onFileValidation) {
+      return this.props.onFileValidation(failedValidationTypes);
+    }
+
+    if (failedValidationTypes.length) {
       this.setState({
-        dragging: false
+        dragging: false,
+        failedValidationTypes
       });
 
-      this.props.onFileRemove(this.props.uploadedFile);
+      return this.props.onFileRemove(this.props.uploadedFile);
     } else {
-      this.props.onFileAdd(file);
+      return this.props.onFileAdd(file);
     }
   };
 
@@ -235,7 +280,7 @@ class FileUpload extends React.Component {
                   type='secondary'
                 />
               </div>
-            ) : null}
+            ) : null }
           </div>
         ) : (
           <div style={styles.dropzoneChild}>
@@ -246,6 +291,11 @@ class FileUpload extends React.Component {
               </div>
             ) : (
               <div style={styles.centered}>
+              {this.state.failedValidationTypes.length > 0 ? (
+                  this.state.failedValidationTypes.map(validationType => {
+                    return (<div style={styles.invalidMessage}>{this._getDefaultValidationMessage(validationType)}</div>);
+                  })
+              ) : null }
                 {this.props.children}
               </div>
             )}
@@ -323,7 +373,8 @@ class FileUpload extends React.Component {
       },
       invalidMessage: {
         fontSize: StyleConstants.FontSizes.LARGE,
-        marginBottom: 10
+        marginBottom: 10,
+        color: StyleConstants.Colors.STRAWBERRY
       },
       invalidIcon: {
         color: StyleConstants.Colors.ASH


### PR DESCRIPTION
I noticed `FileUpload` docs state you could use extensions in the `allowedFileTypes` option, but it wasn't actually filtering.

So this changes that to filter on extension if the type has not already been filtered

A few other changes:
* Skips validating image fields if the `file_type` or `file_size` is already invalid (no point wasting time)
* By default, adds red error messages for each `failedValidationType` so there is feedback to the user why a file won't upload
* If `onFileValidation` callback is present, skips the default and uses the callback instead to allow custom implementation

![screen shot 2017-06-21 at 2 03 13 pm](https://user-images.githubusercontent.com/11321326/27404683-34532abe-568c-11e7-9773-8a5b6a6c603b.png)

cc/ @lukeschunk @jmo @paniclater 