### PR TITLE
Corrects filter on TimeXAxis ticks prop for TimeBasedLineChart

### DIFF
--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -558,9 +558,7 @@ class TimeBasedLineChart extends React.Component {
               <TimeXAxisGroup
                 ticks={
                   data.filter((datum, index) => {
-                    const isMonthRangeType = this.props.rangeType === 'month';
-
-                    return isMonthRangeType || index % 3 === 0;
+                    return index % Math.ceil(data.length / 10) === 0;
                   })
                   .map(datum => {
                     return moment.unix(datum.x).utc().unix();


### PR DESCRIPTION
Showing more than 10 ticks on the x axis can be problematic as dates
can over lap.  Previously we used modulus/3 for just the case where the
type was day and did no correction for month. This allowed over lap in
the case where the date range for the graph was large enough to have
many ticks on the x axis.

We now just calc a modulus value based upon the data’s length / 10 to
ensure that we show the correct number of ticks in all cases.

### Before
![screen shot 2017-06-28 at 1 33 47 pm](https://user-images.githubusercontent.com/6463914/27656585-b9e6bc0c-5c06-11e7-877a-dcf6764913ee.png)

### After
![screen shot 2017-06-28 at 1 34 17 pm](https://user-images.githubusercontent.com/6463914/27656589-bfb65598-5c06-11e7-9136-99847408a8c8.png)
