### PR TITLE
Luke/daterangepicker accessibility updates

### DIFF
--- a/src/components/DateRangePicker/DefaultRanges.js
+++ b/src/components/DateRangePicker/DefaultRanges.js
@@ -28,6 +28,7 @@ class DefaultRanges extends React.Component {
                 this.setState({ selectedOption: index });
               }
             }}
+            role='button'
             style={styles.rangeOption}
             tabIndex={0}
           >

--- a/src/components/DateRangePicker/MonthTable.js
+++ b/src/components/DateRangePicker/MonthTable.js
@@ -32,6 +32,7 @@ class MonthTable extends React.Component {
       const savedStartDate = startDate.date();
       const day = (
         <a
+          aria-label={moment(startDate).format("MMM D, YYYY")}
           key={startDate}
           onClick={!disabledDay && handleDateSelect.bind(null, startDate.unix())}
           onKeyDown={handleKeyDown}
@@ -41,6 +42,7 @@ class MonthTable extends React.Component {
               ref.focus();
             }
           }}
+          role='button'
           style={Object.assign({},
             styles.calendarDay,
             startDate.isSame(moment.unix(currentDate), 'month') && styles.currentMonth,

--- a/src/components/DateRangePicker/MonthTable.js
+++ b/src/components/DateRangePicker/MonthTable.js
@@ -32,7 +32,7 @@ class MonthTable extends React.Component {
       const savedStartDate = startDate.date();
       const day = (
         <a
-          aria-label={moment(startDate).format("MMM D, YYYY")}
+          aria-label={moment(startDate).format('MMM D, YYYY')}
           key={startDate}
           onClick={!disabledDay && handleDateSelect.bind(null, startDate.unix())}
           onKeyDown={handleKeyDown}

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -42,8 +42,10 @@ class SelectionPane extends React.Component {
         <div>
           <label style={styles.boxLabel}>From</label>
           <a
+            aria-label={`Select Start Date, ${selectedStartDate ? 'Current start date is ' + moment.unix(selectedStartDate).format('MMM D, YYYY') : ''}`}
             onClick={() => this._handleDateBoxClick(selectedStartDate, SelectedBox.FROM)}
             onKeyUp={(e) => keycode(e) === 'enter' && this._handleDateBoxClick(selectedStartDate, SelectedBox.FROM)}
+            role='button'
             style={Object.assign({}, styles.dateSelectBox, this.props.selectedBox === SelectedBox.FROM ? styles.selectedDateSelectBox : null)}
             tabIndex={0}
           >
@@ -52,8 +54,10 @@ class SelectionPane extends React.Component {
 
           <label style={styles.boxLabel}>To</label>
           <a
+            aria-label={`Select End Date, ${selectedEndDate ? 'Current end date is ' + moment.unix(selectedEndDate).format('MMM D, YYYY') : ''}`}
             onClick={() => this._handleDateBoxClick(selectedEndDate, SelectedBox.TO)}
             onKeyUp={(e) => keycode(e) === 'enter' && this._handleDateBoxClick(selectedEndDate, SelectedBox.TO)}
+            role='button'
             style={Object.assign({}, styles.dateSelectBox, this.props.selectedBox === SelectedBox.TO ? styles.selectedDateSelectBox : null)}
             tabIndex={0}
           >

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -41,24 +41,24 @@ class SelectionPane extends React.Component {
       <div style={styles.container}>
         <div>
           <label style={styles.boxLabel}>From</label>
-          <div
+          <a
             onClick={() => this._handleDateBoxClick(selectedStartDate, SelectedBox.FROM)}
             onKeyUp={(e) => keycode(e) === 'enter' && this._handleDateBoxClick(selectedStartDate, SelectedBox.FROM)}
             style={Object.assign({}, styles.dateSelectBox, this.props.selectedBox === SelectedBox.FROM ? styles.selectedDateSelectBox : null)}
             tabIndex={0}
           >
             {selectedStartDate ? moment.unix(selectedStartDate).format('MMM D, YYYY') : 'Select Start Date'}
-          </div>
+          </a>
 
           <label style={styles.boxLabel}>To</label>
-          <div
+          <a
             onClick={() => this._handleDateBoxClick(selectedEndDate, SelectedBox.TO)}
             onKeyUp={(e) => keycode(e) === 'enter' && this._handleDateBoxClick(selectedEndDate, SelectedBox.TO)}
             style={Object.assign({}, styles.dateSelectBox, this.props.selectedBox === SelectedBox.TO ? styles.selectedDateSelectBox : null)}
             tabIndex={0}
           >
             {selectedEndDate ? moment.unix(selectedEndDate).format('MMM D, YYYY') : 'Select End Date'}
-          </div>
+          </a>
         </div>
         <div>
           <div style={Object.assign({}, styles.defaultRangesTitle, { color: theme.Colors.PRIMARY })}>
@@ -100,6 +100,7 @@ class SelectionPane extends React.Component {
         borderWidth: 1,
         boxSizing: 'border-box',
         cursor: 'pointer',
+        display: 'block',
         fontFamily: theme.FontFamily,
         fontSize: theme.FontSizes.MEDIUM,
         marginBottom: theme.Spacing.SMALL,

--- a/src/components/DateRangePicker/Selector.js
+++ b/src/components/DateRangePicker/Selector.js
@@ -18,29 +18,22 @@ class Selector extends React.Component {
 
     return (
       <div style={Object.assign({}, this.props.style, styles.container)}>
-        <Icon
-          elementProps={{
-            onClick: this.props.handlePreviousClick,
-            onKeyUp: (e) => keycode(e) === 'enter' && this.props.handlePreviousClick(e),
-            tabIndex: 0
-          }}
-          size={20}
-          style={styles.calendarHeaderNav}
-          type='caret-left'
-        />
-        <div style={styles.currentDate}>
-          {this.props.currentDate}
-        </div>
-        <Icon
-          elementProps={{
-            onClick: this.props.handleNextClick,
-            onKeyUp: (e) => keycode(e) === 'enter' && this.props.handleNextClick(e),
-            tabIndex: 0
-          }}
-          size={20}
-          style={styles.calendarHeaderNav}
-          type='caret-right'
-        />
+        <a
+          onClick={this.props.handlePreviousClick}
+          onKeyUp={e =>
+            keycode(e) === 'enter' && this.props.handlePreviousClick(e)}
+          tabIndex={0}
+        >
+          <Icon size={20} style={styles.calendarHeaderNav} type='caret-left' />
+        </a>
+        <div style={styles.currentDate}>{this.props.currentDate}</div>
+        <a
+          onClick={this.props.handleNextClick}
+          onKeyUp={e => keycode(e) === 'enter' && this.props.handleNextClick(e)}
+          tabIndex={0}
+        >
+          <Icon size={20} style={styles.calendarHeaderNav} type='caret-right' />
+        </a>
       </div>
     );
   }

--- a/src/components/DateRangePicker/Selector.js
+++ b/src/components/DateRangePicker/Selector.js
@@ -10,7 +10,8 @@ class Selector extends React.Component {
     currentDate: PropTypes.string,
     handleNextClick: PropTypes.func,
     handlePreviousClick: PropTypes.func,
-    setCurrentDate: PropTypes.func
+    setCurrentDate: PropTypes.func,
+    type: PropTypes.string
   };
 
   render () {
@@ -19,17 +20,21 @@ class Selector extends React.Component {
     return (
       <div style={Object.assign({}, this.props.style, styles.container)}>
         <a
+          aria-label={`Previous ${this.props.type}`}
           onClick={this.props.handlePreviousClick}
           onKeyUp={e =>
             keycode(e) === 'enter' && this.props.handlePreviousClick(e)}
+          role='button'
           tabIndex={0}
         >
           <Icon size={20} style={styles.calendarHeaderNav} type='caret-left' />
         </a>
         <div style={styles.currentDate}>{this.props.currentDate}</div>
         <a
+          aria-label={`Next ${this.props.type}`}
           onClick={this.props.handleNextClick}
           onKeyUp={e => keycode(e) === 'enter' && this.props.handleNextClick(e)}
+          role='button'
           tabIndex={0}
         >
           <Icon size={20} style={styles.calendarHeaderNav} type='caret-right' />
@@ -84,6 +89,7 @@ class MonthSelector extends React.Component {
         handleNextClick={this._handleNextClick}
         handlePreviousClick={this._handlePreviousClick}
         style={styles.monthSelector}
+        type='Month'
       />
     );
   }
@@ -122,6 +128,7 @@ class YearSelector extends React.Component {
         currentDate={moment.unix(this.props.currentDate).format('YYYY')}
         handleNextClick={this._handleNextClick}
         handlePreviousClick={this._handlePreviousClick}
+        type='Year'
       />
     );
   }


### PR DESCRIPTION
I was getting issues where even though these elements had tabIndex's and what not, they were not focusing when used internally (but they were in the OS demo app...) 

I'm not entirely sure what the cause was, but I fixed by wrapping in `<a>` tags. 

I also added a lot of screen reader support 

![screen shot 2017-10-30 at 9 59 14 am](https://user-images.githubusercontent.com/13579578/32181123-41aed22e-bd59-11e7-8596-949aa86f7a6b.png)
