### PR TITLE
Properly set default element props on Icon.

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -11,10 +11,7 @@ class Icon extends React.Component {
   };
 
   static defaultProps = {
-    elementProps: {
-      'aria-hidden': true,
-      focusable: 'false'
-    },
+    elementProps: {},
     size: 24,
     type: 'accounts'
   };
@@ -1689,7 +1686,11 @@ class Icon extends React.Component {
   };
 
   render () {
-    const { elementProps } = this.props;
+    const elementProps = {
+      'aria-hidden': true,
+      focusable: 'false',
+      ...this.props.elementProps
+    };
     const styles = this.styles();
 
     return (


### PR DESCRIPTION
Previously, we set aria-hidden and focusable, but if the consumer
passed in any of their own props, those would be removed entirely.

This merges them back in with element props, ensuring the passed in
props 'win' over.