### PR TITLE
Close Drawer on press of esc key

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,10 +7,16 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.25</h3>
+        <ul>
+          <li>Adds onKeyUp prop to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/715'>#715</a>)</li>
+        </ul>
+
         <h3>5.1.24</h3>
         <ul>
           <li>Accessibility fix for Drawer component close button(<a href='https://github.com/mxenabled/mx-react-components/pull/714'>#714</a>)</li>
         </ul>
+
         <h3>5.1.23</h3>
         <ul>
           <li>Removes Radium from button component, adds glamor as dep(<a href='https://github.com/mxenabled/mx-react-components/pull/713'>#713</a>)</li>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -137,6 +137,9 @@ class DrawerDocs extends React.Component {
         <h5>onClose<label>Function</label> Required</h5>
         <p>This function will be called when a user clicks the close drawer button.</p>
 
+        <h5>onKeyUp<label>Function</label></h5>
+        <p>An event handler for the key up event of the drawer. If no handler is passed then the drawer will close when the esc key is pressed.</p>
+
         <h5>showCloseButton<label>Boolean</label></h5>
         <p>Default: true</p>
         <p>To remove the close drawer button in the top left corner, set this to <em>false</em>.</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.24",
+  "version": "5.1.25",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -180,11 +180,7 @@ class Drawer extends React.Component {
     e.preventDefault();
     e.stopPropagation();
 
-    if (typeof this.props.onKeyUp === 'function') return this.props.onKeyUp(e);
-
-    if (keycode(e) === 'esc') return this.close();
-
-    return e;
+    if (keycode(e) === 'esc') this.close();
   };
 
   _resize = () => {
@@ -235,7 +231,7 @@ class Drawer extends React.Component {
     return (
       <StyleRoot>
         <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
-          <div onKeyUp={this._handleKeyUp} style={styles.componentWrapper}>
+          <div onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
             <div
               onClick={() => {
                 if (this.props.closeOnScrimClick) this.close();

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -176,6 +176,9 @@ class Drawer extends React.Component {
   };
 
   _handleKeyUp = e => {
+    e.preventDefault();
+    e.stopPropagation();
+
     if (keycode(e) === 'esc') {
       this.close();
     }

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -4,6 +4,7 @@ const _isNumber = require('lodash/isNumber');
 const _merge = require('lodash/merge');
 const _throttle = require('lodash/throttle');
 const FocusTrap = require('focus-trap-react');
+const keycode = require('keycode');
 const PropTypes = require('prop-types');
 const React = require('react');
 const Velocity = require('velocity-animate');
@@ -174,6 +175,12 @@ class Drawer extends React.Component {
     return Velocity(el, transition, options);
   };
 
+  _handleKeyUp = e => {
+    if (keycode(e) === 'esc') {
+      this.close();
+    }
+  };
+
   _resize = () => {
     this._animateComponent({ left: this._getAnimationDistance() }, { duration: 0 });
   };
@@ -222,7 +229,7 @@ class Drawer extends React.Component {
     return (
       <StyleRoot>
         <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
-          <div style={styles.componentWrapper}>
+          <div onKeyUp={this._handleKeyUp} style={styles.componentWrapper}>
             <div
               onClick={() => {
                 if (this.props.closeOnScrimClick) this.close();

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -49,6 +49,7 @@ class Drawer extends React.Component {
       onPreviousClick: PropTypes.func.isRequired
     }),
     onClose: PropTypes.func.isRequired,
+    onKeyUp: PropTypes.func,
     onOpen: PropTypes.func,
     showCloseButton: PropTypes.bool,
     showScrim: PropTypes.bool,
@@ -179,9 +180,11 @@ class Drawer extends React.Component {
     e.preventDefault();
     e.stopPropagation();
 
-    if (keycode(e) === 'esc') {
-      this.close();
-    }
+    if (typeof this.props.onKeyUp === 'function') return this.props.onKeyUp(e);
+
+    if (keycode(e) === 'esc') return this.close();
+
+    return e;
   };
 
   _resize = () => {


### PR DESCRIPTION
I noticed that we had a few places internally where we added key board listeners to close drawers when the `esc` key is pressed.  It's weird to handle it outside the component because you then have to reach into the drawer to call it's close method.  This PR adds the listener to the Drawer's wrapping component div.  See gif for drawer closing on esc.

### gif

![esc-close](https://user-images.githubusercontent.com/6463914/37534653-0cd82122-290b-11e8-9373-61e2ab3c1062.gif)
