### PR TITLE
Add aria label to Drawer's close button

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,6 +7,10 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.24</h3>
+        <ul>
+          <li>Accessibility fix for Drawer component close button(<a href='https://github.com/mxenabled/mx-react-components/pull/714'>#714</a>)</li>
+        </ul>
         <h3>5.1.23</h3>
         <ul>
           <li>Removes Radium from button component, adds glamor as dep(<a href='https://github.com/mxenabled/mx-react-components/pull/713'>#713</a>)</li>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -49,7 +49,7 @@ class DrawerDocs extends React.Component {
           />
         )}
         onClose={this._handleDrawerClose}
-        title='Demo Drawer'
+        title='Demo'
       >
         {({ close }) => {
           return (
@@ -150,7 +150,7 @@ class DrawerDocs extends React.Component {
 
         <h5>title<label>String</label></h5>
         <p>Default: ''</p>
-        <p>This will be displayed in the header of the drawer component.</p>
+        <p>This will be displayed in the header of the drawer component. It is also used to make the aria label for the drawer's close button more descriptive.</p>
 
         <h5>DEPRECATED: navConfig <label>Object</label></h5>
         <p>This object requires 3 properties:</p>
@@ -181,7 +181,7 @@ class DrawerDocs extends React.Component {
         />
       )}
       onClose={this._handleDrawerClose}
-      title='Demo Drawer'
+      title='Demo'
     >
       // Content Here
     </Drawer>
@@ -209,7 +209,7 @@ class DrawerDocs extends React.Component {
         />
       )}
       onClose={this._handleDrawerClose}
-      title='Demo Drawer'
+      title='Demo'
     >
       {({ close }) => {
         return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.22",
+  "version": "5.1.24",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -362,17 +362,6 @@ class Drawer extends React.Component {
           display: 'none',
           padding: 0
         }
-      },
-      visuallyHidden: {
-        border: 0,
-        clip: 'rect(0 0 0 0)',
-        clipPath: 'insert(50%)',
-        height: 1,
-        margin: '-1px',
-        overflow: 'hidden',
-        padding: 0,
-        position: 'absolute',
-        width: 1
       }
     }, this.props.styles);
   };

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -244,9 +244,7 @@ class Drawer extends React.Component {
                       onClick={this.close}
                       theme={theme}
                       type={'base'}
-                    >
-                      <span className='visuallyHidden' style={styles.visuallyHidden}>Close Drawer</span>
-                    </Button>
+                    />
                   }
                 </span>
                 <h1 style={styles.title}>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -240,6 +240,7 @@ class Drawer extends React.Component {
                 <span style={styles.backArrow}>
                   {this.props.showCloseButton &&
                     <Button
+                      aria-label={`Close ${this.props.title} Drawer`}
                       icon='go-back'
                       onClick={this.close}
                       theme={theme}


### PR DESCRIPTION
Before we had visually hidden text in the close button but it wasn't very descriptive.  This PR removes the visually hidden text and replaces it with a more descriptive aria label on the button it self.  I also updated the docs accordingly.

cc @lukeschunk 