### PR TITLE
Allow click events on elements outside of FocusTrap components

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 5.0</h2>
 
+        <h3>5.1.11</h3>
+        <ul>
+          <li>Allow clicking on elements outside focus trap (<a href='https://github.com/mxenabled/mx-react-components/pull/690'>#690</a>)</li>
+        </ul>
+
         <h3>5.1.10</h3>
         <ul>
           <li>Modal Accessibility Improvements (<a href='https://github.com/mxenabled/mx-react-components/pull/686'>#686</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.10",
+  "version": "5.1.11",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -199,7 +199,7 @@ class Drawer extends React.Component {
 
     return (
       <StyleRoot>
-        <FocusTrap>
+        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
           <div style={styles.componentWrapper}>
             <div onClick={this.props.closeOnScrimClick && this.close} style={styles.scrim} />
             <div

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -180,7 +180,7 @@ class Modal extends React.Component {
     const styles = this.styles(theme);
 
     return (
-      <FocusTrap>
+      <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
         <div className='mx-modal' style={Object.assign({}, styles.scrim, this.props.isRelative && styles.relative)}>
           <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)} />
           <div


### PR DESCRIPTION
The `FocusTrap` component that we use on the `Drawer` and `Modal` components was preventing clicks from happening on elements outside the `FocusTrap`.  This was causing issues for things such as are notifications toast that are rendered above drawer and modal components.  

This fixes the issue by passing the correct config option `clickOutsideDeactivates`  to the FocusTrap component for the `Drawer` and `Modal` components.

See documentation for FocusTrap Libraries for details.

https://github.com/davidtheclark/focus-trap-react
https://github.com/davidtheclark/focus-trap

Specific line in focus-trap library that was causing the issue.
https://github.com/davidtheclark/focus-trap/blob/master/index.js#L177