### PR TITLE
.default for Calendar import

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -4,7 +4,7 @@ module.exports = {
   BarChart: require('./components/BarChart'),
   Button: require('./components/Button'),
   ButtonGroup: require('./components/ButtonGroup'),
-  Calendar: require('./components/Calendar'),
+  Calendar: require('./components/Calendar').default,
   Column: require('./components/grid/Column'),
   Container: require('./components/grid/Container'),
   DatePicker: require('./components/DatePicker'),


### PR DESCRIPTION
Since we're now exporting two things from the `Calendar.js` file, the component, and a function for testing, we have to add this `.default`. Unlike ES6 `import` commonJS won't grab the default automatically, so I have to specify which key to grab. 

