### PR TITLE
Issue 585: Fix Nested FocusTraps

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,6 +7,11 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.27</h3>
+        <ul>
+          <li>Fixes issue with focus trap library in Drawer and Modal components(<a href='https://github.com/mxenabled/mx-react-components/pull/719'>#719</a>)</li>
+        </ul>
+
         <h3>5.1.26</h3>
         <ul>
           <li>Adds focusTrapProps prop to Drawer component(<a href='https://github.com/mxenabled/mx-react-components/pull/716'>#716</a>)</li>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -3,13 +3,14 @@
 const React = require('react');
 const { Link } = require('react-router');
 
-const { Button, Drawer, HeaderMenu } = require('mx-react-components');
+const { Button, Drawer, HeaderMenu, Modal } = require('mx-react-components');
 
 const Markdown = require('components/Markdown');
 
 class DrawerDocs extends React.Component {
   state = {
-    demoDrawerOpen: false
+    demoDrawerOpen: false,
+    demoDrawerOpen2: false
   };
 
   _handleDemoButtonClick = () => {
@@ -21,6 +22,12 @@ class DrawerDocs extends React.Component {
   _handleDrawerClose = () => {
     this.setState({
       demoDrawerOpen: false
+    });
+  };
+
+  _handleDrawerClose2 = () => {
+    this.setState({
+      demoDrawerOpen2: false
     });
   };
 
@@ -58,10 +65,31 @@ class DrawerDocs extends React.Component {
               <p>
               Pellentesque finibus eros magna, ac feugiat mauris pretium posuere. Aliquam nec turpis bibendum, hendrerit eros et, interdum neque. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc pulvinar tempus sollicitudin. Mauris vel suscipit dolor. Vestibulum hendrerit malesuada ipsum. Mauris feugiat dui vel leo consequat tempor. Praesent aliquet posuere consequat. Nunc vel tellus eleifend leo finibus auctor.
               </p>
-              <Button onClick={close}>Close Drawer</Button>
+              <p>
+                <Button onClick={close}>Close Drawer</Button>
+              </p>
+              <p>
+                <Button onClick={() => this.setState({ demoDrawerOpen2: true })}>Open Child Drawer</Button>
+              </p>
+              {this.state.demoDrawerOpen2 && this._renderDrawer2()}
             </div>
           );
         }}
+      </Drawer>
+    );
+  };
+  _renderDrawer2 = () => {
+    return (
+      <Drawer
+        onClose={this._handleDrawerClose2}
+        title='Other Drawer'
+      >
+        <p>
+          <Button onClick={() => this.setState({ showModal: true })}>Show Modal</Button>
+        </p>
+        {this.state.showModal && <Modal onRequestClose={() => this.setState({ showModal: false })}>
+          <div style={{ padding: 20, textAlign: 'center' }}>Hello!</div>
+        </Modal>}
       </Drawer>
     );
   };

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -63,7 +63,7 @@ class DrawerDocs extends React.Component {
             <div>
               {this.state.clickedMenu && <code>You clicked: {this.state.clickedMenu.text}</code>}
               <p>
-              Pellentesque finibus eros magna, ac feugiat mauris pretium posuere. Aliquam nec turpis bibendum, hendrerit eros et, interdum neque. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc pulvinar tempus sollicitudin. Mauris vel suscipit dolor. Vestibulum hendrerit malesuada ipsum. Mauris feugiat dui vel leo consequat tempor. Praesent aliquet posuere consequat. Nunc vel tellus eleifend leo finibus auctor.
+                Drawer Component
               </p>
               <p>
                 <Button onClick={close}>Close Drawer</Button>
@@ -84,11 +84,14 @@ class DrawerDocs extends React.Component {
         onClose={this._handleDrawerClose2}
         title='Other Drawer'
       >
-        <p>
+        <p style={{ padding: 20 }}>
+          Child Drawer Component
+        </p>
+        <p style={{ paddingLeft: 20 }}>
           <Button onClick={() => this.setState({ showModal: true })}>Show Modal</Button>
         </p>
         {this.state.showModal && <Modal onRequestClose={() => this.setState({ showModal: false })}>
-          <div style={{ padding: 20, textAlign: 'center' }}>Hello!</div>
+          <div style={{ padding: 50, textAlign: 'center' }}>Child Modal of Child Drawer Component!</div>
         </Modal>}
       </Drawer>
     );

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -91,7 +91,7 @@ class DrawerDocs extends React.Component {
           <Button onClick={() => this.setState({ showModal: true })}>Show Modal</Button>
         </p>
         {this.state.showModal && <Modal onRequestClose={() => this.setState({ showModal: false })}>
-          <div style={{ padding: 50, textAlign: 'center' }}>Child Modal of Child Drawer Component!</div>
+          <div style={{ padding: 50, textAlign: 'center' }}>Child Modal Component of Child Drawer Component</div>
         </Modal>}
       </Drawer>
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.26",
+  "version": "5.1.27",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -10,7 +10,7 @@ const Velocity = require('velocity-animate');
 const { StyleRoot } = require('radium');
 
 const Button = require('../components/Button');
-const { MXFocusTrap } = require('../components/MXFocusTrap');
+const MXFocusTrap = require('../components/MXFocusTrap');
 
 const { themeShape } = require('../constants/App');
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -3,7 +3,6 @@ const _isEqual = require('lodash/isEqual');
 const _isNumber = require('lodash/isNumber');
 const _merge = require('lodash/merge');
 const _throttle = require('lodash/throttle');
-const FocusTrap = require('focus-trap-react');
 const keycode = require('keycode');
 const PropTypes = require('prop-types');
 const React = require('react');
@@ -11,6 +10,7 @@ const Velocity = require('velocity-animate');
 const { StyleRoot } = require('radium');
 
 const Button = require('../components/Button');
+const MXFocusTrap = require('../components/MXFocusTrap');
 
 const { themeShape } = require('../constants/App');
 
@@ -240,7 +240,7 @@ class Drawer extends React.Component {
 
     return (
       <StyleRoot>
-        <FocusTrap {...mergedFocusTrapProps}>
+        <MXFocusTrap {...mergedFocusTrapProps}>
           <div onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
             <div
               onClick={() => {
@@ -279,7 +279,7 @@ class Drawer extends React.Component {
               </div>
             </div>
           </div>
-        </FocusTrap>
+        </MXFocusTrap>
       </ StyleRoot>
     );
   }

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -10,7 +10,7 @@ const Velocity = require('velocity-animate');
 const { StyleRoot } = require('radium');
 
 const Button = require('../components/Button');
-const MXFocusTrap = require('../components/MXFocusTrap');
+const { MXFocusTrap } = require('../components/MXFocusTrap');
 
 const { themeShape } = require('../constants/App');
 

--- a/src/components/MXFocusTrap.js
+++ b/src/components/MXFocusTrap.js
@@ -38,32 +38,4 @@ class MXFocusTrap extends React.Component {
   }
 }
 
-/**
- * For testing purposes.  This provides an easy way to
- * unmount a child focus trap to ensure the parent is
- * unpaused. This component is only used in MXFocusTrap-test.js
- **/
-class WrappedMXFocusTrap extends React.Component {
-  state = {
-    renderChildTrap: true
-  }
-
-  render () {
-    return (
-      <MXFocusTrap>
-        <button>"Outer Focusable Button"</button>
-        {this.state.renderChildTrap ? (
-          <MXFocusTrap>
-            <button>"Inner Focusable Button"</button>
-          </MXFocusTrap>
-        ) : null}
-      </MXFocusTrap>
-    );
-  }
-}
-
-
-module.exports = {
-  MXFocusTrap,
-  WrappedMXFocusTrap
-};
+module.exports = MXFocusTrap;

--- a/src/components/MXFocusTrap.js
+++ b/src/components/MXFocusTrap.js
@@ -1,0 +1,41 @@
+let traps = [];
+
+const React = require('react');
+const FocusTrap = require('focus-trap-react');
+
+/**
+ * MXFocusTrap
+ *
+ * Why is this needed?
+ *
+ * FocusTrap does not un-pause the previous trap when the current trap is unmounted.
+ * This ensures that the previously trapped component is un-paused.
+ */
+class MXFocusTrap extends React.Component {
+  state = {
+    paused: false
+  }
+
+  componentWillMount () {
+    // FocusTrap does it's own pausing but these React components also need to be paused
+    traps.forEach(component => component.setState({ paused: true }));
+    traps.push(this);
+  }
+
+  componentWillUnmount () {
+    traps = traps.filter(component => component !== this);
+    const lastTrap = traps[traps.length - 1];
+
+    if (lastTrap) lastTrap.setState({ paused: false });
+  }
+
+  render () {
+    return (
+      <FocusTrap {...this.props} paused={this.state.paused}>
+        {this.props.children}
+      </FocusTrap>
+    );
+  }
+}
+
+module.exports = MXFocusTrap;

--- a/src/components/MXFocusTrap.js
+++ b/src/components/MXFocusTrap.js
@@ -38,4 +38,32 @@ class MXFocusTrap extends React.Component {
   }
 }
 
-module.exports = MXFocusTrap;
+/**
+ * For testing purposes.  This provides an easy way to
+ * unmount a child focus trap to ensure the parent is
+ * unpaused. This component is only used in MXFocusTrap-test.js
+ **/
+class WrappedMXFocusTrap extends React.Component {
+  state = {
+    renderChildTrap: true
+  }
+
+  render () {
+    return (
+      <MXFocusTrap>
+        <button>"Outer Focusable Button"</button>
+        {this.state.renderChildTrap ? (
+          <MXFocusTrap>
+            <button>"Inner Focusable Button"</button>
+          </MXFocusTrap>
+        ) : null}
+      </MXFocusTrap>
+    );
+  }
+}
+
+
+module.exports = {
+  MXFocusTrap,
+  WrappedMXFocusTrap
+};

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -3,7 +3,7 @@ const React = require('react');
 
 const Button = require('./Button');
 const Icon = require('./Icon');
-const { MXFocusTrap } = require('../components/MXFocusTrap');
+const MXFocusTrap = require('../components/MXFocusTrap');
 
 const _merge = require('lodash/merge');
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -3,7 +3,7 @@ const React = require('react');
 
 const Button = require('./Button');
 const Icon = require('./Icon');
-const MXFocusTrap = require('../components/MXFocusTrap');
+const { MXFocusTrap } = require('../components/MXFocusTrap');
 
 const _merge = require('lodash/merge');
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,9 +1,9 @@
 const PropTypes = require('prop-types');
 const React = require('react');
-const FocusTrap = require('focus-trap-react');
 
 const Button = require('./Button');
 const Icon = require('./Icon');
+const MXFocusTrap = require('../components/MXFocusTrap');
 
 const _merge = require('lodash/merge');
 
@@ -183,7 +183,7 @@ class Modal extends React.Component {
     const styles = this.styles(theme);
 
     return (
-      <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+      <MXFocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
         <div className='mx-modal' style={Object.assign({}, styles.scrim, this.props.isRelative && styles.relative)}>
           <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)} />
           <div
@@ -221,7 +221,7 @@ class Modal extends React.Component {
             )}
           </div>
         </div>
-      </FocusTrap>
+      </MXFocusTrap>
     );
   }
 

--- a/src/components/__tests__/MXFocusTrap-test.js
+++ b/src/components/__tests__/MXFocusTrap-test.js
@@ -29,11 +29,6 @@ describe('MXFocusTrap', () => {
   it('should pause and un-pause parent trap when child trap mounts and unmounts', () => {
     expect.assertions(2);
 
-    /**
-     * WrappedMXFocusTrap renders a MXFocusTrap within a MXFocusTrap
-     * and provides a way to unmount the child trap by setting
-     * state on the wrapper.
-     **/
     const wrapper = mount(<WrappedMXFocusTrap />);
     const parentTrap = wrapper.find(MXFocusTrap).first().instance();
 

--- a/src/components/__tests__/MXFocusTrap-test.js
+++ b/src/components/__tests__/MXFocusTrap-test.js
@@ -1,7 +1,29 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { mount } from 'enzyme';
 
-const { MXFocusTrap, WrappedMXFocusTrap } = require('../MXFocusTrap');
+const MXFocusTrap = require('../MXFocusTrap');
+
+/**
+ * Simple testing component to make test below easier.
+ **/
+class WrappedMXFocusTrap extends React.Component {
+  state = {
+    renderChildTrap: true
+  }
+
+  render () {
+    return (
+      <MXFocusTrap>
+        <button>"Outer Focusable Button"</button>
+        {this.state.renderChildTrap ? (
+          <MXFocusTrap>
+            <button>"Inner Focusable Button"</button>
+          </MXFocusTrap>
+        ) : null}
+      </MXFocusTrap>
+    );
+  }
+}
 
 describe('MXFocusTrap', () => {
   it('should pause and un-pause parent trap when child trap mounts and unmounts', () => {

--- a/src/components/__tests__/MXFocusTrap-test.js
+++ b/src/components/__tests__/MXFocusTrap-test.js
@@ -19,7 +19,7 @@ describe('MXFocusTrap', () => {
     wrapper.setState({ renderChildTrap: false });
     expect(parentTrap.state.paused).toEqual(false);
 
-    // Parent should be paused when child is unmounted.
+    // Parent should be paused when child is mounted.
     wrapper.setState({ renderChildTrap: true });
     expect(parentTrap.state.paused).toEqual(true);
   });

--- a/src/components/__tests__/MXFocusTrap-test.js
+++ b/src/components/__tests__/MXFocusTrap-test.js
@@ -1,0 +1,26 @@
+import React from 'react'; // eslint-disable-line no-unused-vars
+import { mount } from 'enzyme';
+
+const { MXFocusTrap, WrappedMXFocusTrap } = require('../MXFocusTrap');
+
+describe('MXFocusTrap', () => {
+  it('should pause and un-pause parent trap when child trap mounts and unmounts', () => {
+    expect.assertions(2);
+
+    /**
+     * WrappedMXFocusTrap renders a MXFocusTrap within a MXFocusTrap
+     * and provides a way to unmount the child trap by setting
+     * state on the wrapper.
+     **/
+    const wrapper = mount(<WrappedMXFocusTrap />);
+    const parentTrap = wrapper.find(MXFocusTrap).first().instance();
+
+    // Parent should be un-paused when child is unmounted.
+    wrapper.setState({ renderChildTrap: false });
+    expect(parentTrap.state.paused).toEqual(false);
+
+    // Parent should be paused when child is unmounted.
+    wrapper.setState({ renderChildTrap: true });
+    expect(parentTrap.state.paused).toEqual(true);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/mxenabled/mx-react-components/issues/585

The focus trap library that we use on the `Drawer` and `Modal` components does NOT manage un-pausing a trap when a child trap is un-mounted.  

This MR fixes the issue by wrapping the library in a component and introducing a scoped array of traps outside the component to manage pausing and un-pausing.  

Thanks @jtanner for pairing with me on this one.

We've also added some simple tests and updated the `Drawer` docs for future testing purposes.

Here is a gif of the update docs to show that things are still working as expected.

![focus-trap](https://user-images.githubusercontent.com/6463914/37930296-937e5a6a-30ff-11e8-9d8e-c8e293468474.gif)
