### PR TITLE
Remove getComputedStyle

### DIFF
--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -84,8 +84,7 @@ class RangeSelector extends React.Component {
 
   _setDefaultRangeValues = () => {
     const component = ReactDOM.findDOMNode(this.rangeSelectorRef);
-    const componentStyles = window.getComputedStyle(component);
-    const width = parseInt(componentStyles.width, 0);
+    const width = component.offsetWidth;
 
     //convert our values to a 0-based scale
     const lowerPosition = this.state.lowerValue - (this.props.lowerBound);


### PR DESCRIPTION
This removes the `window.getComputedStyle` from the RangeSelector and replaces it with component.offsetWidth.

The `getComputedStyle` was triggering a honeybadger error in the segment builder.

`Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.`