### PR TITLE
change column widths for DisplayInput components

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -68,9 +68,9 @@ class DisplayInput extends React.Component {
 
     // Column Sizes
     const twoWidthColumn = { large: 2, medium: 2, small: 0 };
-    const inputColumn = showHint ? { large: 8, medium: 8, small: 12 } : { large: 10, medium: 10, small: 12 };
-    const labelColumn = { large: 2, medium: 2, small: 12 };
-    const statusColumn = { large: 10, medium: 10, small: 12 };
+    const inputColumn = showHint ? { large: 8, medium: 7, small: 12 } : { large: 10, medium: 9, small: 12 };
+    const labelColumn = { large: 2, medium: 3, small: 12 };
+    const statusColumn = { large: 10, medium: 9, small: 12 };
 
     // Styles
     const styles = this.styles(theme, isLargeOrMediumWindowSize);


### PR DESCRIPTION
I was running into a case internally where at medium screen widths, the DisplayInput `medium` size did not have enough space in between the label and input column. 

Before fix: 
![screen shot 2017-10-04 at 5 57 42 pm](https://user-images.githubusercontent.com/13579578/31205247-8d5c3f9e-a92d-11e7-9d5f-efe67ecc546d.png)


After fix: 
![screen shot 2017-10-04 at 5 55 27 pm](https://user-images.githubusercontent.com/13579578/31205256-95df5264-a92d-11e7-82d6-184cf54a61dc.png)
