### PR TITLE
Tabs > handling single tab use case

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,9 +8,14 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.0.9</h3>
+        <ul>
+          <li>Gracefully handle 1 tab being passed into the Tabs component (<a href='https://github.com/mxenabled/mx-react-components/pull/669'>#669</a>)</li>
+        </ul>
+
         <h3>5.0.8</h3>
         <ul>
-          <li>React 16 Upgrade (<a href='https://github.com/mxenabled/mx-react-components/pull/666'>#668</a>)</li>
+          <li>React 16 Upgrade (<a href='https://github.com/mxenabled/mx-react-components/pull/668'>#668</a>)</li>
         </ul>
 
         <h3>5.0.7</h3>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -174,6 +174,7 @@ class Tabs extends React.Component {
         alignItems: 'center',
         boxSizing: 'border-box',
         color: this.props.brandColor,
+        cursor: 'pointer',
         lineHeight: '20px',
         fontSize: StyleConstants.FontSizes.MEDIUM,
         fontStyle: StyleConstants.Fonts.SEMIBOLD,

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -15,6 +15,7 @@ class Tabs extends React.Component {
     selectedTab: PropTypes.number,
     showBottomBorder: PropTypes.bool,
     tabs: PropTypes.array.isRequired,
+    theme: PropTypes.object,
     useTabsInMobile: PropTypes.bool
   };
 
@@ -96,6 +97,7 @@ class Tabs extends React.Component {
             menuStyles={styles.menu}
             onScrimClick={this._toggleMenu}
             showItems={this.state.showMenu}
+            theme={this.props.theme}
           />
         ) : null}
       </div>

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -26,17 +26,8 @@ class Tabs extends React.Component {
 
   state = {
     selectedTab: this.props.selectedTab || 0,
-    showMenu: false,
-    singleTab: false
+    showMenu: false
   };
-
-  componentDidMount () {
-    if (this.props.tabs.length === 1) {
-      this.setState({
-        singleTab: true
-      });
-    }
-  }
 
   componentWillReceiveProps (nextProps) {
     if (nextProps.selectedTab !== this.state.selectedTab) {
@@ -131,7 +122,7 @@ class Tabs extends React.Component {
 
     return (
       <div style={[styles.component, this.props.style]}>
-        {this._isLargeOrMediumWindowSize() || this.props.useTabsInMobile || this.state.singleTab ? (
+        {this._isLargeOrMediumWindowSize() || this.props.useTabsInMobile || this.props.tabs.length === 1 ? (
           <div style={styles.tabsContainer}>
             {this._renderTabs()}
           </div>

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -26,8 +26,17 @@ class Tabs extends React.Component {
 
   state = {
     selectedTab: this.props.selectedTab || 0,
-    showMenu: false
+    showMenu: false,
+    singleTab: false
   };
+
+  componentDidMount () {
+    if (this.props.tabs.length === 1) {
+      this.setState({
+        singleTab: true
+      });
+    }
+  }
 
   componentWillReceiveProps (nextProps) {
     if (nextProps.selectedTab !== this.state.selectedTab) {
@@ -122,7 +131,7 @@ class Tabs extends React.Component {
 
     return (
       <div style={[styles.component, this.props.style]}>
-        {this._isLargeOrMediumWindowSize() || this.props.useTabsInMobile ? (
+        {this._isLargeOrMediumWindowSize() || this.props.useTabsInMobile || this.state.singleTab ? (
           <div style={styles.tabsContainer}>
             {this._renderTabs()}
           </div>


### PR DESCRIPTION
This PR adds a check to handle situations where only 1 tab is passed in. If only 1 tab is passed in, it will display that tab at the top and disable the dropdown feature.