### PR TITLE
SimpleSelect accessibility updates

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.1.9</h3>
+        <ul>
+          <li>Tweaks to SimpleSelect component to make accessibility easier (<a href='https://github.com/mxenabled/mx-react-components/pull/688'>#688</a>)</li>
+        </ul>
+
         <h3>5.1.8</h3>
         <ul>
           <li>Adds new prop focusOnLoad to Drawer component (<a href='https://github.com/mxenabled/mx-react-components/pull/684'>#684</a>)</li>

--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -46,7 +46,7 @@ class SimpleSelectDocs extends React.Component {
               aria-label='Select a category'
               items={[
                 { icon: 'auto', text: 'Auto', onClick: this._handleItemClick },
-                { icon: 'kids', text: 'Kids', onClick: this._handleItemClick },
+                { icon: 'kids', isSelected: true, text: 'Kids', onClick: this._handleItemClick },
                 { icon: 'pets', text: 'Pets', onClick: this._handleItemClick }
               ]}
               onScrimClick={this._toggleMenu}
@@ -60,7 +60,7 @@ class SimpleSelectDocs extends React.Component {
         <p>The icon size used for icons in menu items if used.</p>
 
         <h5>items <label>Array</label> Required</h5>
-        <p>An array of objects that specify <em>icon</em>, <em>text</em>, and/or <em>onClick</em> of the item..</p>
+        <p>An array of objects that specify <em>icon</em>, <em>isSelected</em>, <em>text</em>, and/or <em>onClick</em> of the item..</p>
 
         <h5>onScrimClick <label>function</label></h5>
         <p><em>onClick</em> handler for the menu scrim.</p>
@@ -101,7 +101,7 @@ class SimpleSelectDocs extends React.Component {
           aria-label='Select a category'
           items={[
             { icon: 'auto', text: 'Auto', onClick: this._handleItemClick },
-            { icon: 'kids', text: 'Kids', onClick: this._handleItemClick },
+            { icon: 'kids', isSelected: true, text: 'Kids', onClick: this._handleItemClick },
             { icon: 'pets', text: 'Pets', onClick: this._handleItemClick }
           ]}
           onScrimClick={this._toggleMenu}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -78,6 +78,7 @@ class SimpleSelect extends React.Component {
 
               return (
                 <Option
+                  isSelected={isSelected}
                   key={i}
                   label={text}
                   onClick={e => {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -74,17 +74,28 @@ class SimpleSelect extends React.Component {
           {this.props.children ?
             this.props.children :
             (this.props.items.map((item, i) => {
+              const { icon, isSelected, onClick, text, ...rest } = item;
+
               return (
                 <Option
                   key={i}
-                  label={item.text}
-                  onClick={this._handleItemClick.bind(null, item)}
+                  label={text}
+                  onClick={e => {
+                    if (this.props.scrimClickOnSelect) {
+                      this.props.onScrimClick(e);
+                    }
+
+                    if (onClick && typeof onClick === 'function') {
+                      onClick(e, item);
+                    }
+                  }}
                   style={styles.item}
+                  {...rest}
                 >
-                  {item.icon ? (
-                    <Icon size={this.props.iconSize || 20} style={styles.icon} type={item.icon} />
+                  {icon ? (
+                    <Icon size={this.props.iconSize || 20} style={styles.icon} type={icon} />
                   ) : null}
-                  <div style={styles.text}>{item.text}</div>
+                  <div style={styles.text}>{text}</div>
                 </Option>
               );
             })

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -53,14 +53,6 @@ class SimpleSelect extends React.Component {
     window.removeEventListener('keydown', this._handleKeyDown);
   }
 
-  _handleItemClick = (item, e) => {
-    if (this.props.scrimClickOnSelect) {
-      this.props.onScrimClick(e);
-    }
-
-    item.onClick(e, item);
-  };
-
   _handleKeyDown = (e) => {
     if (keycode(e) === 'esc') {
       e.preventDefault();

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -128,11 +128,11 @@ class Listbox extends React.Component {
  */
 const Option = ({ children, isSelected, label, ...props }) => (
   <a
-    {...props}
     aria-label={isSelected && label ? `${label}, Current selection` : label}
     aria-selected={isSelected}
     role='option'
     tabIndex={0}
+    {...props}
   >
     {children}
   </a>


### PR DESCRIPTION
Makes it easy to change accessibility on Options in the SimpleSelect by passing additional properties on the item objects in the items array prop that then over write existing properties.  

I did this because I have a use case internally where I need on option to be treated as a toggle button but the rest to remain as standard options.  I achieved this by destructering the expected properties from the item object and then spreading the rest across the Option component.  This should make it easy to over write when needed without having to add a new property any time we need to change something.

I also added the `isSelected` prop to the usage of the `Option` component in the SimpleSelect.  The API for the `Option` component already supported it, we just weren't using it as expected so I fixed it.