### PR TITLE
re-added ccomponentWillReceiveProps

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -86,6 +86,17 @@ class DateRangePicker extends React.Component {
     showSelectionPane: false
   };
 
+  componentWillReceiveProps (newProps) {
+    const isUpdatedSelectedEndDate = newProps.selectedEndDate && newProps.selectedEndDate !== this.props.selectedEndDate;
+    const isUpdatedSelectedStartDate = newProps.selectedStartDate && newProps.selectedStartDate !== this.props.selectedStartDate;
+
+    if (isUpdatedSelectedEndDate || isUpdatedSelectedStartDate) {
+      this.setState({
+        currentDate: newProps.selectedEndDate ? newProps.selectedEndDate : newProps.selectedStartDate
+      });
+    }
+  }
+
   _getDateFormat = () => {
     return this._isLargeOrMediumWindowSize() ? this.props.format : 'MMM D';
   };


### PR DESCRIPTION
Re-adds in `componentWillReceiveProps` as there was a bug where the calendar wasn't updating on default range select. 

I took it out here because i thought it was no longer necessary, but the Month and Year selectors are based on state 🙁  

https://github.com/mxenabled/mx-react-components/pull/643/files#diff-b5e02cb776f0bf4505e16b8ba45bcf8dL182