### PR TITLE
Remove DonutChart label click handler

### DIFF
--- a/docs/components/DonutChartDocs.js
+++ b/docs/components/DonutChartDocs.js
@@ -130,7 +130,7 @@ class DonutChartDocs extends React.Component {
         <p>An id used to give the chart unique classNames/references so that multiple charts on a page don't attempt to animate each other.</p>
 
         <h5>onClick <label>Function</label></h5>
-        <p>A method to be called when a pie slice is clicked. It will be passed the index of the clicke data point.</p>
+        <p>A method to be called when a pie slice is clicked. It will be passed the <code>data</code> at the clicked index.</p>
 
         <h5>onMouseEnter <label>Function</label></h5>
         <p>A method to be called when the mouse hovers over a slice. It will be passed the index of the hovered data point.</p>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2988,8 +2988,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^15.0.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
@@ -3007,8 +3007,8 @@ react-router@^2.0.0:
     warning "^3.0.0"
 
 react@^15.0.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -314,7 +314,6 @@ class DonutChart extends React.Component {
         return (
           <div
             className='mx-donutchart-data'
-            onClick={this._handleClick}
             style={styles.center}
           >
             {this.props.children}
@@ -329,7 +328,6 @@ class DonutChart extends React.Component {
         return (
           <div
             className='mx-donutchart-data'
-            onClick={this._handleClick}
             style={styles.center}
           >
             <div className='mx-donutchart-data-value' style={[styles.value, { color }]}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,8 +1060,8 @@ bowser@^1.0.0:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.1.tgz#a4de8f18a1a0dc9531eb2a92a1521fb6a9ba96a5"
 
 bowser@^1.5.0:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.3.tgz#504bdb43118ca8db9cbbadf28fd60f265af96e4f"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.0.tgz#889d46ac922ec5db8297672747362ef836781ba7"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1906,6 +1906,18 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
@@ -1992,8 +2004,8 @@ flat-cache@^1.2.1:
     write "^0.2.1"
 
 focus-trap-react@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.0.3.tgz#96f934fba39dae9b80a5d2b4839a919c0bc4fa7e"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.0.4.tgz#5f98145ebb95b503c6996610aed61ae610304524"
   dependencies:
     focus-trap "^2.0.1"
 
@@ -3148,12 +3160,20 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8:
+prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+prop-types@^15.5.8:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~1.1.5:
   version "1.1.5"
@@ -3248,8 +3268,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^15.5.4:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
@@ -3257,8 +3277,8 @@ react-dom@^15.5.4:
     prop-types "^15.5.10"
 
 react@^15.5.4:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"


### PR DESCRIPTION
The click handler of the label in the center of the `DonutChart` was setup incorrectly. It didn't pass along the required index to the handler function which caused the `onClick` prop to receive `undefined` for the `event`. This made users of the `DonutChart` have to work around the problem.

The behavior is also undocumented because the docs state that the `onClick` prop is for when a "pie slice is clicked" mentioning nothing about the label. This removes the click handler from the label.