### PR TITLE
Add the side widths back to the Drawer.

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -289,7 +289,8 @@ class Drawer extends React.Component {
         color: theme.Colors.GRAY_500
       },
       backArrow: {
-        textAlign: 'left'
+        textAlign: 'left',
+        width: '25%'
       },
       header: {
         alignItems: 'center',
@@ -317,7 +318,8 @@ class Drawer extends React.Component {
       },
       headerMenu: {
         textAlign: 'right',
-        whiteSpace: 'nowrap'
+        whiteSpace: 'nowrap',
+        width: '25%'
       },
       navLabel: {
         padding: '7px 14px',


### PR DESCRIPTION
These are required in the scenario in which we have no 'right' item
in the header.

Before:
![screen shot 2018-01-10 at 10 13 02 am](https://user-images.githubusercontent.com/2127504/34785635-f8ebe5ee-f5ee-11e7-8855-64798c906cd6.png)

After:
![screen shot 2018-01-10 at 10 12 24 am](https://user-images.githubusercontent.com/2127504/34785646-005d187a-f5ef-11e7-9a87-a98cdc567c35.png)
