### PR TITLE
Calendar - day changed to a tag

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -179,7 +179,7 @@ class Calendar extends React.Component {
             const savedStartDate = day.date();
 
             return (
-              <div
+              <a
                 className='calendar-day'
                 id={
                   day.isSame(moment.unix(this.state.focusedDay), 'day') ?
@@ -214,7 +214,7 @@ class Calendar extends React.Component {
                 }
               >
                 {day.date()}
-              </div>
+              </a>
             );
           })}
         </div>


### PR DESCRIPTION
I"m not sure why - but when I went to use the `Calendar` internally, the divs were not getting a focused state. I feel like I ran into a similar issue with Icon buttons, and had to wrap them in `a` tags instead. 

