### PR TITLE
Fix error in IE 11 for Modal component

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -10,7 +10,7 @@ class Changelog extends React.Component {
 
         <h3>5.1.1</h3>
         <ul>
-          <li>Updates focus-trap-react library to fix IE 11 error with Modal and returning focus (<a href='https://github.com/mxenabled/mx-react-components/pull/673'>#672</a>)</li>
+          <li>Updates focus-trap-react library to fix IE 11 error with Modal and returning focus (<a href='https://github.com/mxenabled/mx-react-components/pull/675'>#675</a>)</li>
         </ul>
 
         <h3>5.1.0</h3>

--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.1.1</h3>
+        <ul>
+          <li>Updates focus-trap-react library to fix IE 11 error with Modal and returning focus (<a href='https://github.com/mxenabled/mx-react-components/pull/673'>#672</a>)</li>
+        </ul>
+
         <h3>5.1.0</h3>
         <ul>
           <li>New 'pill' style added to the Tabs component (<a href='https://github.com/mxenabled/mx-react-components/pull/672'>#672</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,8 +1918,8 @@ flat-cache@^1.2.1:
     write "^0.2.1"
 
 focus-trap-react@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.0.4.tgz#5f98145ebb95b503c6996610aed61ae610304524"
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.0.5.tgz#8fb381b92eafe075c2406297d1da618650d37143"
   dependencies:
     focus-trap "^2.0.1"
 


### PR DESCRIPTION
Pulls in update to `focus-trap-react` library to protect against calling `focus()` on an empty object because IE11 and iFrames suck.

https://github.com/davidtheclark/focus-trap-react/pull/19