### PR TITLE
Fix Calendar Component accessibility

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,6 +7,11 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.21</h3>
+        <ul>
+          <li>Accessibility Fixes to Calendar component(<a href='https://github.com/mxenabled/mx-react-components/pull/707'>#707</a>)</li>
+        </ul>
+
         <h3>5.1.20</h3>
         <ul>
           <li>Remove getComputedStyles from RangeSelector(<a href='https://github.com/mxenabled/mx-react-components/pull/706'>#706</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.20",
+  "version": "5.1.21",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -19,15 +19,17 @@ export const getNewDateStateChange = ({
 }) => {
   let day = null;
   let currentDate = null;
+  // Don't mutate existing focusedDay moment object
+  const copyOfFocusedDay = moment(focusedDay);
 
   if (code === 'right') {
-    day = focusedDay.add(1, 'days').startOf('day');
+    day = copyOfFocusedDay.add(1, 'days').startOf('day');
   } else if (code === 'left') {
-    day = focusedDay.subtract(1, 'days').startOf('day');
+    day = copyOfFocusedDay.subtract(1, 'days').startOf('day');
   } else if (code === 'up') {
-    day = focusedDay.subtract(7, 'days').startOf('day');
+    day = copyOfFocusedDay.subtract(7, 'days').startOf('day');
   } else if (code === 'down') {
-    day = focusedDay.add(7, 'days').startOf('day');
+    day = copyOfFocusedDay.add(7, 'days').startOf('day');
   }
 
   if (day && (day.isBefore(startDate) || day.isAfter(endDate))) {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -202,7 +202,7 @@ class Calendar extends React.Component {
                   if (!disabledDay) this.props.onDateSelect(day.unix(), e);
                 }}
                 onKeyDown={e => this._handleDayKeyDown(e, day)}
-                ref={ref => (this[day.unix()] = ref)}
+                ref={dayAnchorTag => (this[day.unix()] = dayAnchorTag)}
                 style={Object.assign(
                   {},
                   styles.calendarDay,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -188,7 +188,7 @@ class Calendar extends React.Component {
                     'focused-day' :
                     null
                 }
-                key={day}
+                key={day.unix()}
                 onClick={e => {
                   if (!disabledDay) this.props.onDateSelect(day.unix(), e);
                 }}

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -235,7 +235,7 @@ class Calendar extends React.Component {
       <div style={styles.component}>
         <div style={styles.calendarHeader}>
           <a
-            onCLick={this._handlePreviousClick}
+            onClick={this._handlePreviousClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handlePreviousClick()}
             tabIndex={0}
           >

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -80,6 +80,19 @@ class Calendar extends React.Component {
     }
   }
 
+  _handleNextClick = () => {
+    const currentDate = moment
+      .unix(this.state.currentDate)
+      .endOf('month')
+      .add(1, 'd')
+      .unix();
+
+    this.setState({
+      currentDate,
+      focusedDay: currentDate
+    });
+  };
+
   _handlePreviousClick = () => {
     const currentDate = moment
       .unix(this.state.currentDate)
@@ -113,19 +126,6 @@ class Calendar extends React.Component {
     });
 
     if (newDateStateChange !== null) this.setState(newDateStateChange);
-  };
-
-  _handleNextClick = () => {
-    const currentDate = moment
-      .unix(this.state.currentDate)
-      .endOf('month')
-      .add(1, 'd')
-      .unix();
-
-    this.setState({
-      currentDate,
-      focusedDay: currentDate
-    });
   };
 
   _getWeeks = () => {
@@ -178,7 +178,6 @@ class Calendar extends React.Component {
             const disabledDay = this.props.minimumDate ?
               day.isBefore(moment.unix(this.props.minimumDate), 'day') :
               null;
-            const savedStartDate = day.date();
 
             return (
               <a
@@ -193,14 +192,7 @@ class Calendar extends React.Component {
                   if (!disabledDay) this.props.onDateSelect(day.unix(), e);
                 }}
                 onKeyDown={this._handleDayKeyDown}
-                ref={ref => {
-                  if (
-                    ref &&
-                    moment.unix(this.state.focusedDay).date() === savedStartDate
-                  ) {
-                    ref.focus();
-                  }
-                }}
+                ref={ref => (this[day.unix()] = ref)}
                 style={Object.assign(
                   {},
                   styles.calendarDay,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -108,15 +108,15 @@ class Calendar extends React.Component {
     });
   };
 
-  _handleDayKeyDown = e => {
+  _handleDayKeyDown = (e, day) => {
     if (keycode(e) === 'up' || keycode(e) === 'down') e.preventDefault();
 
     if (keycode(e) === 'enter')
-      this.props.onDateSelect(this.state.focusedDay, e);
+      this.props.onDateSelect(day.unix(), e);
 
     const newDateStateChange = getNewDateStateChange({
       code: keycode(e),
-      focusedDay: moment.unix(this.state.focusedDay),
+      focusedDay: day,
       startDate: moment
         .unix(this.state.currentDate)
         .startOf('month')
@@ -193,7 +193,7 @@ class Calendar extends React.Component {
                 onClick={e => {
                   if (!disabledDay) this.props.onDateSelect(day.unix(), e);
                 }}
-                onKeyDown={this._handleDayKeyDown}
+                onKeyDown={e => this._handleDayKeyDown(e, day)}
                 ref={ref => (this[day.unix()] = ref)}
                 style={Object.assign(
                   {},

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -32,7 +32,7 @@ export const getNewDateStateChange = ({
     day = copyOfFocusedDay.add(7, 'days').startOf('day');
   }
 
-  if (day && (day.isAfter(startDate) || day.isBefore(endDate))) {
+  if (day && (day.isBefore(startDate) || day.isAfter(endDate))) {
     currentDate = day.unix();
   }
 

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -32,7 +32,7 @@ export const getNewDateStateChange = ({
     day = copyOfFocusedDay.add(7, 'days').startOf('day');
   }
 
-  if (day && (day.isBefore(startDate) || day.isAfter(endDate))) {
+  if (day && (day.isAfter(startDate) || day.isBefore(endDate))) {
     currentDate = day.unix();
   }
 

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -82,6 +82,14 @@ class Calendar extends React.Component {
     }
   }
 
+  componentDidUpdate (prevProps, prevState) {
+    if (prevState.focusedDay !== this.state.focusedDay) {
+      const focusedDayRef = this[this.state.focusedDay];
+
+      if (focusedDayRef && focusedDayRef.focus) focusedDayRef.focus();
+    }
+  }
+
   _handleNextClick = () => {
     const currentDate = moment
       .unix(this.state.currentDate)

--- a/src/components/__tests__/Calendar-test.js
+++ b/src/components/__tests__/Calendar-test.js
@@ -46,6 +46,7 @@ describe('Calendar', () => {
 
     it('should return an object with a focusedDay key when right key is pressed', () => {
       const result = {
+        currentDate: moment(focusedDay).add(1, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).add(1, 'days').startOf('day').unix()
       };
 
@@ -66,6 +67,7 @@ describe('Calendar', () => {
 
     it('should return an object with a focusedDay key when left key is pressed', () => {
       const result = {
+        currentDate: moment(focusedDay).subtract(1, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).subtract(1, 'days').startOf('day').unix()
       };
 
@@ -85,6 +87,7 @@ describe('Calendar', () => {
 
     it('should return correct day when up key is pressed', () => {
       const result = {
+        currentDate: moment(focusedDay).subtract(7, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).subtract(7, 'days').startOf('day').unix()
       };
 
@@ -93,6 +96,7 @@ describe('Calendar', () => {
 
     it('should return correct day when down key is pressed', () => {
       const result = {
+        currentDate: moment(focusedDay).add(7, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).add(7, 'days').startOf('day').unix()
       };
 

--- a/src/components/__tests__/Calendar-test.js
+++ b/src/components/__tests__/Calendar-test.js
@@ -46,7 +46,6 @@ describe('Calendar', () => {
 
     it('should return an object with a focusedDay key when right key is pressed', () => {
       const result = {
-        currentDate: moment(focusedDay).add(1, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).add(1, 'days').startOf('day').unix()
       };
 
@@ -67,7 +66,6 @@ describe('Calendar', () => {
 
     it('should return an object with a focusedDay key when left key is pressed', () => {
       const result = {
-        currentDate: moment(focusedDay).subtract(1, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).subtract(1, 'days').startOf('day').unix()
       };
 
@@ -87,7 +85,6 @@ describe('Calendar', () => {
 
     it('should return correct day when up key is pressed', () => {
       const result = {
-        currentDate: moment(focusedDay).subtract(7, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).subtract(7, 'days').startOf('day').unix()
       };
 
@@ -96,7 +93,6 @@ describe('Calendar', () => {
 
     it('should return correct day when down key is pressed', () => {
       const result = {
-        currentDate: moment(focusedDay).add(7, 'days').startOf('day').unix(),
         focusedDay: moment(focusedDay).add(7, 'days').startOf('day').unix()
       };
 


### PR DESCRIPTION
#### Fixes accessibility issue with Calendar component. 

We were running into issues internally not being able to tab to anything on the Calendar component because of the focus call we were doing in the ref callback on the day anchor tag interfering with how the Focus Trap library manages tabbing in the Drawer component works.  This MR fixes that issue and a few other minor things.

- Removes weird focus call in ref call back
- Moves focusing of day to componentDidUpdate
- Fixes moment object mutation bug on focusedDay
- Fixes typo for onClick handler on go back a month calendar button
- Groups click handlers for month nav buttons together