### PR TITLE
luke/added default aria-label & focusable to Icon, removed usage in Button

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -64,7 +64,6 @@ class Button extends React.Component {
         <div style={styles.children}>
           {(this.props.icon && !this.props.isActive) && (
             <Icon
-              elementProps={{ 'aria-hidden': true, focusable: false }}
               size={20}
               style={styles.icon}
               type={this.props.icon}
@@ -72,7 +71,7 @@ class Button extends React.Component {
           )}
           {this.props.isActive && (
             <Spin direction='counterclockwise'>
-              <Icon elementProps={{ 'aria-hidden': true, focusable: false }} size={20} type='spinner' />
+              <Icon size={20} type='spinner' />
             </Spin>
           )}
           <div style={styles.buttonText}>

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -10,7 +10,10 @@ class Icon extends React.Component {
   };
 
   static defaultProps = {
-    elementProps: {},
+    elementProps: {
+      'aria-hidden': true,
+      focusable: false
+    },
     size: 24,
     type: 'accounts'
   };


### PR DESCRIPTION
We decided that having `aria-hidden: true` and `focusable: false` set as defaults on our `<Icon />` SVGs would be a good way to go. 

I added them in default props rather then right on the `<svg>` tag so we can still override if necessary. 