### PR TITLE
removed reference to React.PropTypes

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -44,7 +44,7 @@ class Drawer extends React.Component {
       onPreviousClick: PropTypes.func.isRequired
     }),
     onClose: PropTypes.func.isRequired,
-    onOpen: React.PropTypes.func,
+    onOpen: PropTypes.func,
     showCloseButton: PropTypes.bool,
     showScrim: PropTypes.bool,
     styles: PropTypes.object,


### PR DESCRIPTION
Was doing some testing when I noticed we were still referencing `React.PropTypes`. This was breaking for me when testing on React 16 Internally.

Did a project wide search for other references like this and found none. 