### PR TITLE
Luke/daterangepicker mobile css fix

### DIFF
--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -57,7 +57,7 @@ class SelectionPane extends React.Component {
         borderRight: isLargeOrMediumWindowSize ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
         padding: StyleConstants.Spacing.MEDIUM,
         boxSizing: 'border-box',
-        width: isLargeOrMediumWindowSize ? 255 : '100%'
+        width: isLargeOrMediumWindowSize ? 275 : '100%'
       },
       calendarHeaderNav: {
         width: 35,

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -57,7 +57,7 @@ class SelectionPane extends React.Component {
         borderRight: isLargeOrMediumWindowSize ? '1px solid ' + StyleConstants.Colors.FOG : 'none',
         padding: StyleConstants.Spacing.MEDIUM,
         boxSizing: 'border-box',
-        width: isLargeOrMediumWindowSize ? 275 : '100%'
+        width: isLargeOrMediumWindowSize ? 255 : '100%'
       },
       calendarHeaderNav: {
         width: 35,

--- a/src/components/DateRangePickerTest.js
+++ b/src/components/DateRangePickerTest.js
@@ -370,14 +370,14 @@ class DateRangePicker extends React.Component {
         right: isLargeOrMediumWindowSize ? 'auto' : 0,
         transform: isLargeOrMediumWindowSize ? 'translateX(-50%)' : null,
         zIndex: 10,
-        maxWidth: 575,
+        maxWidth: 540,
         width: window.innerWidth
       },
       calendarWrapper: {
         boxSizing: 'border-box',
         padding: isLargeOrMediumWindowSize ? 20 : 10,
         margin: 'auto',
-        maxWidth: 275,
+        maxWidth: 255,
         width: isLargeOrMediumWindowSize ? 275 : '100%'
       },
 

--- a/src/components/DateRangePickerTest.js
+++ b/src/components/DateRangePickerTest.js
@@ -370,14 +370,14 @@ class DateRangePicker extends React.Component {
         right: isLargeOrMediumWindowSize ? 'auto' : 0,
         transform: isLargeOrMediumWindowSize ? 'translateX(-50%)' : null,
         zIndex: 10,
-        maxWidth: 540,
+        maxWidth: 575,
         width: window.innerWidth
       },
       calendarWrapper: {
         boxSizing: 'border-box',
-        padding: isLargeOrMediumWindowSize ? 20 : 10,
+        padding: 20,
         margin: 'auto',
-        maxWidth: 255,
+        maxWidth: 275,
         width: isLargeOrMediumWindowSize ? 275 : '100%'
       },
 

--- a/src/components/DateRangePickerTest.js
+++ b/src/components/DateRangePickerTest.js
@@ -369,7 +369,9 @@ class DateRangePicker extends React.Component {
         left: isLargeOrMediumWindowSize ? '50%' : 0,
         right: isLargeOrMediumWindowSize ? 'auto' : 0,
         transform: isLargeOrMediumWindowSize ? 'translateX(-50%)' : null,
-        zIndex: 10
+        zIndex: 10,
+        maxWidth: 575,
+        width: window.innerWidth
       },
       calendarWrapper: {
         boxSizing: 'border-box',


### PR DESCRIPTION
When testing this internally I was getting an error with the positioning on mobile.

 It was caused by the fact that the `optionsWrapper` are positioned absolutely, however, the component was being nested inside of elements with `position: relative` and thus not taking up the whole width of the window (which is desired on mobile). 


