### PR TITLE
Fix for common height issues in Drawer component.

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,4 +1,5 @@
 const _isNumber = require('lodash/isNumber');
+const _get = require('lodash/get');
 const PropTypes = require('prop-types');
 const { StyleRoot } = require('radium');
 const FocusTrap = require('focus-trap-react');
@@ -93,6 +94,21 @@ class Drawer extends React.Component {
 
       return Math.max(newLeft, windowWidth - this.props.maxWidth);
     }
+  };
+
+  /**
+   * Figure out the height of the header. This can come from either:
+   *
+   * this.props.headerStyle.height
+   * this.props.header.height
+   *
+   * If neither are set, default to 50px
+   */
+  _getHeaderHeight = () => {
+    return _get(this.props, ['headerStyle', 'height'],
+                _get(this.props,
+                     ['styles', 'header', 'height'],
+                     '50px'));
   };
 
   /**
@@ -199,7 +215,7 @@ class Drawer extends React.Component {
   }
 
   styles = () => {
-    const HEADER_HEIGHT = '50px';
+    const HEADER_HEIGHT = this._getHeaderHeight();
 
     return _merge({}, {
       component: {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -199,6 +199,8 @@ class Drawer extends React.Component {
   }
 
   styles = () => {
+    const HEADER_HEIGHT = '50px';
+
     return _merge({}, {
       component: {
         border: '1px solid ' + StyleConstants.Colors.FOG,
@@ -229,7 +231,8 @@ class Drawer extends React.Component {
       },
       content: {
         backgroundColor: StyleConstants.Colors.WHITE,
-        height: '100%'
+        overflow: 'auto',
+        height: `calc(100% - ${HEADER_HEIGHT})`
       },
       scrim: {
         zIndex: 1000,
@@ -264,7 +267,7 @@ class Drawer extends React.Component {
         justifyContent: 'center',
         padding: '7px 7px',
         position: 'relative',
-        minHeight: StyleConstants.Spacing.XLARGE
+        height: HEADER_HEIGHT
       },
       title: {
         overflow: 'hidden',


### PR DESCRIPTION
- Set a static height (50px) to the header
- Use calc to assign dynamic height for the content
- set overflow on the content.