### PR TITLE
Joe/theme provider

### DIFF
--- a/docs/components/ThemeDocs.js
+++ b/docs/components/ThemeDocs.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const { Link } = require('react-router');
 
-const { Button } = require('mx-react-components');
+const { Button, ThemeProvider } = require('mx-react-components');
 
 const Code = require('components/Code');
 const Markdown = require('components/Markdown');
@@ -15,19 +15,39 @@ class ThemeDocs extends React.Component {
           <label>Custom themes for mx-react-components.</label>
         </h1>
 
-        <h3>Basic Usage</h3>
-        <p>The most common theming use case is to modify <Code>Colors.PRIMARY</Code>. For example:</p>
+        <h3>Passing the Theme</h3>
+        <p>There are two options available for theming a component.         The most common theming use case is to modify <Code>Colors.PRIMARY</Code>. For the full list of theme-able constants see <Link to='/components/styles'>Styles</Link>.</p>
+
+        <h4>Option 1: ThemeProvider</h4>
+        <p>Use <Code>&lt;ThemeProvider&gt;</Code> to make the theme available to all components in the application without passing it via props. Render it once at the root of your application and all theme-able components will have access to the theme.
+        </p>
+
         <Markdown lang='js'>
           {`
-    <Button theme={{ Colors: { PRIMARY: '#6C3F6F' } }}>Click me!</Button>
+    <ThemeProvider theme={{ Colors: { PRIMARY: '#F00' } }}>
+      <Button>Click me!</Button>
+    </ThemeProvider>
           `}
         </Markdown>
-        <p><Button theme={{ Colors: { PRIMARY: '#b421c4' } }}>Click me!</Button></p>
+        <p>
+          <ThemeProvider theme={{ Colors: { PRIMARY: '#F00' } }}>
+            <Button>Click me!</Button>
+          </ThemeProvider>
+        </p>
+
+        <h4>Option 2: Props</h4>
+        <Markdown lang='js'>
+          {`
+    <Button theme={{ Colors: { PRIMARY: '#F00' } }}>Click me!</Button>
+          `}
+        </Markdown>
+        <p>
+          <Button theme={{ Colors: { PRIMARY: '#F00' } }}>Click me!</Button>
+        </p>
 
         <h3>Advanced Usage</h3>
         <p>
           For more complex theming please view the source code of the component and look for how the <Code>theme</Code> prop is used.
-          See <Link to='/components/styles'>Styles</Link> for the full list of theme-able constants.
         </p>
         <p>Here's a link to the <Code>Button</Code> component's source to get you started:</p>
         <p><a href='https://github.com/mxenabled/mx-react-components/blob/master/src/components/Button.js'>https://github.com/mxenabled/mx-react-components/blob/master/src/components/Button.js</a></p>

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {
-    "release": "yarn && yarn test && babel src --out-dir dist",
-    "dev-release": "yarn && babel src --watch --out-dir dist",
+    "build": "babel src --out-dir dist --ignore __tests__",
+    "release": "yarn && yarn test && yarn build",
+    "dev-release": "yarn && yarn build",
     "dev": "yarn && yarn upgrade && cd docs && yarn && yarn upgrade && open 'http://localhost:8080' && NODE_ENV=development webpack-dev-server --inline --hot --host 0.0.0.0",
     "docs:release": "yarn && cd docs && yarn && NODE_ENV=production webpack --progress && git add -A && git commit -m \"Docs Version: $(node -p 'require(\"../package.json\").version')\"",
     "test": "jest && eslint src",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src --out-dir dist --ignore __tests__",
     "release": "yarn && yarn test && yarn build",
-    "dev-release": "yarn && yarn build",
+    "dev-release": "yarn && yarn build -- --watch",
     "dev": "yarn && yarn upgrade && cd docs && yarn && yarn upgrade && open 'http://localhost:8080' && NODE_ENV=development webpack-dev-server --inline --hot --host 0.0.0.0",
     "docs:release": "yarn && cd docs && yarn && NODE_ENV=production webpack --progress && git add -A && git commit -m \"Docs Version: $(node -p 'require(\"../package.json\").version')\"",
     "test": "jest && eslint src",

--- a/src/Index.js
+++ b/src/Index.js
@@ -39,6 +39,8 @@ module.exports = {
   Spin: require('./components/Spin'),
   Tabs: require('./components/Tabs'),
   TextArea: require('./components/TextArea'),
+  ThemeContext: require('./components/Theme').ThemeContext,
+  ThemeProvider: require('./components/Theme').ThemeProvider,
   TimeBasedLineChart: require('./components/TimeBasedLineChart'),
   ToggleSwitch: require('./components/ToggleSwitch'),
   Tooltip: require('./components/Tooltip'),

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -5,6 +5,7 @@ const _merge = require('lodash/merge');
 const _omit = require('lodash/omit');
 const _functions = require('lodash/functions');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -474,4 +475,4 @@ class BarChart extends React.Component {
   };
 }
 
-module.exports = BarChart;
+module.exports = withTheme(BarChart);

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,7 +3,7 @@ const PropTypes = require('prop-types');
 
 import { css } from 'glamor';
 
-import { ThemeContext } from './Theme';
+import { withTheme } from './Theme';
 
 const Icon = require('./Icon');
 const Spin = require('./Spin');
@@ -61,42 +61,38 @@ class Button extends React.Component {
   };
 
   render () {
-    return (
-      <ThemeContext>{contextTheme => {
-        // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
-        // Keep elementProps for backwards compatibility.
-        const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme: propTheme, ...rest } = this.props;
-        const theme = StyleUtils.mergeTheme(contextTheme || propTheme, primaryColor);
-        const styles = this.styles(theme);
+    // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
+    // Keep elementProps for backwards compatibility.
+    const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props;
+    const mergedTheme = StyleUtils.mergeTheme(theme, primaryColor);
+    const styles = this.styles(mergedTheme);
 
-        return (
-          <button
-            className={css({ ...styles.component, ...styles[this.props.type], ...style })}
-            disabled={this.props.type === 'disabled'}
-            ref={buttonRef}
-            {...rest}
-            {...elementProps}
-          >
-            <div style={styles.children}>
-              {(icon && !isActive) && (
-                <Icon
-                  size={20}
-                  style={styles.icon}
-                  type={icon}
-                />
-              )}
-              {isActive && (
-                <Spin direction='counterclockwise'>
-                  <Icon size={20} type='spinner' />
-                </Spin>
-              )}
-              <div style={styles.buttonText}>
-                {isActive ? actionText : children}
-              </div>
-            </div>
-          </button>
-        );
-      }}</ThemeContext>
+    return (
+      <button
+        className={css({ ...styles.component, ...styles[this.props.type], ...style })}
+        disabled={this.props.type === 'disabled'}
+        ref={buttonRef}
+        {...rest}
+        {...elementProps}
+      >
+        <div style={styles.children}>
+          {(icon && !isActive) && (
+            <Icon
+              size={20}
+              style={styles.icon}
+              type={icon}
+            />
+          )}
+          {isActive && (
+            <Spin direction='counterclockwise'>
+              <Icon size={20} type='spinner' />
+            </Spin>
+          )}
+          <div style={styles.buttonText}>
+            {isActive ? actionText : children}
+          </div>
+        </div>
+      </button>
     );
   }
 
@@ -255,4 +251,4 @@ class Button extends React.Component {
   };
 }
 
-module.exports = Button;
+module.exports = withTheme(Button);

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,6 +3,8 @@ const PropTypes = require('prop-types');
 
 import { css } from 'glamor';
 
+import { ThemeContext } from './Theme';
+
 const Icon = require('./Icon');
 const Spin = require('./Spin');
 
@@ -59,38 +61,42 @@ class Button extends React.Component {
   };
 
   render () {
-    // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
-    // Keep elementProps for backwards compatibility.
-    const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props;
-    const mergedTheme = StyleUtils.mergeTheme(theme, primaryColor);
-    const styles = this.styles(mergedTheme);
-
     return (
-      <button
-        className={css({ ...styles.component, ...styles[this.props.type], ...style })}
-        disabled={this.props.type === 'disabled'}
-        ref={buttonRef}
-        {...rest}
-        {...elementProps}
-      >
-        <div style={styles.children}>
-          {(icon && !isActive) && (
-            <Icon
-              size={20}
-              style={styles.icon}
-              type={icon}
-            />
-          )}
-          {isActive && (
-            <Spin direction='counterclockwise'>
-              <Icon size={20} type='spinner' />
-            </Spin>
-          )}
-          <div style={styles.buttonText}>
-            {isActive ? actionText : children}
-          </div>
-        </div>
-      </button>
+      <ThemeContext>{contextTheme => {
+        // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
+        // Keep elementProps for backwards compatibility.
+        const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme: propTheme, ...rest } = this.props;
+        const theme = StyleUtils.mergeTheme(contextTheme || propTheme, primaryColor);
+        const styles = this.styles(theme);
+
+        return (
+          <button
+            className={css({ ...styles.component, ...styles[this.props.type], ...style })}
+            disabled={this.props.type === 'disabled'}
+            ref={buttonRef}
+            {...rest}
+            {...elementProps}
+          >
+            <div style={styles.children}>
+              {(icon && !isActive) && (
+                <Icon
+                  size={20}
+                  style={styles.icon}
+                  type={icon}
+                />
+              )}
+              {isActive && (
+                <Spin direction='counterclockwise'>
+                  <Icon size={20} type='spinner' />
+                </Spin>
+              )}
+              <div style={styles.buttonText}>
+                {isActive ? actionText : children}
+              </div>
+            </div>
+          </button>
+        );
+      }}</ThemeContext>
     );
   }
 

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -2,6 +2,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
+import { withTheme } from './Theme';
 const Button = require('./Button');
 
 const { buttonTypes, themeShape } = require('../constants/App');
