### PR TITLE
Luke/modal accessibility fix

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -200,19 +200,21 @@ class Modal extends React.Component {
             </div>
             {this._renderFooter(styles, theme)}
             {this.props.showCloseIcon && (
-              <Icon
-                className='mx-modal-close'
-                elementProps={{
-                  tabIndex: 0,
-                  'aria-label': 'Close Modal',
-                  role: 'button',
-                  onClick: this.props.onRequestClose,
-                  onKeyUp: (e) => e.keyCode === 13 && this.props.onRequestClose()
-                }}
-                size={24}
+              <button
+                aria-label='Close Modal'
+                onClick={this.props.onRequestClose}
+                onKeyUp={e => e.keyCode === 13 && this.props.onRequestClose()}
+                role='button'
                 style={styles.close}
-                type='close-solid'
-              />
+                tabIndex={0}
+              >
+                <Icon
+                  className='mx-modal-close'
+                  size={24}
+                  style={styles.closeIcon}
+                  type='close-solid'
+                />
+              </button>
             )}
           </div>
         </div>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -246,10 +246,10 @@ class Modal extends React.Component {
         margin: '-12px -12px 0 0',
         cursor: 'pointer',
         border: 'none',
-        backgroundColor: 'transparent',
+        backgroundColor: 'transparent'
       },
       closeIcon: {
-        color: theme.Colors.GRAY_700,
+        color: theme.Colors.GRAY_700
       },
       container: {
         fontFamily: theme.FontFamily,

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -245,7 +245,11 @@ class Modal extends React.Component {
         right: 0,
         margin: '-12px -12px 0 0',
         cursor: 'pointer',
-        color: theme.Colors.GRAY_700
+        border: 'none',
+        backgroundColor: 'transparent',
+      },
+      closeIcon: {
+        color: theme.Colors.GRAY_700,
       },
       container: {
         fontFamily: theme.FontFamily,


### PR DESCRIPTION
Once upon a time i was naiive and I thought I could focus and use aria attributes on SVGs...

However in my old age I've realized that wrapping is the way to go - here I wrapped the modal's close Icon with a button for accessibility. 

![modalaccessibility](https://user-images.githubusercontent.com/13579578/33630207-c43b390e-d9c3-11e7-9e2d-5d0b0c4bf06f.gif)
