### PR TITLE
Fix - Issue #642 : select last year

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -73,8 +73,8 @@ class DateRangePicker extends React.Component {
       },
       {
         displayValue: 'Last Year',
-        getEndDate: () => moment().startOf('day').unix(),
-        getStartDate: () => moment().startOf('day').subtract(1, 'y').unix()
+        getEndDate: () => moment().startOf('year').subtract(1, 'd').unix(),
+        getStartDate: () => moment().startOf('year').subtract(1, 'y').unix()
       }
     ],
     format: 'MMM D, YYYY',


### PR DESCRIPTION
Fix for issue #642 "Date Range Picker (test/new) - Last Year should show last calendar year"

I will now display the last calendar year instead of the last 365 days to the current day.