### PR TITLE
implemented _isEqual props check in Icon shouldComponentUpdate

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,5 +1,6 @@
 const PropTypes = require('prop-types');
 const React = require('react');
+const _isEqual = require('lodash/isEqual');
 
 class Icon extends React.Component {
   static propTypes = {
@@ -17,6 +18,10 @@ class Icon extends React.Component {
     size: 24,
     type: 'accounts'
   };
+
+  shouldComponentUpdate (nextProps) {
+    return !_isEqual(nextProps, this.props);
+  }
 
   _renderSvg = () => {
     switch (this.props.type) {


### PR DESCRIPTION
This implements shouldComponentUpdate in the `<Icon />` component. This should fix performance bugs caused from the Icon re-rendering too many times. 

I tried to use [React.PureComponent](https://facebook.github.io/react/docs/react-api.html#react.purecomponent) but that wasn't working as it does a shallow comparison, and elementProps is an object. 

