### PR TITLE
Luke/Simple Select pass e 

### DIFF
--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -63,7 +63,7 @@ class SimpleSelectDocs extends React.Component {
         <p>An array of objects that specify <em>icon</em>, <em>isSelected</em>, <em>text</em>, and/or <em>onClick</em> of the item..</p>
 
         <h5>onScrimClick <label>function</label></h5>
-        <p><em>onClick</em> handler for the menu scrim. Function will be passed the event as its first argument.</p>
+        <p><em>onClick</em> handler for the menu scrim.</p>
 
         <h5>scrimClickOnSelect <label>boolean</label></h5>
         <p>Boolean that triggers a scrim click on select. Can be used to auto-close.</p>

--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -63,7 +63,7 @@ class SimpleSelectDocs extends React.Component {
         <p>An array of objects that specify <em>icon</em>, <em>isSelected</em>, <em>text</em>, and/or <em>onClick</em> of the item..</p>
 
         <h5>onScrimClick <label>function</label></h5>
-        <p><em>onClick</em> handler for the menu scrim.</p>
+        <p><em>onClick</em> handler for the menu scrim. Function will be passed the event as it's first argument.</p>
 
         <h5>scrimClickOnSelect <label>boolean</label></h5>
         <p>Boolean that triggers a scrim click on select. Can be used to auto-close.</p>

--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -63,7 +63,7 @@ class SimpleSelectDocs extends React.Component {
         <p>An array of objects that specify <em>icon</em>, <em>isSelected</em>, <em>text</em>, and/or <em>onClick</em> of the item..</p>
 
         <h5>onScrimClick <label>function</label></h5>
-        <p><em>onClick</em> handler for the menu scrim. Function will be passed the event as it's first argument.</p>
+        <p><em>onClick</em> handler for the menu scrim. Function will be passed the event as its first argument.</p>
 
         <h5>scrimClickOnSelect <label>boolean</label></h5>
         <p>Boolean that triggers a scrim click on select. Can be used to auto-close.</p>

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -56,7 +56,7 @@ class SimpleSelect extends React.Component {
   _handleKeyDown = (e) => {
     if (keycode(e) === 'esc') {
       e.preventDefault();
-      this.props.onScrimClick(e);
+      this.props.onScrimClick();
     }
   };
 
@@ -83,7 +83,7 @@ class SimpleSelect extends React.Component {
                   label={text}
                   onClick={e => {
                     if (this.props.scrimClickOnSelect) {
-                      this.props.onScrimClick(e);
+                      this.props.onScrimClick();
                     }
 
                     if (onClick && typeof onClick === 'function') {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -83,6 +83,7 @@ class SimpleSelect extends React.Component {
                   label={text}
                   onClick={e => {
                     if (this.props.scrimClickOnSelect) {
+                      e.stopPropagation();
                       this.props.onScrimClick();
                     }
 
@@ -102,7 +103,13 @@ class SimpleSelect extends React.Component {
             })
           )}
         </Listbox>
-        <div onClick={this.props.onScrimClick} style={styles.scrim} />
+        <div
+          onClick={e => {
+            e.stopPropagation();
+            this.props.onScrimClick();
+          }}
+          style={styles.scrim}
+        />
       </div>
     );
   }

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -56,7 +56,7 @@ class SimpleSelect extends React.Component {
   _handleKeyDown = (e) => {
     if (keycode(e) === 'esc') {
       e.preventDefault();
-      this.props.onScrimClick();
+      this.props.onScrimClick(e);
     }
   };
 


### PR DESCRIPTION
`this.props.onScrimClick` can take the event as an argument so you can act on the event in the parent if need be. We weren't passing the event when `this.props.onScrimClick()` was called when the escape key was pressed. 

