### PR TITLE
Prevent requestAnimationFrame console error in tests

### DIFF
--- a/jest-shim.js
+++ b/jest-shim.js
@@ -1,0 +1,10 @@
+/**
+ * React 16 depends on requestAnimationFrame even in test environments
+ * https://reactjs.org/docs/javascript-environment-requirements.html
+ */
+global.requestAnimationFrame = function (callback) {
+  setTimeout(callback, 0);
+};
+global.cancelAnimationFrame = function (callback) {
+  setTimeout(callback, 0);
+};

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "jest": {
     "setupFiles": [
+      "<rootDir>/jest-shim.js",
       "<rootDir>/jest-setup.js"
     ],
     "setupTestFrameworkScriptFile": "<rootDir>/node_modules/jest-enzyme/lib/index.js"


### PR DESCRIPTION
This cleans up console errors for `requestAnimationFrame` when running tests.