### PR TITLE
RangeSelector: add check for component

### DIFF
--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -84,7 +84,7 @@ class RangeSelector extends React.Component {
 
   _setDefaultRangeValues = () => {
     const component = ReactDOM.findDOMNode(this.rangeSelectorRef);
-    const width = component.offsetWidth;
+    const width = component ? component.offsetWidth : 0;
 
     //convert our values to a 0-based scale
     const lowerPosition = this.state.lowerValue - (this.props.lowerBound);


### PR DESCRIPTION
We are getting honey badgers from the RangeSelector where it is trying to get `component.offsetWidth` when component is undefined. 

This puts in a check for component before calling that with a fallback value of `0`.

