### PR TITLE
Select: jump to option on type

### DIFF
--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -2,7 +2,6 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 const keycode = require('keycode');
-const _find = require('lodash/find');
 const _findIndex = require('lodash/findIndex');
 const _startsWith = require('lodash/startsWith');
 


### PR DESCRIPTION
This adds the ability to jump to an option by typing.

This also fixes the arrow keys to scroll through the list

Paired with @daveguymon on this.

- Add `searchString` state to `ListBox`
- Clean search timeout on unmount
- Remove check for space to select
- Add check for space or letter character to trigger search
 - Clean any existing timeouts
 - Convert space keycode to an actual space or just return key
 - Append to search string and set to state
 - Perform search
 - Reset search string state to empty string if no action within one second 
- Call `focusNext` and `focusPrevious` methods with the new index on arrow keys

@lukeschunk: would like your eyes on this to make sure we haven't broken anything for accessibility. 