### PR TITLE
use a tags for accessibility, native browser styling

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -275,7 +275,7 @@ class DateRangePicker extends React.Component {
 
     return (
       <div style={styles.component}>
-        <div
+        <a
           onClick={this._toggleSelectionPane}
           onKeyUp={(e) => keycode(e) === 'enter' && this._toggleSelectionPane()}
           style={styles.selectedDateWrapper}
@@ -302,7 +302,7 @@ class DateRangePicker extends React.Component {
             style={styles.selectedDateCaret}
             type={this.state.showSelectionPane ? 'caret-up' : 'caret-down'}
           />
-        </div>
+        </a>
         <div style={styles.container}>
           <div>
             <div style={styles.optionsWrapper}>

--- a/src/components/DateRangePicker/MonthTable.js
+++ b/src/components/DateRangePicker/MonthTable.js
@@ -31,7 +31,7 @@ class MonthTable extends React.Component {
       const isSelectedDay = startDate.isSame(moment.unix(selectedStartDate), 'day') || startDate.isSame(moment.unix(selectedEndDate), 'day');
       const savedStartDate = startDate.date();
       const day = (
-        <div
+        <a
           key={startDate}
           onClick={!disabledDay && handleDateSelect.bind(null, startDate.unix())}
           onKeyDown={handleKeyDown}
@@ -52,7 +52,7 @@ class MonthTable extends React.Component {
           tabIndex={startDate.isSame(moment.unix(focusedDay), 'day') ? 0 : null}
         >
           {startDate.date()}
-        </div>
+        </a>
       );
 
       days.push(day);


### PR DESCRIPTION
There were some issues in different browsers with the DateRangePicker having no visual indication of what was focused in some cases. 

This changes some `<div>`s to `<a>` tags. While these aren't links in the traditional sense, they are still focusable elements that can respond to a user action (click, keyup), so I think it's appropriate to use `<a>`. 

This way we can let the browser handle the focus styles rather than having to recreate. 