### PR TITLE
fix check for invalid type and extension

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -224,7 +224,7 @@ class FileUpload extends React.Component {
       failedValidationTypes.push('file_size');
     }
 
-    if (isInvalidFileType || isInvalidFileExtension) {
+    if (isInvalidFileType && isInvalidFileExtension) {
       failedValidationTypes.push('file_type');
     }
 


### PR DESCRIPTION
I remembered why I needed `&&` to check this condition.

We're checking `invalidity` with an `if` statement. So in order for this to evaluate, we would need both to be invalid. 

The way it is now a valid extension still gets flagged because it's an invalid file type. 🤦‍♂️ 

cc @iheartrachie @lukeschunk 