### PR TITLE
Button Component - Add elementProps prop

### DIFF
--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -101,6 +101,9 @@ class ButtonDocs extends React.Component {
         <p>If defined, adds an <Code>aria-label</Code> attribute equal to the supplied value on the button element for accessibility.</p>
         <p><a href='https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute'>aria-label documentation</a></p>
 
+        <h5>elementProps <label>Object</label></h5>
+        <p>Object of native html attributes that you wish to have spread across the html button element of the component.  Usefull for adding things such as aria and data-dash attributes.</p>
+
         <h5>icon <label>String</label></h5>
         <p>This can be any of the <Code>Icon</Code> component values. If defined, an icon will be shown to the left of the button content.</p>
 
@@ -120,7 +123,7 @@ class ButtonDocs extends React.Component {
         <h3>Example</h3>
         <Markdown>
   {`
-    <Button aria-label='Submit Form' theme={{ Colors: { PRIMARY: '#333333' } }} type='secondary' />
+    <Button aria-label='Submit Form' elementProps={{ 'data-my-attribute': 'my attribute data here' }} theme={{ Colors: { PRIMARY: '#333333' } }} type='secondary' />
   `}
         </Markdown>
       </div>

--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -10,7 +10,7 @@ class Changelog extends React.Component {
 
         <h3>5.1.6</h3>
         <ul>
-          <li>Adds elementProps prop to Button component (<a href='https://github.com/mxenabled/mx-react-components/pull/680'>#680</a>)</li>
+          <li>Adds elementProps prop to Button component (<a href='https://github.com/mxenabled/mx-react-components/pull/681'>#681</a>)</li>
         </ul>
 
         <h3>5.1.5</h3>

--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.1.6</h3>
+        <ul>
+          <li>Adds elementProps prop to Button component (<a href='https://github.com/mxenabled/mx-react-components/pull/680'>#680</a>)</li>
+        </ul>
+
         <h3>5.1.5</h3>
         <ul>
           <li>DateRangePicker Accessibility updates (<a href='https://github.com/mxenabled/mx-react-components/pull/680'>#680</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -15,6 +15,7 @@ class Button extends React.Component {
     'aria-label': PropTypes.string,
     actionText: PropTypes.string,
     buttonRef: PropTypes.func,
+    elementProps: PropTypes.object,
     icon: PropTypes.string,
     isActive: PropTypes.bool,
     onClick: PropTypes.func,
@@ -25,6 +26,7 @@ class Button extends React.Component {
   };
 
   static defaultProps = {
+    elementProps: {},
     onClick () {},
     isActive: false,
     type: 'primary'
@@ -65,6 +67,7 @@ class Button extends React.Component {
         onClick={this.props.type === 'disabled' ? null : this.props.onClick}
         ref={this.props.buttonRef}
         style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}
+        {...this.props.elementProps}
       >
         <div style={styles.children}>
           {(this.props.icon && !this.props.isActive) && (


### PR DESCRIPTION
We have a need to be able to pass various aria attributes to the native button element in the Button component for accessibility purposes so this adds the elementProps prop to allow for that.  

Also updated the docs and change log respectively.  