### PR TITLE
Correct focus trap update

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.1.2</h3>
+        <ul>
+          <li>Previous attempt to update focus-trap-react didn't work.  This should resolve the issue.  (<a href='https://github.com/mxenabled/mx-react-components/pull/676'>#676</a>)</li>
+        </ul>
+
         <h3>5.1.1</h3>
         <ul>
           <li>Updates focus-trap-react library to fix IE 11 error with Modal and returning focus (<a href='https://github.com/mxenabled/mx-react-components/pull/675'>#675</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   "dependencies": {
     "bowser": "^1.5.0",
     "d3": "^3.5.6",
-    "focus-trap-react": "^3.0.2",
+    "focus-trap-react": "^3.0.5",
     "keycode": "^2.1.8",
     "lodash": "^4.6.1",
     "moment": "2.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,7 +1917,7 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-focus-trap-react@^3.0.2:
+focus-trap-react@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.0.5.tgz#8fb381b92eafe075c2406297d1da618650d37143"
   dependencies:


### PR DESCRIPTION
My last release that updated `focus-trap-react` didn't seem to work.  The version in the node modules directory what still on 3.0.3 even though the yarn.lock said 3.0.5.  Blowing out and yarn installing also didn't fix the issue.  This PR updates the version in the package.json file to 3.0.5 in an attempt to fix.