### PR TITLE
Calendar - pass e, prop expects an e in DateTimePicker

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -187,8 +187,8 @@ class Calendar extends React.Component {
                     null
                 }
                 key={day}
-                onClick={() => {
-                  if (!disabledDay) this.props.onDateSelect(day.unix());
+                onClick={e => {
+                  if (!disabledDay) this.props.onDateSelect(day.unix(), e);
                 }}
                 onKeyDown={this._handleDayKeyDown}
                 ref={ref => {


### PR DESCRIPTION
I was using the `<DateTimePicker />` and I noticed it was throwing a `cannot read stopPropagation of undefined`. This is because the prop in the DateTimePicker [expects an event](https://github.com/mxenabled/mx-react-components/blob/master/src/components/DateTimePicker.js#L87), and we weren't passing it in the Calendar's onClick. 