### PR TITLE
luke/adds focusable false to icon buttons

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -64,7 +64,7 @@ class Button extends React.Component {
         <div style={styles.children}>
           {(this.props.icon && !this.props.isActive) && (
             <Icon
-              elementProps={{ 'aria-hidden': true }}
+              elementProps={{ 'aria-hidden': true, focusable: false }}
               size={20}
               style={styles.icon}
               type={this.props.icon}
@@ -72,7 +72,7 @@ class Button extends React.Component {
           )}
           {this.props.isActive && (
             <Spin direction='counterclockwise'>
-              <Icon elementProps={{ 'aria-hidden': true }} size={20} type='spinner' />
+              <Icon elementProps={{ 'aria-hidden': true, focusable: false }} size={20} type='spinner' />
             </Spin>
           )}
           <div style={styles.buttonText}>


### PR DESCRIPTION
SVG Icons inside of Buttons were causing me a lot of issues in IE and when using the screen reader. This adds the `focusable: false` attribute on uses of `<Icon />` in button. 

Here's an explanation i found super useful. 

>The `<svg>` elements inside focusable elements (like links or buttons) in Internet Explorer default to focusable=”true” due to a bug. This causes both the parent element and the `<svg>` to receive focus. The focus indicator disappears when the image file receives focus, which is a problem for sighted keyboard-only users. Additionally, some screen readers read the content twice since parts of it get focus twice.

>The way to fix this is to add focusable=”false” to the `<svg>` to set the attribute to what it should be by default.