### PR TITLE
only showing calendar icon if not small device

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -314,15 +314,18 @@ class DateRangePicker extends React.Component {
   render () {
     const styles = this.styles();
     const spans = this.spans();
+    const shouldShowCalendarIcon = StyleConstants.getWindowSize() !== 'small';
 
     return (
       <div style={styles.component}>
         <div onClick={this._toggleCalendar} style={styles.selectedDateWrapper}>
-          <Icon
-            size={20}
-            style={styles.selectedDateIcon}
-            type='calendar'
-          />
+          {shouldShowCalendarIcon ? (
+            <Icon
+              size={20}
+              style={styles.selectedDateIcon}
+              type='calendar'
+            />
+          ) : null}
           <div style={styles.selectedDateText}>
             {this.props.selectedStartDate && this.props.selectedEndDate ? (
               <div>


### PR DESCRIPTION
When the xsmall size was removed here it accidentally started showing the calendar icon on iphone 5 and similar 'small' sized devices.

This adds that check back in without adding the 'xsmall' size.

Here was the change:
https://github.com/mxenabled/mx-react-components/commit/466ca4df54dd67e3e432ad7646cabaa429cfc15e

The old check would actually return xsmall if the device size was `width <= breakPoints.small` the greater than or equals check is what broke the calendar icon display.

before: 

![screen shot 2017-07-18 at 4 45 42 pm](https://user-images.githubusercontent.com/1081167/28343081-c343e27a-6bd8-11e7-91a0-7af8ffd3cddf.png)

after:

![screen shot 2017-07-18 at 4 46 49 pm](https://user-images.githubusercontent.com/1081167/28343087-c8ee5f66-6bd8-11e7-993c-604a05152315.png)