@@ -106,4 +107,4 @@ class ButtonGroup extends React.Component {
   };
 }
 
-module.exports = Radium(ButtonGroup);
+module.exports = withTheme(Radium(ButtonGroup));

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -4,6 +4,7 @@ const Radium = require('radium');
 const moment = require('moment');
 const keycode = require('keycode');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -366,4 +367,4 @@ class Calendar extends React.Component {
   };
 }
 
-export default Radium(Calendar);
+export default withTheme(Radium(Calendar));

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -3,6 +3,7 @@ const PropTypes = require('prop-types');
 const Radium = require('radium');
 const moment = require('moment');
 
+import { withTheme } from './Theme';
 import Calendar from './Calendar';
 const Icon = require('./Icon');
 
@@ -178,4 +179,4 @@ class DatePicker extends React.Component {
   };
 }
 
-module.exports = Radium(DatePicker);
+module.exports = withTheme(Radium(DatePicker));

--- a/src/components/DatePickerFullScreen.js
+++ b/src/components/DatePickerFullScreen.js
@@ -3,6 +3,7 @@ const PropTypes = require('prop-types');
 const Radium = require('radium');
 const moment = require('moment');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -525,4 +526,4 @@ class DatePickerFullScreen extends React.Component {
   }
 }
 
-module.exports = Radium(DatePickerFullScreen);
+module.exports = withTheme(Radium(DatePickerFullScreen));

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -3,6 +3,7 @@ const PropTypes = require('prop-types');
 const Radium = require('radium');
 const keycode = require('keycode');
 
