### PR TITLE
adding type to HTML input tag in DisplayInput

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.0.5</h3>
+        <ul>
+          <li>DisplayInput can now pass a type to the HTML input tag (<a href='https://github.com/mxenabled/mx-react-components/pull/663'>#663</a>)</li>
+        </ul>
+
         <h3>5.0.4</h3>
         <ul>
           <li>State to manage which default range the user clicked on (<a href='https://github.com/mxenabled/mx-react-components/pull/659'>#659</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -30,6 +30,7 @@ class DisplayInput extends React.Component {
     }),
     styles: PropTypes.object,
     theme: themeShape,
+    type: PropTypes.string,
     valid: PropTypes.bool
   };
 
@@ -100,6 +101,7 @@ class DisplayInput extends React.Component {
                     id={this._inputId}
                     key='input'
                     style={styles.input}
+                    type={this.props.type}
                   />
                 </div>
               )}


### PR DESCRIPTION
This MR allows us to define a type prop for the input tag in DisplayInput.