### PR TITLE
Calendar - only prevent default if its up or down arrow

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -93,7 +93,7 @@ class Calendar extends React.Component {
   };
 
   _handleDayKeyDown = e => {
-    e.preventDefault();
+    if (keycode(e) === 'up' || keycode(e) === 'down') e.preventDefault();
 
     if (keycode(e) === 'enter')
       this.props.onDateSelect(this.state.focusedDay, e);

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -88,7 +88,8 @@ class Calendar extends React.Component {
       .unix();
 
     this.setState({
-      currentDate
+      currentDate,
+      focusedDay: currentDate
     });
   };
 
@@ -122,7 +123,8 @@ class Calendar extends React.Component {
       .unix();
 
     this.setState({
-      currentDate
+      currentDate,
+      focusedDay: currentDate
     });
   };
 
@@ -232,23 +234,29 @@ class Calendar extends React.Component {
     return (
       <div style={styles.component}>
         <div style={styles.calendarHeader}>
-          <Icon
-            elementProps={{
-              onClick: this._handlePreviousClick
-            }}
-            size={20}
-            style={styles.calendayHeaderNav}
-            type='caret-left'
-          />
+          <a
+            tabIndex={0}
+            onCLick={this._handlePreviousClick}
+            onKeyUp={e => keycode(e) === 'enter' && this._handlePreviousClick()}
+          >
+            <Icon
+              size={20}
+              style={styles.calendayHeaderNav}
+              type='caret-left'
+            />
+          </a>
           <div>{moment.unix(this.state.currentDate).format('MMMM YYYY')}</div>
-          <Icon
-            elementProps={{
-              onClick: this._handleNextClick
-            }}
-            size={20}
-            style={styles.calendayHeaderNav}
-            type='caret-right'
-          />
+          <a
+            tabIndex={0}
+            onClick={this._handleNextClick}
+            onKeyUp={e => keycode(e) === 'enter' && this._handleNextClick()}
+          >
+            <Icon
+              size={20}
+              style={styles.calendayHeaderNav}
+              type='caret-right'
+            />
+          </a>
         </div>
         <div style={styles.calendarWeekHeader}>
           {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -235,9 +235,9 @@ class Calendar extends React.Component {
       <div style={styles.component}>
         <div style={styles.calendarHeader}>
           <a
-            tabIndex={0}
             onCLick={this._handlePreviousClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handlePreviousClick()}
+            tabIndex={0}
           >
             <Icon
               size={20}
@@ -247,9 +247,9 @@ class Calendar extends React.Component {
           </a>
           <div>{moment.unix(this.state.currentDate).format('MMMM YYYY')}</div>
           <a
-            tabIndex={0}
             onClick={this._handleNextClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handleNextClick()}
+            tabIndex={0}
           >
             <Icon
               size={20}


### PR DESCRIPTION
@paniclater originally we talked about always preventing default, however this was causing issues - for example when pressing the tab key, i _do_ want the default browser behavior. Other keys as well we probably want to allow defaults. 

Really the only place I saw the default causing the issue was the up/down arrow with browser scrolling. So I only prevent default if it's an up/down key. 

I thought about trying to do this check in the `getNewDateStateChange` function, but then I'd have to pass in the event, and that function which had become fairly pure would be less so... 

#### edit 

Also adds tabIndex/keyboard nav support to the next and previous month icon buttons. 