### PR TITLE
File Upload: fix file upload validation

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -217,6 +217,7 @@ class FileUpload extends React.Component {
   };
 
   _validateFile = (file, width = null, height = null) => {
+    console.log('validate', file);
     let failedValidationTypes = [];
     const fileExt = file.name.split('.').pop();
     const isTooBig = this.props.maxFileSize < file.size / 1000;
@@ -235,7 +236,7 @@ class FileUpload extends React.Component {
       failedValidationTypes = failedValidationTypes.concat(this._validateImageDimensions(width, height));
     }
 
-    if (this.props.onFileValidation) {
+    if (this.props.onFileValidation && failedValidationTypes.length) {
       this.props.onFileValidation(failedValidationTypes);
     } else if (failedValidationTypes.length) {
       this.setState({
@@ -254,6 +255,8 @@ class FileUpload extends React.Component {
     const styles = this.styles(theme);
     const dropzoneLoaded = this.props.imageUrl || this.props.uploadedFile;
     const imageSource = this.state.imageSource || this.props.imageUrl;
+
+    console.log('render 4');
 
     return (
       <div

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -217,7 +217,6 @@ class FileUpload extends React.Component {
   };
 
   _validateFile = (file, width = null, height = null) => {
-    console.log('validate', file);
     let failedValidationTypes = [];
     const fileExt = file.name.split('.').pop();
     const isTooBig = this.props.maxFileSize < file.size / 1000;
@@ -255,8 +254,6 @@ class FileUpload extends React.Component {
     const styles = this.styles(theme);
     const dropzoneLoaded = this.props.imageUrl || this.props.uploadedFile;
     const imageSource = this.state.imageSource || this.props.imageUrl;
-
-    console.log('render 4');
 
     return (
       <div


### PR DESCRIPTION
There was a bug in the file upload where if there was a validation callback provided, it called it regardless of if there were errors or not. 

This adds a check for error length and allows the method to fall through to the else if the file is valid. 

