### PR TITLE
Wengert/button

### DIFF
--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -97,13 +97,6 @@ class ButtonDocs extends React.Component {
         <h5>actionText <label>String</label></h5>
         <p>The button text when <Code>isActive</Code> is <Code>true</Code>. If not defined, a spinner without text is shown.</p>
 
-        <h5>aria-label <label>String</label></h5>
-        <p>If defined, adds an <Code>aria-label</Code> attribute equal to the supplied value on the button element for accessibility.</p>
-        <p><a href='https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute'>aria-label documentation</a></p>
-
-        <h5>elementProps <label>Object</label></h5>
-        <p>Object of native html attributes that you wish to have spread across the html button element of the component.  Usefull for adding things such as aria and data-dash attributes.</p>
-
         <h5>icon <label>String</label></h5>
         <p>This can be any of the <Code>Icon</Code> component values. If defined, an icon will be shown to the left of the button content.</p>
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -58,32 +58,34 @@ class Button extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
-    const styles = this.styles(theme);
+    // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
+    // Keep elementProps for backwards compatibility.
+    const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props
+    const mergedTheme = StyleUtils.mergeTheme(theme, primaryColor);
+    const styles = this.styles(mergedTheme);
 
     return (
       <button
-        aria-label={this.props['aria-label']}
-        onClick={this.props.type === 'disabled' ? null : this.props.onClick}
-        ref={this.props.buttonRef}
-        style={Object.assign({}, styles.component, styles[this.props.type], this.props.style)}
-        {...this.props.elementProps}
+        ref={buttonRef}
+        style={Object.assign({}, styles.component, styles[this.props.type], style)}
+        {...rest}
+        {...elementProps}
       >
         <div style={styles.children}>
-          {(this.props.icon && !this.props.isActive) && (
+          {(icon && !isActive) && (
             <Icon
               size={20}
               style={styles.icon}
-              type={this.props.icon}
+              type={icon}
             />
           )}
-          {this.props.isActive && (
+          {isActive && (
             <Spin direction='counterclockwise'>
               <Icon size={20} type='spinner' />
             </Spin>
           )}
           <div style={styles.buttonText}>
-            {this.props.isActive ? this.props.actionText : this.props.children}
+            {isActive ? actionText : children}
           </div>
         </div>
       </button>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -66,6 +66,7 @@ class Button extends React.Component {
 
     return (
       <button
+        disabled={this.props.type === 'disabled'}
         ref={buttonRef}
         style={Object.assign({}, styles.component, styles[this.props.type], style)}
         {...rest}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -60,7 +60,7 @@ class Button extends React.Component {
   render () {
     // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
     // Keep elementProps for backwards compatibility.
-    const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props
+    const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props;
     const mergedTheme = StyleUtils.mergeTheme(theme, primaryColor);
     const styles = this.styles(mergedTheme);
 

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -45,21 +45,22 @@ class ButtonGroup extends React.Component {
           const isOnlyChild = isFirstChild && isLastChild;
           const isDisabled = button.type === 'disabled';
 
+          const { style, ...rest } = button;
+
           return (
             <Button
-              aria-label={button['aria-label']}
-              icon={button.icon}
               key={i}
-              onClick={isDisabled ? null : button.onClick}
               style={Object.assign({},
                 styles.component,
                 isFirstChild && styles.firstChild,
                 isLastChild && styles.lastChild,
                 isOnlyChild && styles.onlyChild,
                 isDisabled && styles.disabled,
-                button.style)}
+                style)}
               theme={theme}
               type={this.props.type}
+              disabled={isDisabled}
+              {...rest}
             >
               {button.text}
             </Button>

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -59,7 +59,6 @@ class ButtonGroup extends React.Component {
                 style)}
               theme={theme}
               type={this.props.type}
-              disabled={isDisabled}
               {...rest}
             >
               {button.text}

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -20,4 +20,24 @@ describe('Button', () => {
     expect(withIcon.find(Icon)).toBePresent();
     expect(withoutIcon.find(Icon)).toBeEmpty();
   });
+
+  it('can support real button attributes', () => {
+    const button = shallow(<Button aria-pressed="false" />)
+
+    expect(button.html()).toContain('aria-pressed')
+  })
+
+  describe("non element props", () => {
+    it('should not pass down non element props being used elsewhere', () => {
+      const button = shallow(<Button icon='foo' />)
+
+      expect(button.html()).not.toContain('foo')
+    })
+
+    it('should not pass down non element props being used elsewhere', () => {
+      const button = shallow(<Button isActive='foo' />)
+
+      expect(button.html()).not.toContain('foo')
+    })
+  })
 });

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -22,22 +22,22 @@ describe('Button', () => {
   });
 
   it('can support real button attributes', () => {
-    const button = shallow(<Button aria-pressed="false" />)
+    const button = shallow(<Button aria-pressed='false' />);
 
-    expect(button.html()).toContain('aria-pressed')
-  })
+    expect(button.html()).toContain('aria-pressed');
+  });
 
-  describe("non element props", () => {
+  describe('non element props', () => {
     it('should not pass down non element props being used elsewhere', () => {
-      const button = shallow(<Button icon='foo' />)
+      const button = shallow(<Button icon='foo' />);
 
-      expect(button.html()).not.toContain('foo')
-    })
+      expect(button.html()).not.toContain('foo');
+    });
 
     it('should not pass down non element props being used elsewhere', () => {
-      const button = shallow(<Button isActive='foo' />)
+      const button = shallow(<Button isActive='foo' />);
 
-      expect(button.html()).not.toContain('foo')
-    })
-  })
+      expect(button.html()).not.toContain('foo');
+    });
+  });
 });


### PR DESCRIPTION
We had a mix of native props and custom props being passed to our Button element. We also had the concept of elementProps which would just expand onto the native button. This removes that confusion so we don't have to use elementProps anymore while still maintaining backwards compatibility.  

@jtanner @lukeschunk 