### PR TITLE
Drawer Tweaks

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,6 +7,11 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.22</h3>
+        <ul>
+          <li>Accessibility Fix and functionality additions to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/711'>#711</a>)</li>
+          <li>Fixes closeOnScrimClick prop warning for Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/710'>#710</a>)</li>
+        </ul>
         <h3>5.1.21</h3>
         <ul>
           <li>Accessibility Fixes to Calendar component(<a href='https://github.com/mxenabled/mx-react-components/pull/707'>#707</a>)</li>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -83,6 +83,9 @@ class DrawerDocs extends React.Component {
         {this.state.demoDrawerOpen && this._renderDrawer()}
 
         <h3>Usage</h3>
+        <h5>children<label>Node or Function</label></h5>
+        <p>Children of the Drawer component can be a normal DOM node or a function.  If children are a function, the function is called and the drawer's close method is passed as the functions first argument.  This is handy if you need to close the drawer from the drawer's content area and want to ensure the drawer's animation is run before close. See the second example below for more details.</p>
+
         <h5>animateLeftDistance<label>Number</label></h5>
         <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
 

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -37,28 +37,28 @@ class DrawerDocs extends React.Component {
       <Drawer
         breakPoints={{ large: 1200, medium: 1100 }}
         contentStyle={styles.content}
-        headerMenu={closeDrawer => (
+        headerMenu={({ close }) => (
           <HeaderMenu
             buttonIcon='gear'
             buttonText='Settings'
             items={[
               { icon: 'auto', onClick: this._handleSimpleSelectClick, text: 'Auto' },
               { icon: 'kids', onClick: this._handleSimpleSelectClick, text: 'Kids' },
-              { icon: 'close', onClick: closeDrawer, text: 'Close Drawer' }
+              { icon: 'close', onClick: close, text: 'Close Drawer' }
             ]}
           />
         )}
         onClose={this._handleDrawerClose}
         title='Demo Drawer'
       >
-        {closeDrawer => {
+        {({ close }) => {
           return (
             <div>
               {this.state.clickedMenu && <code>You clicked: {this.state.clickedMenu.text}</code>}
               <p>
               Pellentesque finibus eros magna, ac feugiat mauris pretium posuere. Aliquam nec turpis bibendum, hendrerit eros et, interdum neque. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc pulvinar tempus sollicitudin. Mauris vel suscipit dolor. Vestibulum hendrerit malesuada ipsum. Mauris feugiat dui vel leo consequat tempor. Praesent aliquet posuere consequat. Nunc vel tellus eleifend leo finibus auctor.
               </p>
-              <Button onClick={closeDrawer}>Close Drawer</Button>
+              <Button onClick={close}>Close Drawer</Button>
             </div>
           );
         }}
@@ -85,7 +85,7 @@ class DrawerDocs extends React.Component {
         <h3>Usage</h3>
         <h5>children<label>DOM Node/Element or Function</label></h5>
         <p>Children of the Drawer component can be a component, DOM node/element, or a function.</p>
-        <p>If children is a function, the function is called and the drawer's close method is passed as the functions first argument. The returned value of the function call must be a component or DOM node/element. This is handy if you need to close the drawer from the drawer's content area and want to ensure the drawer's animation is run before close. See the second example below for more details.</p>
+        <p>If children is a function, the function is called and passed an object of exposed drawer functions. Currently the Drawer's close function is the only exposed function in the object and has a key of `close`. The returned value of the function call must be a component or DOM node/element. This is handy if you need to close the drawer from the drawer's content area and want to ensure the drawer's animation is run before close. See the second example below for more details.</p>
 
         <h5>animateLeftDistance<label>Number</label></h5>
         <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
@@ -126,7 +126,7 @@ class DrawerDocs extends React.Component {
 
         <h5>headerMenu<label>Component or Function</label></h5>
         <p>A component or function that you can use to  add a menu of items to the header of the drawer.</p>
-        <p>If headerMenu is a function, the function is called and the drawer's close function is passed as the first argument. The returned value of the function call must be a component or DOM node/element.</p>
+        <p>If headerMenu is a function, the function is called and passed an object of exposed drawer functions. Currently the Drawer's close function is the only exposed function in the object and has a key of `close`. The returned value of the function call must be a component or DOM node/element.</p>
         <p>See first example for how to pass a component as headerMenu.</p>
         <p>See second example for how to pass a function as headerMenu.</p>
 
@@ -201,23 +201,23 @@ class DrawerDocs extends React.Component {
     <Drawer
       breakPoints={{ large: 1200, medium: 1100 }}
       contentStyle={styles.content}
-      headerMenu={closeDrawerFunction => (
+      headerMenu={({ close }) => (
         <HeaderMenu
           handleButtonClick={this._handleSimpleSelectClick}
-          handleScrimClick={closeDrawerFunction}
+          handleScrimClick={close}
           showSimpleSelectMenu={this.state.showMenu}
         />
       )}
       onClose={this._handleDrawerClose}
       title='Demo Drawer'
     >
-      {closeDrawerFunction => {
+      {({ close }) => {
         return (
           <div>
             <p>
               Content Here
             </p>
-            <button onClick={closeDrawerFunction}>Close the drawer from the conten</button>
+            <button onClick={close}>Close the drawer from the conten</button>
           </div>
         )
       }}

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -51,11 +51,17 @@ class DrawerDocs extends React.Component {
         onClose={this._handleDrawerClose}
         title='Demo Drawer'
       >
-
-        {this.state.clickedMenu && <code>You clicked: {this.state.clickedMenu.text}</code>}
-        <p>
-        Pellentesque finibus eros magna, ac feugiat mauris pretium posuere. Aliquam nec turpis bibendum, hendrerit eros et, interdum neque. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc pulvinar tempus sollicitudin. Mauris vel suscipit dolor. Vestibulum hendrerit malesuada ipsum. Mauris feugiat dui vel leo consequat tempor. Praesent aliquet posuere consequat. Nunc vel tellus eleifend leo finibus auctor.
-        </p>
+        {closeDrawer => {
+          return (
+            <div>
+              {this.state.clickedMenu && <code>You clicked: {this.state.clickedMenu.text}</code>}
+              <p>
+              Pellentesque finibus eros magna, ac feugiat mauris pretium posuere. Aliquam nec turpis bibendum, hendrerit eros et, interdum neque. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc pulvinar tempus sollicitudin. Mauris vel suscipit dolor. Vestibulum hendrerit malesuada ipsum. Mauris feugiat dui vel leo consequat tempor. Praesent aliquet posuere consequat. Nunc vel tellus eleifend leo finibus auctor.
+              </p>
+              <Button onClick={closeDrawer}>Close Drawer</Button>
+            </div>
+          );
+        }}
       </Drawer>
     );
   };
@@ -148,7 +154,7 @@ class DrawerDocs extends React.Component {
           <li style={styles.listItem}><h5 style={styles.h5ListItem}>onNextClick <label>Function</label></h5> this function will be called when the right arrow is clicked.</li>
         </ul>
 
-        <h3>Example</h3>
+        <h3>Normal Example</h3>
         <Markdown>
   {`
 
@@ -172,6 +178,43 @@ class DrawerDocs extends React.Component {
       title='Demo Drawer'
     >
       // Content Here
+    </Drawer>
+  `}
+        </Markdown>
+
+        <h3>Function as Children Example</h3>
+        <Markdown>
+  {`
+
+    _handleDrawerClose () {
+      this.setState({
+        demoDrawerOpen: false
+      });
+    },
+
+    <Drawer
+      breakPoints={{ large: 1200, medium: 1100 }}
+      contentStyle={styles.content}
+      headerMenu={(
+        <HeaderMenu
+          handleButtonClick={this._handleSimpleSelectClick}
+          handleScrimClick={this._handleSimpleSelectClick}
+          showSimpleSelectMenu={this.state.showMenu}
+        />
+      )}
+      onClose={this._handleDrawerClose}
+      title='Demo Drawer'
+    >
+      {closeDrawerFunction => {
+        return (
+          <div>
+            <p>
+              Content Here
+            </p>
+            <button onClick={closeDrawerFunction}>Close the drawer from the conten</button>
+          </div>
+        )
+      }}
     </Drawer>
   `}
         </Markdown>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -37,14 +37,14 @@ class DrawerDocs extends React.Component {
       <Drawer
         breakPoints={{ large: 1200, medium: 1100 }}
         contentStyle={styles.content}
-        headerMenu={(
+        headerMenu={closeDrawer => (
           <HeaderMenu
             buttonIcon='gear'
             buttonText='Settings'
             items={[
               { icon: 'auto', onClick: this._handleSimpleSelectClick, text: 'Auto' },
               { icon: 'kids', onClick: this._handleSimpleSelectClick, text: 'Kids' },
-              { icon: 'pets', onClick: this._handleSimpleSelectClick, text: 'Pets' }
+              { icon: 'close', onClick: closeDrawer, text: 'Close Drawer' }
             ]}
           />
         )}
@@ -83,8 +83,9 @@ class DrawerDocs extends React.Component {
         {this.state.demoDrawerOpen && this._renderDrawer()}
 
         <h3>Usage</h3>
-        <h5>children<label>Node or Function</label></h5>
-        <p>Children of the Drawer component can be a normal DOM node or a function.  If children are a function, the function is called and the drawer's close method is passed as the functions first argument.  This is handy if you need to close the drawer from the drawer's content area and want to ensure the drawer's animation is run before close. See the second example below for more details.</p>
+        <h5>children<label>DOM Node/Element or Function</label></h5>
+        <p>Children of the Drawer component can be a component, DOM node/element, or a function.</p>
+        <p>If children is a function, the function is called and the drawer's close method is passed as the functions first argument. The returned value of the function call must be a component or DOM node/element. This is handy if you need to close the drawer from the drawer's content area and want to ensure the drawer's animation is run before close. See the second example below for more details.</p>
 
         <h5>animateLeftDistance<label>Number</label></h5>
         <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
@@ -123,9 +124,11 @@ class DrawerDocs extends React.Component {
         <h5>headerStyle<label>Object or Array</label></h5>
         <p>Styles for the header part of the drawer.</p>
 
-        <h5>headerMenu<label>Function or Component</label></h5>
-        <p>This is a function or component that you can pass into the header for a menu or addtional nav items.</p>
-        <p>(See code in example for how to pass a component as a prop.)</p>
+        <h5>headerMenu<label>Component or Function</label></h5>
+        <p>A component or function that you can use to  add a menu of items to the header of the drawer.</p>
+        <p>If headerMenu is a function, the function is called and the drawer's close function is passed as the first argument. The returned value of the function call must be a component or DOM node/element.</p>
+        <p>See first example for how to pass a component as headerMenu.</p>
+        <p>See second example for how to pass a function as headerMenu.</p>
 
         <h5>maxWidth<label>Number</label></h5>
         <p>Default: 960</p>
@@ -198,10 +201,10 @@ class DrawerDocs extends React.Component {
     <Drawer
       breakPoints={{ large: 1200, medium: 1100 }}
       contentStyle={styles.content}
-      headerMenu={(
+      headerMenu={closeDrawerFunction => (
         <HeaderMenu
           handleButtonClick={this._handleSimpleSelectClick}
-          handleScrimClick={this._handleSimpleSelectClick}
+          handleScrimClick={closeDrawerFunction}
           showSimpleSelectMenu={this.state.showMenu}
         />
       )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.21",
+  "version": "5.1.22",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -33,7 +33,10 @@ class Drawer extends React.Component {
     duration: PropTypes.number,
     easing: PropTypes.array,
     focusOnLoad: PropTypes.bool,
-    headerMenu: PropTypes.element,
+    headerMenu: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func
+    ]),
     headerStyle: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.object

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -222,9 +222,9 @@ class Drawer extends React.Component {
                     </Button>
                   }
                 </span>
-                <span style={styles.title}>
+                <h1 style={styles.title}>
                   {this.props.title}
-                </span>
+                </h1>
                 <div style={styles.headerMenu}>
                   {this.props.headerMenu ? this.props.headerMenu : this.props.navConfig && this._renderNav(styles, theme)}
                 </div>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -310,7 +310,13 @@ class Drawer extends React.Component {
         }
       },
       title: {
+        alignItems: 'center',
+        display: 'flex',
         flex: '1 0 auto',
+        fontSize: theme.FontSizes.MEDIUM,
+        height: '100%',
+        justifyContent: 'center',
+        marginBottom: 0,
         overflow: 'hidden',
         textAlign: 'center',
         textOverflow: 'ellipsis',

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -125,6 +125,10 @@ class Drawer extends React.Component {
     }
   };
 
+  _getExposedDrawerFunctions = () => {
+    return { close: this.close };
+  };
+
   /**
    * Figure out the height of the header. This can come from either:
    *
@@ -205,7 +209,7 @@ class Drawer extends React.Component {
     // If headerMenu is a function then we want to pass the Drawer's
     // close function to the call.
     if (typeof headerMenu === 'function') {
-      menu = headerMenu(this.close);
+      menu = headerMenu(this._getExposedDrawerFunctions());
     // If headerMenu is a normal node/element then use directly.
     } else if (headerMenu) {
       menu = headerMenu;
@@ -248,7 +252,7 @@ class Drawer extends React.Component {
                 </div>
               </header>
               <div style={Object.assign({}, styles.content, this.props.contentStyle)}>
-                {typeof this.props.children === 'function' ? this.props.children(this.close) : this.props.children}
+                {typeof this.props.children === 'function' ? this.props.children(this._getExposedDrawerFunctions()) : this.props.children}
               </div>
             </div>
           </div>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -313,7 +313,7 @@ class Drawer extends React.Component {
         alignItems: 'center',
         display: 'flex',
         flex: '1 0 auto',
-        fontSize: theme.FontSizes.MEDIUM,
+        fontSize: theme.FontSizes.LARGE,
         height: '100%',
         justifyContent: 'center',
         marginBottom: 0,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -174,21 +174,21 @@ class Drawer extends React.Component {
     this._animateComponent({ left: this._getAnimationDistance() }, { duration: 0 });
   };
 
-  _renderNav = (styles, theme) => {
+  _renderNav = (navConfig, styles, theme) => {
     return (
       <nav style={styles.nav}>
         <Button
           icon='caret-left'
-          onClick={this.props.navConfig.onPreviousClick}
+          onClick={navConfig.onPreviousClick}
           theme={theme}
           type='base'
         />
         <span style={styles.navLabel}>
-          {this.props.navConfig.label}
+          {navConfig.label}
         </span>
         <Button
           icon='caret-right'
-          onClick={this.props.navConfig.onNextClick}
+          onClick={navConfig.onNextClick}
           theme={theme}
           type='base'
         />

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -207,7 +207,7 @@ class Drawer extends React.Component {
     let menu = null;
 
     // If headerMenu is a function then we want to pass the Drawer's
-    // close function to the call.
+    // exposed functions to the call.
     if (typeof headerMenu === 'function') {
       menu = headerMenu(this._getExposedDrawerFunctions());
     // If headerMenu is a normal node/element then use directly.

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -199,6 +199,21 @@ class Drawer extends React.Component {
   render () {
     const { theme } = this.state;
     const styles = this.styles(theme);
+    const { headerMenu, navConfig } = this.props;
+    let menu = null;
+
+    // If headerMenu is afunction then we want to pass the Drawer's
+    // close function to the call.
+    if (typeof headerMenu === 'function') {
+      menu = headerMenu(this.close);
+    // If headerMenu is a normal node/element then use directly.
+    } else if (headerMenu) {
+      menu = headerMenu;
+    // If no headerMenu and navConfig passed then use Drawer's
+    // _renderNav function to generate the menu.
+    } else if (navConfig) {
+      menu = this._renderNav(navConfig, styles, theme);
+    }
 
     return (
       <StyleRoot>
@@ -229,7 +244,7 @@ class Drawer extends React.Component {
                   {this.props.title}
                 </h1>
                 <div style={styles.headerMenu}>
-                  {this.props.headerMenu ? this.props.headerMenu : this.props.navConfig && this._renderNav(styles, theme)}
+                  {menu}
                 </div>
               </header>
               <div style={Object.assign({}, styles.content, this.props.contentStyle)}>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -202,7 +202,7 @@ class Drawer extends React.Component {
     const { headerMenu, navConfig } = this.props;
     let menu = null;
 
-    // If headerMenu is afunction then we want to pass the Drawer's
+    // If headerMenu is a function then we want to pass the Drawer's
     // close function to the call.
     if (typeof headerMenu === 'function') {
       menu = headerMenu(this.close);

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -230,7 +230,7 @@ class Drawer extends React.Component {
                 </div>
               </header>
               <div style={Object.assign({}, styles.content, this.props.contentStyle)}>
-                {this.props.children}
+                {typeof this.props.children === 'function' ? this.props.children(this.close) : this.props.children}
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Fixes accessibility issue with title of drawer by wrapping it in an H1 tag and tweaking it styling so to continues to look the way it did before.
- Allows children of Drawer to be a function so that we can pass the children the drawer's close function
- Allows headerMenu prop to be a function so that we can pass the headerMenu the drawer's close function
- Updates the Drawers `_renderNav` function to take the navConfig as an argument rather than accessing the prop directly.

I've added the function as children functionality here because we have gotten into the habit internally of adding `refs` to drawers to get at its `close` function to ensure that the drawer animation fires before unmount.  

This is fragile because the ref can change due to things like wrapping it with redux connect.  I feel that getting at the drawers close method via a function call is a way more stable code path so I've put together this PR. 

### Demo of Drawer with function as children

![drawerdemo](https://user-images.githubusercontent.com/6463914/37367268-87307d92-26c8-11e8-9039-16e515ff02e4.gif)