+import { withTheme } from './Theme';
 const moment = require('moment');
 const _merge = require('lodash/merge');
 
@@ -670,4 +671,4 @@ class DateRangePicker extends React.Component {
   };
 }
 
-module.exports = Radium(DateRangePicker);
+module.exports = withTheme(Radium(DateRangePicker));

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -3,6 +3,7 @@ const moment = require('moment');
 const keycode = require('keycode');
 const PropTypes = require('prop-types');
 
+import { withTheme } from '../Theme';
 const DefaultRanges = require('../DateRangePicker/DefaultRanges');
 
 const { SelectedBox } = require('../../constants/DateRangePicker');
@@ -159,4 +160,4 @@ class SelectionPane extends React.Component {
   };
 }
 
-module.exports = SelectionPane;
+module.exports = withTheme(SelectionPane);

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -2,6 +2,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const moment = require('moment-timezone/builds/moment-timezone-with-data.min');
 
+import { withTheme } from './Theme';
 import Calendar from './Calendar';
 const Column = require('./grid/Column');
 const Container = require('./grid/Container');
@@ -343,4 +344,4 @@ class DatePicker extends React.Component {
   };
 }
 
-module.exports = DatePicker;
+module.exports = withTheme(DatePicker);

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -4,6 +4,7 @@ const Radium = require('radium');
 const _uniqueId = require('lodash/uniqueId');
 const _merge = require('lodash/merge');
 
+import { withTheme } from './Theme';
 const Column = require('../components/grid/Column');
 const Container = require('../components/grid/Container');
 const Row = require('../components/grid/Row');
@@ -235,4 +236,4 @@ class DisplayInput extends React.Component {
   };
 }
 
-module.exports = Radium(DisplayInput);
+module.exports = withTheme(Radium(DisplayInput));

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -4,6 +4,7 @@ const PropTypes = require('prop-types');
 const Radium = require('radium');
 const d3 = require('d3');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -399,4 +400,4 @@ class DonutChart extends React.Component {
   };
 }
 
-module.exports = Radium(DonutChart);
+module.exports = withTheme(Radium(DonutChart));

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -9,6 +9,7 @@ const React = require('react');
 const Velocity = require('velocity-animate');
 const { StyleRoot } = require('radium');
 
+import { withTheme } from './Theme';
 const Button = require('../components/Button');
 const MXFocusTrap = require('../components/MXFocusTrap');
 
@@ -386,4 +387,4 @@ class Drawer extends React.Component {
   };
 }
 
-module.exports = Drawer;
+module.exports = withTheme(Drawer);

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -2,6 +2,7 @@ const numeral = require('numeral');
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -388,4 +389,4 @@ class FileUpload extends React.Component {
   };
 }
 
-module.exports = FileUpload;
+module.exports = withTheme(FileUpload);

--- a/src/components/Gauge.js
+++ b/src/components/Gauge.js
@@ -3,6 +3,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const d3 = require('d3');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -263,4 +264,4 @@ class Gauge extends React.Component {
   };
 }
 
-module.exports = Gauge;
+module.exports = withTheme(Gauge);

--- a/src/components/HeaderMenu.js
+++ b/src/components/HeaderMenu.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const Button = require('./Button');
 const SimpleSelect = require('./SimpleSelect');
 
@@ -60,4 +61,4 @@ class HeaderMenu extends React.Component {
   }
 }
 
-module.exports = HeaderMenu;
+module.exports = withTheme(HeaderMenu);

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const Spin = require('./Spin');
 
 const { themeShape } = require('../constants/App');
@@ -97,4 +98,4 @@ class Loader extends React.Component {
 }
 
 
-module.exports = Loader;
+module.exports = withTheme(Loader);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const Icon = require('../components/Icon');
 
 const { themeShape } = require('../constants/App');
@@ -156,4 +157,4 @@ class Menu extends React.Component {
   };
 }
 
-module.exports = Menu;
+module.exports = withTheme(Menu);

