### PR TITLE
Drawer focus trap fix

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -9,7 +9,7 @@ class Changelog extends React.Component {
         <h2>MX React Components V 5.0</h2>
         <h3>5.1.26</h3>
         <ul>
-          <li>Adds focusTrapPaused prop to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/716'>#716</a>)</li>
+          <li>Adds focusTrapProps prop to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/716'>#716</a>)</li>
         </ul>
 
         <h3>5.1.25</h3>

--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,6 +7,11 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.26</h3>
+        <ul>
+          <li>Adds focusTrapPaused prop to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/716'>#716</a>)</li>
+        </ul>
+
         <h3>5.1.25</h3>
         <ul>
           <li>Adds onKeyUp prop to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/715'>#715</a>)</li>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -121,6 +121,12 @@ class DrawerDocs extends React.Component {
         <p>Default: true</p>
         <p>Determines if the Drawer component is focused on component mount</p>
 
+        <h5>focusTrapPaused<label>Boolean</label></h5>
+        <p>Default: false</p>
+        <p>The Drawer component uses the <a href='https://github.com/davidtheclark/focus-trap-react'>Focus Trap React</a> library to prevent a user from tabing outside the drawer for accessibility reasons.</p>
+        <p>The focusTrapPaused prop provides a mechanism for pausing the Focus Trap in cases where you have another Drawer or Modal as a child.</p>
+        <p>See the library documentation for details.</p>
+
         <h5>headerStyle<label>Object or Array</label></h5>
         <p>Styles for the header part of the drawer.</p>
 

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -121,11 +121,11 @@ class DrawerDocs extends React.Component {
         <p>Default: true</p>
         <p>Determines if the Drawer component is focused on component mount</p>
 
-        <h5>focusTrapPaused<label>Boolean</label></h5>
-        <p>Default: false</p>
+        <h5>focusTrapProps<label>Object</label></h5>
+        <p>Default: Empty Object</p>
         <p>The Drawer component uses the <a href='https://github.com/davidtheclark/focus-trap-react'>Focus Trap React</a> library to prevent a user from tabing outside the drawer for accessibility reasons.</p>
-        <p>The focusTrapPaused prop provides a mechanism for pausing the Focus Trap in cases where you have another Drawer or Modal as a child.</p>
-        <p>See the library documentation for details.</p>
+        <p>The focusTrapProps object provides a mechanism for passing the focus trap component props.</p>
+        <p>See the library documentation for details on what props it accepts and how to use them.</p>
 
         <h5>headerStyle<label>Object or Array</label></h5>
         <p>Styles for the header part of the drawer.</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.25",
+  "version": "5.1.26",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -34,6 +34,7 @@ class Drawer extends React.Component {
     duration: PropTypes.number,
     easing: PropTypes.array,
     focusOnLoad: PropTypes.bool,
+    focusTrapPaused: PropTypes.bool,
     headerMenu: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func
@@ -64,6 +65,7 @@ class Drawer extends React.Component {
     duration: 500,
     easing: [0.28, 0.14, 0.34, 1.04],
     focusOnLoad: true,
+    focusTrapPaused: false,
     maxWidth: 960,
     onOpen: () => {},
     showCloseButton: true,
@@ -212,7 +214,7 @@ class Drawer extends React.Component {
   render () {
     const { theme } = this.state;
     const styles = this.styles(theme);
-    const { headerMenu, navConfig } = this.props;
+    const { headerMenu, focusTrapPaused, navConfig } = this.props;
     let menu = null;
 
     // If headerMenu is a function then we want to pass the Drawer's
@@ -230,7 +232,7 @@ class Drawer extends React.Component {
 
     return (
       <StyleRoot>
-        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} paused={focusTrapPaused}>
           <div onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
             <div
               onClick={() => {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -34,7 +34,7 @@ class Drawer extends React.Component {
     duration: PropTypes.number,
     easing: PropTypes.array,
     focusOnLoad: PropTypes.bool,
-    focusTrapPaused: PropTypes.bool,
+    focusTrapProps: PropTypes.object,
     headerMenu: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func
@@ -65,7 +65,7 @@ class Drawer extends React.Component {
     duration: 500,
     easing: [0.28, 0.14, 0.34, 1.04],
     focusOnLoad: true,
-    focusTrapPaused: false,
+    focusTrapProps: {},
     maxWidth: 960,
     onOpen: () => {},
     showCloseButton: true,
@@ -214,7 +214,15 @@ class Drawer extends React.Component {
   render () {
     const { theme } = this.state;
     const styles = this.styles(theme);
-    const { headerMenu, focusTrapPaused, navConfig } = this.props;
+    const { headerMenu, focusTrapProps, navConfig } = this.props;
+    const mergedFocusTrapProps = {
+      focusTrapOptions: {
+        clickOutsideDeactivates: true
+      },
+      paused: false,
+      ...focusTrapProps
+    };
+
     let menu = null;
 
     // If headerMenu is a function then we want to pass the Drawer's
@@ -232,7 +240,7 @@ class Drawer extends React.Component {
 
     return (
       <StyleRoot>
-        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} paused={focusTrapPaused}>
+        <FocusTrap {...mergedFocusTrapProps}>
           <div onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
             <div
               onClick={() => {


### PR DESCRIPTION
Adds new prop `focusTrapProps` to be able to pause the focus trap for the drawer if another drawer or modal needs to be mounted/rendered as a child of the drawer.

From the `Focus Trap` library documentation

```
focusTrap.pause()
Pause an active focus trap's event listening without deactivating the trap.

If the focus trap has not been activated, nothing happens.

Returns the focusTrap.

Any onDeactivate callback will not be called, and focus will not return to the element that was focused before the trap's activation. But the trap's behavior will be paused.

This is useful in various cases, one of which is when you want one focus trap within another. demo-six exemplifies how you can implement this.
```

The traps pause function is called when the Focus Trap React component is passed true for it's paused prop. See links below for the details in the Libraries docs.

Focus Trap React Library
https://github.com/davidtheclark/focus-trap-react

Focus Trap Library
https://github.com/davidtheclark/focus-trap