### PR TITLE
Simple input docs

### DIFF
--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -22,17 +22,48 @@ class SimpleInputDocs extends React.Component {
           elementProps={{
             placeholder: 'Type something'
           }}
+          handleResetClick={() => {
+            /* eslint-disable no-console */
+            console.log('clicked me');
+            /* eslint-enable no-console */
+          }}
+          // icon={'bike'}
+          // rightIcon={'close-solid'}
         />
 
         <h3>Usage</h3>
+        <h5>baseColor <label>String</label></h5>
+        <p>The color of the <Code>input</Code> border on focus.</p>
+
         <h5>elementProps <label>Object</label></h5>
         <p>Properties to pass directly to the <Code>input</Code> element.</p>
+
+        <h5>focusOnLoad <label>Boolean</label></h5>
+        <p>Focus <Code>input</Code> on load, default of false.</p>
+
+        <h5>handleResetClick <label>Function</label></h5>
+        <p>The function that will execute when <Code>rightIcon</Code> is clicked. This prop will not work properly unless <Code>rightIcon</Code> is also declared. </p>
+
+        <h5>icon <label>String</label></h5>
+        <p>The name of icon to display in the left side of the <Code>input</Code>.</p>
 
         <h5>placeholder <label>String</label></h5>
         <p>The text to show before the user starts typing or when the <Code>input</Code> is empty.</p>
 
+        <h5>rightIcon <label>String</label></h5>
+        <p>The name of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
+
+        <h5>style <label>Object or Array</label></h5>
+        <p>blah blah</p>
+
+        <h5>styles <label>Object</label></h5>
+        <p>blah blah</p>
+
         <h5>theme <label>Object</label></h5>
         <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
+
+        <h5>type <label>String</label></h5>
+        <p>blah blah</p>
 
         <h5>valid <label>Boolean</label></h5>
         <p>Indicates whether the value of Input field is valid. If it is not valid, the input field will have a red border.</p>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -27,9 +27,10 @@ class SimpleInputDocs extends React.Component {
         <h3>Usage</h3>
         <h5>baseColor <label>String</label></h5>
         <p>The color of the <Code>input</Code> border on focus.</p>
+        <p>*This prop is deprecated, please use <Code>themes</Code> instead.</p>
 
         <h5>elementProps <label>Object</label></h5>
-        <p>Attributes to pass directly to the <Code>input</Code> element. ie. placeholder, value, onchange, etc.</p>
+        <p>Pass props directly to the <Code>input</Code> element. ie. placeholder, value, onchange, etc.</p>
 
         <h5>focusOnLoad <label>Boolean</label></h5>
         <p>Focus <Code>input</Code> on load, default of false.</p>
@@ -38,10 +39,10 @@ class SimpleInputDocs extends React.Component {
         <p>The function that will execute when <Code>rightIcon</Code> is clicked. This prop will not work properly unless <Code>rightIcon</Code> is also declared. </p>
 
         <h5>icon <label>String</label></h5>
-        <p>The name of icon to display in the left side of the <Code>input</Code>.</p>
+        <p>The type of icon to display in the left side of the <Code>input</Code>.</p>
 
         <h5>rightIcon <label>String</label></h5>
-        <p>The name of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
+        <p>The type of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
 
         <h5>styles <label>Object</label></h5>
         <p>Allows style additions or overrides to specific component elements including:</p>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -83,6 +83,7 @@ class SimpleInputDocs extends React.Component {
               rightIcon: { paddingRight: '40px' }
             }}
             theme={{ Colors: { PRIMARY: 'orange' } }}
+            valid={false}
           />
         `}
         </Markdown>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -22,6 +22,12 @@ class SimpleInputDocs extends React.Component {
           elementProps={{
             placeholder: 'Type something'
           }}
+          // style={{ backgroundColor: 'purple', border: '4px solid green', marginTop: '50px' }}
+          styles={{
+            wrapper: { backgroundColor: 'red' },
+            activeWrapper: { backgroundColor: 'blue' }
+          }}
+
         />
 
         <h3>Usage</h3>
@@ -43,8 +49,8 @@ class SimpleInputDocs extends React.Component {
         <h5>rightIcon <label>String</label></h5>
         <p>The name of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
 
-        <h5>style <label>Object or Array</label></h5>
-        <p>blah blah</p>
+        <h5>style <label>Object</label></h5>
+        <p>The styles are applied to the outtermost wrapper element in the component.</p>
 
         <h5>styles <label>Object</label></h5>
         <p>blah blah</p>
@@ -71,6 +77,7 @@ class SimpleInputDocs extends React.Component {
             handleResetClick={myRightIconClickCallbackFunction}
             icon={'bike'}
             rightIcon={'close-solid'}
+            style={{ backgroundColor: 'purple', border: '4px solid green', marginTop: '50px' }}
           />
         `}
         </Markdown>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -22,13 +22,6 @@ class SimpleInputDocs extends React.Component {
           elementProps={{
             placeholder: 'Type something'
           }}
-          handleResetClick={() => {
-            /* eslint-disable no-console */
-            console.log('clicked me');
-            /* eslint-enable no-console */
-          }}
-          // icon={'bike'}
-          // rightIcon={'close-solid'}
         />
 
         <h3>Usage</h3>
@@ -36,7 +29,7 @@ class SimpleInputDocs extends React.Component {
         <p>The color of the <Code>input</Code> border on focus.</p>
 
         <h5>elementProps <label>Object</label></h5>
-        <p>Properties to pass directly to the <Code>input</Code> element.</p>
+        <p>Attributes to pass directly to the <Code>input</Code> element. ie. placeholder, value, onchange, etc.</p>
 
         <h5>focusOnLoad <label>Boolean</label></h5>
         <p>Focus <Code>input</Code> on load, default of false.</p>
@@ -46,9 +39,6 @@ class SimpleInputDocs extends React.Component {
 
         <h5>icon <label>String</label></h5>
         <p>The name of icon to display in the left side of the <Code>input</Code>.</p>
-
-        <h5>placeholder <label>String</label></h5>
-        <p>The text to show before the user starts typing or when the <Code>input</Code> is empty.</p>
 
         <h5>rightIcon <label>String</label></h5>
         <p>The name of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
@@ -72,18 +62,15 @@ class SimpleInputDocs extends React.Component {
         <Markdown>
           {`
           <SimpleInput
-            placeholder='Type something'
-            type='text'
-            valid={false}
-          />
-
-          <SimpleInput
+            baseColor={'red'}
             elementProps={{
-              onChange: myOnChangeCallbackFunction
+              onChange: myOnChangeCallbackFunction,
               placeholder: 'Type something'
             }}
-            label='Type something'
-            valid={true}
+            focusOnLoad={true}
+            handleResetClick={myRightIconClickCallbackFunction}
+            icon={'bike'}
+            rightIcon={'close-solid'}
           />
         `}
         </Markdown>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -22,12 +22,6 @@ class SimpleInputDocs extends React.Component {
           elementProps={{
             placeholder: 'Type something'
           }}
-          // style={{ backgroundColor: 'purple', border: '4px solid green', marginTop: '50px' }}
-          styles={{
-            wrapper: { backgroundColor: 'red' },
-            activeWrapper: { backgroundColor: 'blue' }
-          }}
-
         />
 
         <h3>Usage</h3>
@@ -49,11 +43,16 @@ class SimpleInputDocs extends React.Component {
         <h5>rightIcon <label>String</label></h5>
         <p>The name of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
 
-        <h5>style <label>Object</label></h5>
-        <p>The styles are applied to the outtermost wrapper element in the component.</p>
-
         <h5>styles <label>Object</label></h5>
-        <p>blah blah</p>
+        <p>Style changes or additions to specific component elements including:</p>
+          <ul >
+          <li><Code>wrapper</Code>: the outermost element of the component.</li>
+          <li><Code>activeWrapper</Code>: the outermost element of the component when active.</li>
+          <li><Code>input</Code>: the component's <Code>input</Code> element.</li>
+          <li><Code>icon</Code>: the icon located in the left side of the <Code>input</Code> element.</li>
+          <li><Code>rightIcon</Code>: the icon located in the right side of the <Code>input</Code> element.</li>
+          </ul>
+          <p>*see example for syntax</p>
 
         <h5>theme <label>Object</label></h5>
         <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
@@ -70,14 +69,19 @@ class SimpleInputDocs extends React.Component {
           <SimpleInput
             baseColor={'red'}
             elementProps={{
-              onChange: myOnChangeCallbackFunction,
               placeholder: 'Type something'
             }}
             focusOnLoad={true}
             handleResetClick={myRightIconClickCallbackFunction}
             icon={'bike'}
             rightIcon={'close-solid'}
-            style={{ backgroundColor: 'purple', border: '4px solid green', marginTop: '50px' }}
+            styles={{
+              wrapper: { backgroundColor: 'red', border: '4px solid green' },
+              activeWrapper: { backgroundColor: 'blue', border: '4px solid red' },
+              input: { color: 'purple' },
+              icon: { paddingLeft: '40px' },
+              rightIcon: { paddingRight: '40px' }
+            }}
           />
         `}
         </Markdown>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -44,7 +44,7 @@ class SimpleInputDocs extends React.Component {
         <p>The name of icon to display in the right side of the <Code>input</Code>. This icon is clickable and will execute the function specified in the <Code>handleResetClick</Code> prop.  This prop will not work properly unless <Code>handleResetClick</Code> is also declared.</p>
 
         <h5>styles <label>Object</label></h5>
-        <p>Style changes or additions to specific component elements including:</p>
+        <p>Allows style additions or overrides to specific component elements including:</p>
           <ul >
           <li><Code>wrapper</Code>: the outermost element of the component.</li>
           <li><Code>activeWrapper</Code>: the outermost element of the component when active.</li>
@@ -52,10 +52,10 @@ class SimpleInputDocs extends React.Component {
           <li><Code>icon</Code>: the icon located in the left side of the <Code>input</Code> element.</li>
           <li><Code>rightIcon</Code>: the icon located in the right side of the <Code>input</Code> element.</li>
           </ul>
-          <p>*see example for syntax</p>
+          <p>*<Code>styles</Code> will override defaults and conflicting <Code>themes</Code></p>
 
         <h5>theme <label>Object</label></h5>
-        <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
+        <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information. Themes may be overridden by <Code>styles</Code></p>
 
         <h5>type <label>String</label></h5>
         <p>blah blah</p>
@@ -82,6 +82,7 @@ class SimpleInputDocs extends React.Component {
               icon: { paddingLeft: '40px' },
               rightIcon: { paddingRight: '40px' }
             }}
+            theme={{ Colors: { PRIMARY: 'orange' } }}
           />
         `}
         </Markdown>

--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -55,10 +55,10 @@ class SimpleInputDocs extends React.Component {
           <p>*<Code>styles</Code> will override defaults and conflicting <Code>themes</Code></p>
 
         <h5>theme <label>Object</label></h5>
-        <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information. Themes may be overridden by <Code>styles</Code></p>
+        <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information. Themes will be overridden by conflicting <Code>styles</Code></p>
 
         <h5>type <label>String</label></h5>
-        <p>blah blah</p>
+        <p>Specifies the <Code>input</Code> type. Default <Code>type</Code> is text.</p>
 
         <h5>valid <label>Boolean</label></h5>
         <p>Indicates whether the value of Input field is valid. If it is not valid, the input field will have a red border.</p>

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -16,7 +16,6 @@ class Input extends React.Component {
     focusOnLoad: PropTypes.bool,
     handleResetClick: PropTypes.func,
     icon: PropTypes.string,
-    placeholder: PropTypes.string,
     rightIcon: PropTypes.string,
     style: PropTypes.oneOfType([
       PropTypes.array,

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -17,6 +17,7 @@ class Input extends React.Component {
     handleResetClick: PropTypes.func,
     icon: PropTypes.string,
     rightIcon: PropTypes.string,
+    //keep style for backwards compatibility
     style: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.object


### PR DESCRIPTION
issue #616 (SimpleInput is missing docs for most of its props) 

I updated/added prop descriptions in the docs and added them to the example snippet for syntax clarity. I removed placeholder prop and excluded style prop from the docs (placeholder was nonexistent and style was redundant to styles - left in component for backwards compatibility).

I was thinking about overall usability of the docs. Do we want to show multiple variations in the top Demo section so people can see at a glance what customization is possible? Or do we want to keep it clean with a single basic demo?  

Maybe we keep the top demo demo section simple with one basic/default component displayed but expand bottom Example section to show multiple variations displayed along with their code snippets? Thoughts?
  

