### PR TITLE
Auto doc

### DIFF
--- a/docs/autoDocsLoader.js
+++ b/docs/autoDocsLoader.js
@@ -1,19 +1,43 @@
 module.exports = function(content) {
+  //Tag Aggregation
+  let tagRegex = /(@autoDocsSrc\(?.+\S\)?)\S/g;
+  let tagMatch = [];
+  let tagName = '';
+  let tagList = [];
 
-  let srcRegex = /(@autoDocsSrc\(?.+\S\)?)\S/g;
-  let targetRegex = /(@autoDocsTarget\(?.+\S\)?)\S/g;
-  let targetMatch, targetMatches, srcMatch, srcMatches = [];
-
-  while ((targetMatch = targetRegex.exec(content)) != null) {
-    targetMatches.push(targetMatch[0]);
+  while ((tagMatch = tagRegex.exec(content)) !== null) {
+    let tagParsed = tagMatch[0].split(/\(|\)/);
+    tagName = tagParsed[1];
+    if (tagList.indexOf(tagName) === -1) {
+      tagList.push(tagName);
+    }
   }
 
-  while ((srcMatch = srcRegex.exec(content)) != null) {
-    srcMatches.push(srcMatch[0]);
+  // Create target object with tag names and associated content, remove all src tags in scrubbedContent
+  let targets = {};
+  let scrubbedContent = content;
+
+  if (tagList.length > 0) {
+    for (var i = 0; i < tagList.length; i++) {
+      let scrubbedContArr = scrubbedContent.split('@autoDocsSrc(' + tagList[i] + ')');
+      scrubbedContent = scrubbedContArr.join('');
+      targets[tagList[i]] = scrubbedContArr[1];
+    }
   }
 
-  console.log("!!!!!!!!!!!!!!!!!",targetMatches, srcMatches)
-  return content;
+  //Replace target target tags with associated values stored in the target object
+  for (let target in targets) {
+    let scrubbedContArr = scrubbedContent.split('@autoDocsTarget(' + target + ')');
+    scrubbedContent = scrubbedContArr.join(targets[target])
+  }
+  // console.log(scrubbedContent);
+  return scrubbedContent;
+
+  // ================ TO DO =================
+  // Debugging errors needed:
+  //   multiple src tags with the same name  (multiple target tags ok)
+  //   target tag without src tag or vice versa 
+  //   src tag missing opening or closing sibling
+  //   prevent nesting of tags
 }
-
 

--- a/docs/autoDocsLoader.js
+++ b/docs/autoDocsLoader.js
@@ -1,0 +1,19 @@
+module.exports = function(content) {
+
+  let srcRegex = /(@autoDocsSrc\(?.+\S\)?)\S/g;
+  let targetRegex = /(@autoDocsTarget\(?.+\S\)?)\S/g;
+  let targetMatch, targetMatches, srcMatch, srcMatches = [];
+
+  while ((targetMatch = targetRegex.exec(content)) != null) {
+    targetMatches.push(targetMatch[0]);
+  }
+
+  while ((srcMatch = srcRegex.exec(content)) != null) {
+    srcMatches.push(srcMatch[0]);
+  }
+
+  console.log("!!!!!!!!!!!!!!!!!",targetMatches, srcMatches)
+  return content;
+}
+
+

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -47,7 +47,14 @@ class ButtonDocs extends React.Component {
 
         <h3>Demo</h3>
         <div className='flex'>
+        <Markdown>
+          {`
+          @autoDocsTarget(primaryBtn)
+          `}
+        </Markdown>
+          @autoDocsSrc(primaryBtn)
           <Button>Primary</Button>
+          @autoDocsSrc(primaryBtn)
           <Button style={buttonStyle} type='primaryOutline'>Primary Outline</Button>
           <Button style={buttonStyle} type='secondary'>Secondary</Button>
           <Button style={buttonStyle} type='base'>Base</Button>

--- a/docs/components/ButtonDocs.js
+++ b/docs/components/ButtonDocs.js
@@ -46,20 +46,20 @@ class ButtonDocs extends React.Component {
         </h1>
 
         <h3>Demo</h3>
-        <div className='flex'>
         <Markdown>
           {`
-          @autoDocsTarget(primaryBtn)
+          @autoDocsTarget(buttonGroup)
           `}
         </Markdown>
-          @autoDocsSrc(primaryBtn)
+        <div className='flex'>
+          @autoDocsSrc(buttonGroup)
           <Button>Primary</Button>
-          @autoDocsSrc(primaryBtn)
           <Button style={buttonStyle} type='primaryOutline'>Primary Outline</Button>
           <Button style={buttonStyle} type='secondary'>Secondary</Button>
           <Button style={buttonStyle} type='base'>Base</Button>
           <Button style={buttonStyle} type='neutral'>Neutral</Button>
           <Button style={buttonStyle} type='disabled'>Disabled</Button>
+          @autoDocsSrc(buttonGroup)
         </div>
         <div
           className='flex'

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -26,6 +26,12 @@ module.exports = {
           presets: ['react', 'es2015', 'stage-0'],
           plugins: ['transform-object-assign', 'transform-class-properties']
         }
+      },
+      {
+        test: /ButtonDocs\.js/,
+        include: /components/,
+        exclude: /node_modules/,
+        loader: path.resolve('./autoDocsLoader')
       }
     ],
     noParse: [/autoit.js/]


### PR DESCRIPTION
This was an idea i had in response to issue #582 

This approach uses tags ie:
@autoDocSrc(myAssignedName1) and @autoDocsTarget(myAssignedName1)

to automate the markdown for demos. Multiple tags and combinations of tags allow JSX, supporting methods, props or anything else to be organized and displayed in the markdown. The autoDocsLoader parses everything in webpack. There is still a lot of work that needs to be done, but I wanted to get feedback from the team about this overall approach before I do any more work. 

@jtanner this doesn't have any of the tab formatting in place yet, but I would like the end result to look like your screenshots.