### PR TITLE
Sb/date components lazy getters

### DIFF
--- a/docs/components/DateRangePickerDocs.js
+++ b/docs/components/DateRangePickerDocs.js
@@ -41,14 +41,15 @@ class DateRangePickerDocs extends React.Component {
         <p>Determines if the calendar is closed after successful range selection.</p>
 
         <h5>defaultRanges <label>Array of range option objects</label></h5>
-        <p>Default: <a href='https://github.com/mxenabled/mx-react-components/blob/master/src/components/DateRangePicker.js#L30'>See Code for default array of ranges</a></p>
+        <p>Default: <a href='https://github.com/mxenabled/mx-react-components/blob/master/src/components/DateRangePicker.js#L41'>See Code for default array of ranges</a></p>
         <p>Array of default range objects used when showDefaultRanges prop is set to true.  If not supplied, the default above is used.</p>
+        <p>Range objects consists of a `displayValue` and two functions that get the start and end date. These functions much return unix timestamps</p>
         <Markdown lang='js'>
         {`
           [{
             displayValue: 'Today',
-            endDate: 1446063248, // Unix timestamp
-            startDate: 1446063248 // Unix timestamp
+            getEndDate: () => moment.endOf('day').unix(), // These must be a unix timestamp
+            getStartDate: () => moment.startOf('day').unix()
           }]
         `}
         </Markdown>

--- a/docs/components/TimeBasedLineChartDocs.js
+++ b/docs/components/TimeBasedLineChartDocs.js
@@ -54,9 +54,9 @@ class TimeBasedLineChartDocs extends React.Component {
 
         <h3>Demo</h3>
         <TimeBasedLineChart
-          breakPointDate={moment().startOf('month').unix()}
           breakPointLabel={'This Month'}
           data={lineChartData}
+          getBreakPointDate={() => moment().startOf('month').unix()}
           height={this.state.chartHeight}
           rangeType={'month'}
           showZeroLine={true}
@@ -64,9 +64,9 @@ class TimeBasedLineChartDocs extends React.Component {
         />
 
         <h3>Usage</h3>
-        <h5>breakPointDate <label>Number</label></h5>
+        <h5>getBreakPointDate <label>Function</label></h5>
         <p>Default: today (as a Unix timestamp)</p>
-        <p>A Unix timestamp that sets the breakpoint for the chart. The breakpoint is displayed as a vertical line on the chart. If 'dashedFutureLine' is set to 'true', then the line after the breakpoint will be dashed instead of solid.</p>
+        <p>A function that returns a unix timestamp that sets the breakpoint for the chart. The breakpoint is displayed as a vertical line on the chart. If 'dashedFutureLine' is set to 'true', then the line after the breakpoint will be dashed instead of solid.</p>
 
         <h5>breakPointLabel <label>String</label></h5>
         <p>Default: 'Today'</p>

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -19,8 +19,8 @@ class DateRangePicker extends React.Component {
     closeCalendarOnRangeSelect: PropTypes.bool,
     defaultRanges: PropTypes.arrayOf(PropTypes.shape({
       displayValue: PropTypes.string,
-      endDate: PropTypes.number,
-      startDate: PropTypes.number
+      getEndDate: PropTypes.func,
+      getStartDate: PropTypes.func
     })),
     format: PropTypes.string,
     isRelative: PropTypes.bool,
@@ -41,33 +41,33 @@ class DateRangePicker extends React.Component {
     defaultRanges: [
       {
         displayValue: 'This Month',
-        endDate: moment().endOf('month').unix(),
-        startDate: moment().startOf('month').unix()
+        getEndDate: () => moment().endOf('month').unix(),
+        getStartDate: () => moment().startOf('month').unix()
       },
       {
         displayValue: 'Last 30 Days',
-        endDate: moment().endOf('day').unix(),
-        startDate: moment().subtract(29, 'days').startOf('day').unix()
+        getEndDate: () => moment().endOf('day').unix(),
+        getStartDate: () => moment().subtract(29, 'days').startOf('day').unix()
       },
       {
         displayValue: 'Last Month',
-        endDate: moment().subtract(1, 'months').endOf('month').unix(),
-        startDate: moment().subtract(1, 'months').startOf('month').unix()
+        getEndDate: () => moment().subtract(1, 'months').endOf('month').unix(),
+        getStartDate: () => moment().subtract(1, 'months').startOf('month').unix()
       },
       {
         displayValue: 'Last 90 Days',
-        endDate: moment().endOf('day').unix(),
-        startDate: moment().subtract(89, 'days').startOf('day').unix()
+        getEndDate: () => moment().endOf('day').unix(),
+        getStartDate: () => moment().subtract(89, 'days').startOf('day').unix()
       },
       {
         displayValue: 'Year To Date',
-        endDate: moment().endOf('day').unix(),
-        startDate: moment().startOf('year').unix()
+        getEndDate: () => moment().endOf('day').unix(),
+        getStartDate: () => moment().startOf('year').unix()
       },
       {
         displayValue: 'Last Year',
-        endDate: moment().startOf('day').unix(),
-        startDate: moment().startOf('day').subtract(1, 'y').unix()
+        getEndDate: () => moment().startOf('day').unix(),
+        getStartDate: () => moment().startOf('day').subtract(1, 'y').unix()
       }
     ],
     format: 'MMM D, YYYY',
@@ -143,7 +143,7 @@ class DateRangePicker extends React.Component {
   };
 
   _handleDefaultRangeSelection = (range) => {
-    this.props.onDateSelect(range.startDate, range.endDate, range.displayValue);
+    this.props.onDateSelect(range.getStartDate(), range.getEndDate(), range.displayValue);
 
     if (this.props.closeCalendarOnRangeSelect) {
       this._handleScrimClick();

--- a/src/components/DateRangePicker/DefaultRanges.js
+++ b/src/components/DateRangePicker/DefaultRanges.js
@@ -7,12 +7,12 @@ const DefaultRanges = Radium(({ defaultRanges, handleDefaultRangeSelection, prim
   <div style={styles.rangeOptions}>
 
     {defaultRanges.map(range => (
-      <div key={range.displayValue + range.startDate} onClick={handleDefaultRangeSelection.bind(null, range)} style={styles.rangeOption}>
+      <div key={range.displayValue + range.getStartDate()} onClick={handleDefaultRangeSelection.bind(null, range)} style={styles.rangeOption}>
         <div>
           <Icon
             size={20}
             style={Object.assign({}, styles.rangeOptionIcon, {
-              fill: range.startDate === selectedStartDate && range.endDate === selectedEndDate ? primaryColor : 'transparent'
+              fill: range.getStartDate() === selectedStartDate && range.getEndDate() === selectedEndDate ? primaryColor : 'transparent'
             })}
             type='check-solid'
           />

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -197,9 +197,9 @@ class HoveredDataPointGroup extends React.Component {
 // Main Component
 class TimeBasedLineChart extends React.Component {
   static propTypes = {
-    breakPointDate: PropTypes.number,
     breakPointLabel: PropTypes.string,
     data: PropTypes.array.isRequired,
+    getBreakPointDate: PropTypes.func,
     height: PropTypes.number,
     hoveredDataPointDetails: PropTypes.array,
     limitLineCircles: PropTypes.bool,
@@ -216,7 +216,7 @@ class TimeBasedLineChart extends React.Component {
   };
 
   static defaultProps = {
-    breakPointDate: moment().startOf('day').unix(),
+    getBreakPointDate: () => moment().startOf('day').unix(),
     breakPointLabel: 'Today',
     height: 400,
     limitLineCircles: false,
@@ -294,7 +294,7 @@ class TimeBasedLineChart extends React.Component {
   _getDataForLineCircles = () => {
     if (this.props.limitLineCircles) {
       return this.props.data.filter((dataPoint, index) => {
-        return index === 0 || index === this.props.data.length - 1 || dataPoint.x === this.props.breakPointDate;
+        return index === 0 || index === this.props.data.length - 1 || dataPoint.x === this.props.getBreakPointDate();
       });
     }
 
@@ -396,7 +396,7 @@ class TimeBasedLineChart extends React.Component {
   };
 
   _getShadedRectangleXValue = () => {
-    const breakPointXValue = this._getXScaleValue(this.props.breakPointDate);
+    const breakPointXValue = this._getXScaleValue(this.props.getBreakPointDate());
 
     return breakPointXValue < 0 ? 0 : breakPointXValue;
   };
@@ -507,7 +507,7 @@ class TimeBasedLineChart extends React.Component {
   };
 
   render () {
-    const { breakPointDate, breakPointLabel, data, height, lineColor, margin, rangeType, shadeBelowZero, shadeFutureOnGraph, showBreakPoint, showZeroLine, width, zeroState, yAxisFormatter } = this.props;
+    const { getBreakPointDate, breakPointLabel, data, height, lineColor, margin, rangeType, shadeBelowZero, shadeFutureOnGraph, showBreakPoint, showZeroLine, width, zeroState, yAxisFormatter } = this.props;
     const { adjustedHeight, adjustedWidth, hoveredDataPoint } = this.state;
 
     return (
@@ -572,7 +572,7 @@ class TimeBasedLineChart extends React.Component {
                 <BreakPointGroup
                   adjustedHeight={adjustedHeight}
                   adjustedWidth={adjustedWidth}
-                  breakPointDate={breakPointDate}
+                  breakPointDate={getBreakPointDate()}
                   breakPointLabel={breakPointLabel}
                   margin={margin}
                   translation={this._getVerticalLineTranslation()}


### PR DESCRIPTION
This changes the API to DateRangePicker and TimeBasedLIneChart.

Now, their default date props are functions rather than values. This allows them to pick up global config settings since defaultProps are set at import time rather than instantiation time.