### PR TITLE
luke/Calendar - fixed tests

### DIFF
--- a/src/components/__tests__/Calendar-test.js
+++ b/src/components/__tests__/Calendar-test.js
@@ -39,11 +39,12 @@ describe('Calendar', () => {
     });
   });
 
+// moment('2016-01-01');
 
   describe('getNewDateStateChange', () => {
-    const focusedDay = moment();
-    const startDate = moment().startOf('month').startOf('week');
-    const endDate = moment().endOf('month').endOf('week');
+    const focusedDay = moment('2018-01-17');
+    const startDate = moment('2018-01-17').startOf('month').startOf('week');
+    const endDate = moment('2018-01-17').endOf('month').endOf('week');
 
     it('should return an object with a focusedDay key when right key is pressed', () => {
       const result = {
@@ -58,9 +59,11 @@ describe('Calendar', () => {
         focusedDay: moment(focusedDay).add(1, 'days').startOf('day').unix(),
         currentDate: moment(focusedDay).add(1, 'days').startOf('day').unix()
       };
-      const endDateOutOfRange = focusedDay;
+      //deliberately set to be out of range
+      const endDate = moment(focusedDay).clone();
 
-      expect(getNewDateStateChange({ code: 'right', focusedDay, startDate, endDateOutOfRange })).toEqual(result);
+
+      expect(getNewDateStateChange({ code: 'right', focusedDay, startDate, endDate })).toEqual(result);
     });
 
     it('should return an object with a focusedDay key when left key is pressed', () => {
@@ -76,9 +79,10 @@ describe('Calendar', () => {
         focusedDay: moment(focusedDay).subtract(1, 'days').startOf('day').unix(),
         currentDate: moment(focusedDay).subtract(1, 'days').startOf('day').unix()
       };
-      const startDateOutOfRange = focusedDay;
+      //deliberately set to be out of range
+      const startDate = moment(focusedDay).clone();
 
-      expect(getNewDateStateChange({ code: 'left', focusedDay, startDateOutOfRange, endDate })).toEqual(result);
+      expect(getNewDateStateChange({ code: 'left', focusedDay, startDate, endDate })).toEqual(result);
     });
 
     it('should return correct day when up key is pressed', () => {


### PR DESCRIPTION
Because I was allowing moment() to be called with whatever the actual date was, these tests would fail in some cases. To fix this, I called moment and passed in a date as a string `'2018-01-17'`

Also - and idk how this was passing before - but because the function that I was testing relied on param object destructuring, I was getting undefined as I wasn't matching the object key names exactly in my passed object.  