--- a/src/components/MessageBox.js
+++ b/src/components/MessageBox.js
@@ -2,6 +2,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const _merge = require('lodash/merge');
 
+import { withTheme } from './Theme';
 const Icon = require('../components/Icon');
 
 const { themeShape } = require('../constants/App');
@@ -98,4 +99,4 @@ class MessageBox extends React.Component {
   };
 }
 
-module.exports = MessageBox;
+module.exports = withTheme(MessageBox);

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const Button = require('./Button');
 const Icon = require('./Icon');
 const MXFocusTrap = require('../components/MXFocusTrap');
@@ -337,4 +338,4 @@ class Modal extends React.Component {
   };
 }
 
-module.exports = Modal;
+module.exports = withTheme(Modal);

--- a/src/components/PageIndicator.js
+++ b/src/components/PageIndicator.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -67,4 +68,4 @@ class PageIndicator extends React.Component {
   };
 }
 
-module.exports = PageIndicator;
+module.exports = withTheme(PageIndicator);

--- a/src/components/PaginationButtons.js
+++ b/src/components/PaginationButtons.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const ButtonGroup = require('./ButtonGroup');
 
 const { themeShape } = require('../constants/App');
@@ -191,4 +192,4 @@ class PaginationButtons extends React.Component {
   };
 }
 
-module.exports = PaginationButtons;
+module.exports = withTheme(PaginationButtons);

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -2,6 +2,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const _merge = require('lodash/merge');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -51,4 +52,4 @@ class ProgressBar extends React.Component {
   };
 }
 
-module.exports = ProgressBar;
+module.exports = withTheme(ProgressBar);

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -68,4 +69,4 @@ class RadioButton extends React.Component {
   };
 }
 
-module.exports = RadioButton;
+module.exports = withTheme(RadioButton);

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -4,6 +4,7 @@ const PropTypes = require('prop-types');
 const Radium = require('radium');
 const _throttle = require('lodash/throttle');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -429,4 +430,4 @@ class RangeSelector extends React.Component {
   };
 }
 
-module.exports = Radium(RangeSelector);
+module.exports = withTheme(Radium(RangeSelector));

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const Input = require('./SimpleInput');
 
 const { themeShape } = require('../constants/App');
@@ -64,4 +65,4 @@ class SearchInput extends React.Component {
   };
 }
 
-module.exports = SearchInput;
+module.exports = withTheme(SearchInput);

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -5,6 +5,7 @@ const Radium = require('radium');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 const { Listbox, Option } = require('./accessibility/Listbox');
 
@@ -317,4 +318,4 @@ class Select extends React.Component {
 }
 
 
-module.exports = Radium(Select);
+module.exports = withTheme(Radium(Select));

--- a/src/components/SelectFullScreen.js
+++ b/src/components/SelectFullScreen.js
@@ -2,6 +2,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -212,4 +213,4 @@ class SelectFullScreen extends React.Component {
   }
 }
 
-module.exports = Radium(SelectFullScreen);
+module.exports = withTheme(Radium(SelectFullScreen));

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -101,6 +101,7 @@ class Input extends React.Component {
 
     return (
       <div
+        className='mx-simple-input'
         style={this.state.focus ? { ...styles.wrapper, ...styles.activeWrapper } : styles.wrapper}
       >
         {this.props.icon ? (

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -2,6 +2,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const _merge = require('lodash/merge');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -174,4 +175,4 @@ class Input extends React.Component {
   };
 }
 
-module.exports = Input;
+module.exports = withTheme(Input);

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -4,6 +4,7 @@ const Radium = require('radium');
 const keycode = require('keycode');
 const _merge = require('lodash/merge');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 const { Listbox, Option } = require('./accessibility/Listbox');
 
@@ -171,4 +172,4 @@ class SimpleSelect extends React.Component {
   };
 }
 
-module.exports = Radium(SimpleSelect);
+module.exports = withTheme(Radium(SimpleSelect));

--- a/src/components/SimpleSlider.js
+++ b/src/components/SimpleSlider.js
@@ -5,6 +5,7 @@ const Radium = require('radium');
 const _merge = require('lodash/merge');
 const browser = require('bowser');
 
+import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
@@ -174,4 +175,4 @@ class SimpleSlider extends React.Component {
   };
 }
 
-module.exports = Radium(SimpleSlider);
+module.exports = withTheme(Radium(SimpleSlider));

--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -1,7 +1,8 @@
 const PropTypes = require('prop-types');
 const React = require('react');
-
 const _merge = require('lodash/merge');
+
+import { withTheme } from './Theme';
 
 const { themeShape } = require('../constants/App');
 
@@ -105,4 +106,4 @@ class TextArea extends React.Component {
   };
 }
 
-module.exports = TextArea;
+module.exports = withTheme(TextArea);

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -9,10 +9,10 @@ const { themeShape } = require('../constants/App');
  */
 export class ThemeProvider extends React.Component {
   static propTypes = { theme: themeShape }
-  static childContextTypes = { theme: themeShape }
+  static childContextTypes = { mxTheme: themeShape }
 
   getChildContext () {
-    return { theme: this.props.theme };
+    return { mxTheme: this.props.theme };
   }
 
   render () {
@@ -26,10 +26,10 @@ export class ThemeProvider extends React.Component {
  */
 export class ThemeContext extends React.Component {
   static contextTypes = {
-    theme: themeShape
+    mxTheme: themeShape
   }
 
   render () {
-    return this.props.children(this.context.theme);
+    return this.props.children(this.context.mxTheme);
   }
 }

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+const ThemeContext = React.createContext('mxTheme');
 const { themeShape } = require('../constants/App');
 
 /**
@@ -9,27 +10,35 @@ const { themeShape } = require('../constants/App');
  */
 export class ThemeProvider extends React.Component {
   static propTypes = { theme: themeShape }
-  static childContextTypes = { mxTheme: themeShape }
-
-  getChildContext () {
-    return { mxTheme: this.props.theme };
-  }
 
   render () {
-    return this.props.children;
+    return (
+      <ThemeContext.Provider value={this.props.theme}>
+        {this.props.children}
+      </ThemeContext.Provider>
+    );
   }
 }
 
 /**
- * ThemeContext is for use inside components that need access
- * to the theme.
+ * `withTheme` injects the `theme` from `ThemeProvider` as a prop into `Component`.
+ *
+ * `theme` can still be provided as a prop to the themed component to override the theme.
  */
-export class ThemeContext extends React.Component {
-  static contextTypes = {
-    mxTheme: themeShape
+export function withTheme (Component) {
+  // "ref" is provided by React.forwardRef
+  function ThemedComponent (props, ref) {
+    return (
+      <ThemeContext.Consumer>
+        {theme => (
+          <Component {...props} ref={ref} theme={props.theme || theme} />
+        )}
+      </ThemeContext.Consumer>
+    );
   }
+  ThemedComponent.propTypes = { theme: themeShape };
+  ThemedComponent.displayName = `withTheme(${Component.displayName || Component.name})`;
 
-  render () {
-    return this.props.children(this.context.mxTheme);
-  }
+  // pass "ref" to ThemedComponent
+  return React.forwardRef(ThemedComponent);
 }

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-const ThemeContext = React.createContext('mxTheme');
 const { themeShape } = require('../constants/App');
 
 /**
@@ -10,35 +9,48 @@ const { themeShape } = require('../constants/App');
  */
 export class ThemeProvider extends React.Component {
   static propTypes = { theme: themeShape }
+  static childContextTypes = { mxTheme: themeShape }
+
+  getChildContext () {
+    return { mxTheme: this.props.theme };
+  }
 
   render () {
-    return (
-      <ThemeContext.Provider value={this.props.theme}>
-        {this.props.children}
-      </ThemeContext.Provider>
-    );
+    return this.props.children;
   }
 }
 
 /**
- * `withTheme` injects the `theme` from `ThemeProvider` as a prop into `Component`.
- *
- * `theme` can still be provided as a prop to the themed component to override the theme.
+ * ThemeContext is for use inside components that need access
+ * to the theme.
  */
+class ThemeContext extends React.Component {
+  static contextTypes = {
+    mxTheme: themeShape
+  }
+
+  render () {
+    return this.props.children(this.context.mxTheme);
+  }
+}
+
+ /**
+  * `withTheme` injects the `theme` from `ThemeProvider` as a prop into `Component`.
+  *
+  * `theme` can still be provided as a prop to the themed component to override the theme.
+  */
 export function withTheme (Component) {
-  // "ref" is provided by React.forwardRef
-  function ThemedComponent (props, ref) {
+  function ThemedComponent (props) {
     return (
-      <ThemeContext.Consumer>
+      <ThemeContext>
         {theme => (
-          <Component {...props} ref={ref} theme={props.theme || theme} />
+          <Component {...props} theme={props.theme || theme} />
         )}
-      </ThemeContext.Consumer>
+      </ThemeContext>
     );
   }
   ThemedComponent.propTypes = { theme: themeShape };
   ThemedComponent.displayName = `withTheme(${Component.displayName || Component.name})`;
 
-  // pass "ref" to ThemedComponent
-  return React.forwardRef(ThemedComponent);
+  return ThemedComponent;
 }

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const { themeShape } = require('../constants/App');
+
+/**
+ * Use ThemeProvider at the top-level of the application to
+ * make theme available to all theme-able components without
+ * the need to explicitly pass the theme prop.
+ */
+export class ThemeProvider extends React.Component {
+  static propTypes = { theme: themeShape }
+  static childContextTypes = { theme: themeShape }
+
+  getChildContext () {
+    return { theme: this.props.theme };
+  }
+
+  render () {
+    return this.props.children;
+  }
+}
+
+/**
+ * ThemeContext is for use inside components that need access
+ * to the theme.
+ */
+export class ThemeContext extends React.Component {
+  static contextTypes = {
+    theme: themeShape
+  }
+
+  render () {
+    return this.props.children(this.context.theme);
+  }
+}

--- a/src/components/TimeBasedLineChart.js
+++ b/src/components/TimeBasedLineChart.js
@@ -1,11 +1,12 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
-
 const d3 = require('d3');
 const moment = require('moment');
 const numeral = require('numeral');
 const _isEqual = require('lodash/isEqual');
+
+import { withTheme } from './Theme';
 
 const BreakPointGroup = require('./d3/BreakPointGroup');
 const GridLinesGroup = require('./d3/GridLinesGroup');
@@ -674,4 +675,4 @@ class TimeBasedLineChart extends React.Component {
   }
 }
 
-module.exports = Radium(TimeBasedLineChart);
+module.exports = withTheme(Radium(TimeBasedLineChart));

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -2,6 +2,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -133,4 +134,4 @@ class ToggleSwitch extends React.Component {
   };
 }
 
-module.exports = Radium(ToggleSwitch);
+module.exports = withTheme(Radium(ToggleSwitch));

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -130,4 +131,4 @@ class Tooltip extends React.Component {
   };
 }
 
-module.exports = Tooltip;
+module.exports = withTheme(Tooltip);

--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -3,6 +3,7 @@ const ReactDOM = require('react-dom');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
 
+import { withTheme } from './Theme';
 const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
@@ -434,4 +435,4 @@ class TypeAhead extends React.Component {
   };
 }
 
-module.exports = Radium(TypeAhead);
+module.exports = withTheme(Radium(TypeAhead));

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -1,5 +1,5 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
-import { shallow } from 'enzyme';
+import React from 'react';
+import { mount } from 'enzyme';
 
 import Button from '../Button';
 import Icon from '../Icon';
@@ -7,35 +7,35 @@ import Icon from '../Icon';
 describe('Button', () => {
   it('fires the onClick handler when clicked', () => {
     const onClick = jest.fn();
-    const button = shallow(<Button onClick={onClick} />);
+    const button = mount(<Button onClick={onClick} />);
 
     button.simulate('click');
     expect(onClick).toBeCalled();
   });
 
   it('can show an Icon', () => {
-    const withIcon = shallow(<Button icon='add' />);
-    const withoutIcon = shallow(<Button />);
+    const withIcon = mount(<Button icon='add' />);
+    const withoutIcon = mount(<Button />);
 
     expect(withIcon.find(Icon)).toBePresent();
     expect(withoutIcon.find(Icon)).toBeEmpty();
   });
 
   it('can support real button attributes', () => {
-    const button = shallow(<Button aria-pressed='false' />);
+    const button = mount(<Button aria-pressed='false' />);
 
     expect(button.html()).toContain('aria-pressed');
   });
 
   describe('non element props', () => {
     it('should not pass down non element props being used elsewhere', () => {
-      const button = shallow(<Button icon='foo' />);
+      const button = mount(<Button icon='foo' />);
 
       expect(button.html()).not.toContain('foo');
     });
 
     it('should not pass down non element props being used elsewhere', () => {
-      const button = shallow(<Button actionText='foo' />);
+      const button = mount(<Button actionText='foo' />);
 
       expect(button.html()).not.toContain('foo');
     });

--- a/src/components/__tests__/Calendar-test.js
+++ b/src/components/__tests__/Calendar-test.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import moment from 'moment';
 
 import { getNewDateStateChange } from '../Calendar';
@@ -19,7 +19,7 @@ describe('Calendar', () => {
 
     const mockCallback = jest.fn();
 
-    wrapper = shallow(
+    wrapper = mount(
       <Calendar
         onDateSelect={mockCallback}
         selectedDate={moment().unix()}

--- a/src/components/__tests__/SimpleInput-test.js
+++ b/src/components/__tests__/SimpleInput-test.js
@@ -1,38 +1,42 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 const Icon = require('../Icon');
 const SimpleInput = require('../SimpleInput');
 
 describe('SimpleInput', () => {
   it('should render a input', () => {
-    const wrapper = shallow(<SimpleInput />);
+    const wrapper = mount(<SimpleInput />);
 
     expect(wrapper.find('input')).toHaveLength(1);
   });
 
   it('should render a prefix to the left of the input if prop provided', () => {
-    const wrapper = shallow(<SimpleInput prefix={(<span>Prefix</span>)} />);
+    const wrapper = mount(<SimpleInput prefix={(<span>Prefix</span>)} />);
+    const children = wrapper.find('div').first().children();
 
-    expect(wrapper.children().first().html()).toEqual('<span>Prefix</span>');
+    expect(children.first().html()).toEqual('<span>Prefix</span>');
   });
 
   it('should render a suffix to the right of the input if prop provided', () => {
-    const wrapper = shallow(<SimpleInput suffix={(<span>Suffix</span>)} />);
+    const wrapper = mount(<SimpleInput suffix={(<span>Suffix</span>)} />);
+    const children = wrapper.find('div').first().children();
 
-    expect(wrapper.children().last().html()).toEqual('<span>Suffix</span>');
+    expect(children.last().html()).toEqual('<span>Suffix</span>');
   });
 
   it('should render a icon to the left of the input if icon prop provided', () => {
-    const wrapper = shallow(<SimpleInput icon='cash' />);
+    const wrapper = mount(<SimpleInput icon='cash' />);
+    const children = wrapper.find('div').first().children();
 
-    expect(wrapper.children().first().type()).toEqual(Icon);
+    expect(children.first().type()).toEqual(Icon);
   });
 
   it('should render a icon to the right of the input if rightIcon prop provided', () => {
-    const wrapper = shallow(<SimpleInput rightIcon='cash' />);
+    const wrapper = mount(<SimpleInput rightIcon='cash' />);
+    const children = wrapper.find('div').first().children();
 
-    expect(wrapper.children().last().type()).toEqual(Icon);
+    expect(children.last().type()).toEqual(Icon);
   });
 
   it('should provide a ref to the input via the elementRef prop', () => {
@@ -40,6 +44,6 @@ describe('SimpleInput', () => {
 
     const wrapper = mount(<SimpleInput elementRef={ref => inputRef = ref} />);
 
-    expect(inputRef).toEqual(wrapper.instance().elementRef);
+    expect(inputRef).toEqual(wrapper.find('input').instance());
   });
 });

--- a/src/components/__tests__/SimpleInput-test.js
+++ b/src/components/__tests__/SimpleInput-test.js
@@ -13,28 +13,30 @@ describe('SimpleInput', () => {
 
   it('should render a prefix to the left of the input if prop provided', () => {
     const wrapper = mount(<SimpleInput prefix={(<span>Prefix</span>)} />);
-    const children = wrapper.find('div').first().children();
+    const children = wrapper.find('.mx-simple-input').first().children();
 
     expect(children.first().html()).toEqual('<span>Prefix</span>');
   });
 
   it('should render a suffix to the right of the input if prop provided', () => {
     const wrapper = mount(<SimpleInput suffix={(<span>Suffix</span>)} />);
-    const children = wrapper.find('div').first().children();
+    const children = wrapper.find('.mx-simple-input').first().children();
 
     expect(children.last().html()).toEqual('<span>Suffix</span>');
   });
 
   it('should render a icon to the left of the input if icon prop provided', () => {
+    // NOTE: this will log a warning in the console
     const wrapper = mount(<SimpleInput icon='cash' />);
-    const children = wrapper.find('div').first().children();
+    const children = wrapper.find('.mx-simple-input').first().children();
 
     expect(children.first().type()).toEqual(Icon);
   });
 
   it('should render a icon to the right of the input if rightIcon prop provided', () => {
+    // NOTE: this will log a warning in the console
     const wrapper = mount(<SimpleInput rightIcon='cash' />);
-    const children = wrapper.find('div').first().children();
+    const children = wrapper.find('.mx-simple-input').first().children();
 
     expect(children.last().type()).toEqual(Icon);
   });

--- a/src/components/__tests__/Theme-test.js
+++ b/src/components/__tests__/Theme-test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { ThemeContext, ThemeProvider } from '../Theme';
+
+const ThemedComponent = () => (
+  <ThemeContext>
+    {theme => (
+      <div style={{ color: theme ? theme.Colors.PRIMARY : DEFAULT_COLOR }}>
+        Hello Theme!
+      </div>
+    )}
+  </ThemeContext>
+);
+
+const DEFAULT_COLOR = '#F00';
+const THEME = {
+  Colors: {
+    PRIMARY: '#C0FFEE'
+  }
+};
+
+describe('Theme', () => {
+  it('makes the theme available when set on the ThemeProvider', () => {
+    const wrapper = mount(
+      <ThemeProvider theme={THEME}>
+        <ThemedComponent />
+      </ThemeProvider>
+    );
+    const div = wrapper.find(ThemedComponent).find('div').first();
+
+    expect(div.prop('style')).toEqual({ color: THEME.Colors.PRIMARY });
+  });
+
+  it('does not pass a theme when ThemeProvider is not used', () => {
+    const wrapper = mount(<ThemedComponent />);
+    const div = wrapper.find(ThemedComponent).find('div').first();
+
+    expect(div.prop('style')).toEqual({ color: DEFAULT_COLOR });
+  });
+});

--- a/src/components/__tests__/Theme-test.js
+++ b/src/components/__tests__/Theme-test.js
@@ -1,17 +1,13 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { ThemeContext, ThemeProvider } from '../Theme';
+import { ThemeProvider, withTheme } from '../Theme';
 
-const ThemedComponent = () => (
-  <ThemeContext>
-    {theme => (
-      <div style={{ color: theme ? theme.Colors.PRIMARY : DEFAULT_COLOR }}>
-        Hello Theme!
-      </div>
-    )}
-  </ThemeContext>
-);
+const ThemedComponent = withTheme(({ theme }) => (
+  <div style={{ color: theme ? theme.Colors.PRIMARY : DEFAULT_COLOR }}>
+    Hello Theme!
+  </div>
+));
 
 const DEFAULT_COLOR = '#F00';
 const THEME = {

--- a/src/components/d3/BarTimeXAxis.js
+++ b/src/components/d3/BarTimeXAxis.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const d3 = require('d3');
 const moment = require('moment');
 const _merge = require('lodash/merge');
@@ -91,4 +92,4 @@ class BarTimeXAxis extends React.Component {
   };
 }
 
-module.exports = BarTimeXAxis;
+module.exports = withTheme(BarTimeXAxis);

--- a/src/components/d3/CirclesGroup.js
+++ b/src/components/d3/CirclesGroup.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const { themeShape } = require('../../constants/App');
 
 const StyleUtils = require('../../utils/Style');
@@ -103,4 +104,4 @@ class CirclesGroup extends React.Component {
   }
 }
 
-module.exports = CirclesGroup;
+module.exports = withTheme(CirclesGroup);

--- a/src/components/d3/LineGroup.js
+++ b/src/components/d3/LineGroup.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const d3 = require('d3');
 
 const { themeShape } = require('../../constants/App');
@@ -85,4 +86,4 @@ class LineGroup extends React.Component {
   }
 }
 
-module.exports = LineGroup;
+module.exports = withTheme(LineGroup);

--- a/src/components/d3/ShadedAreaRectangleGroup.js
+++ b/src/components/d3/ShadedAreaRectangleGroup.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const { themeShape } = require('../../constants/App');
 
 const StyleUtils = require('../../utils/Style');
@@ -42,4 +43,4 @@ class ShadedAreaRectangleGroup extends React.Component {
   }
 }
 
-module.exports = ShadedAreaRectangleGroup;
+module.exports = withTheme(ShadedAreaRectangleGroup);

--- a/src/components/d3/ShadedHatchPatternRectangleGroup.js
+++ b/src/components/d3/ShadedHatchPatternRectangleGroup.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const { themeShape } = require('../../constants/App');
 
 const StyleUtils = require('../../utils/Style');
@@ -51,4 +52,4 @@ class ShadedHatchPatternRectangleGroup extends React.Component {
   }
 }
 
-module.exports = ShadedHatchPatternRectangleGroup;
+module.exports = withTheme(ShadedHatchPatternRectangleGroup);

--- a/src/components/tabs/PillTabs.js
+++ b/src/components/tabs/PillTabs.js
@@ -72,4 +72,4 @@ const PillTabs = ({
 
 PillTabs.propTypes = Tabbable.propTypes;
 
-module.exports = StyleUtils.withMergedTheme(Tabbable(PillTabs));
+module.exports = Tabbable(PillTabs);

--- a/src/components/tabs/StandardTabs.js
+++ b/src/components/tabs/StandardTabs.js
@@ -3,8 +3,6 @@ const React = require('react');
 const Tab = require('./Tab');
 const Tabbable = require('./Tabbable');
 
-const { withMergedTheme } = require('../../utils/Style');
-
 const StandardTabs = ({
   activeTabStyles,
   onTabSelect,
@@ -30,4 +28,4 @@ const StandardTabs = ({
 
 StandardTabs.propTypes = Tabbable.propTypes;
 
-module.exports = withMergedTheme(Tabbable(StandardTabs));
+module.exports = Tabbable(StandardTabs);

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -2,6 +2,7 @@ const PropTypes = require('prop-types');
 const Radium = require('radium');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const { themeShape } = require('../../constants/App');
 
 const StyleUtils = require('../../utils/Style');
@@ -65,4 +66,4 @@ class Tab extends React.Component {
   }
 }
 
-module.exports = Radium(Tab);
+module.exports = withTheme(Radium(Tab));

--- a/src/components/tabs/Tabbable.js
+++ b/src/components/tabs/Tabbable.js
@@ -1,6 +1,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+import { withTheme } from '../Theme';
 const { themeShape } = require('../../constants/App');
 
 const StyleUtils = require('../../utils/Style');
@@ -79,4 +80,4 @@ Tabbable.propTypes = {
   theme: themeShape
 };
 
-module.exports = Tabbable;
+module.exports = withTheme(Tabbable);

--- a/src/components/tabs/Tabbable.js
+++ b/src/components/tabs/Tabbable.js
@@ -66,7 +66,7 @@ const Tabbable = (TabsComponent) => {
     }
   };
 
-  return TabbableComponent;
+  return withTheme(TabbableComponent);
 };
 
 Tabbable.propTypes = {
@@ -80,4 +80,4 @@ Tabbable.propTypes = {
   theme: themeShape
 };
 
-module.exports = withTheme(Tabbable);
+module.exports = Tabbable;


### PR DESCRIPTION
Issue: #717

This is the first iteration of adding `<ThemeProvider>` to make theming easier. `<ThemeProvider>` should be instantiated at the root of an application, similar to Redux's `<Provider>`.

To use the theme provided by `<ThemeProvider>` each theme-able component must use `<ThemeContext>` in its `render()` function. I added `<ThemeContext>` only to `<Button>` for now, once I get a 👍 for the approach then I will work on updating the other components.

What do you all think of how the changes in `<Button>` turned out?

UPDATE:
I followed the "Render Props" idea suggested [[here]](https://css-tricks.com/putting-things-in-context-with-react/#article-header-id-5) for the `<ThemeContext>` API. I chose to use `children` as a function instead of a `render` prop because it more closely matches the new React context API. That way, once React 16.3 is released only `<ThemeProvider>` and `<ThemeContext>` need minor updates and the other components will require no changes.

----

Here's what the updated docs looks like:

<img width="560" alt="screen shot 2018-03-27 at 4 15 31 pm" src="https://user-images.githubusercontent.com/4348/37999228-22cd383c-31df-11e8-8ef9-7cee49c7e31e.png">
