### PR TITLE
DateRangePicker - fix state issues

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -7,6 +7,11 @@ class Changelog extends React.Component {
         <h1>Change Log</h1>
 
         <h2>MX React Components V 5.0</h2>
+        <h3>5.1.33</h3>
+        <ul>
+          <li>Fix state issues in DateRangePicker component(<a href='https://github.com/mxenabled/mx-react-components/pull/728'>#728</a>)</li>
+        </ul>
+
         <h3>5.1.32</h3>
         <ul>
           <li>Theme cancel and apply buttons in DateRangePicker componente(<a href='https://github.com/mxenabled/mx-react-components/pull/727'>#727</a>)</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "5.1.32",
+  "version": "5.1.33",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "scripts": {

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -159,9 +159,11 @@ class DateRangePicker extends React.Component {
       if (isLargeOrMediumWindowSize) this.setState({ selectedBox: SelectedBox.FROM });
     }
 
+    const modifiedRangeCompleteButDatesInversed = startDate && endDate && this._endDateIsBeforeStartDate(startDate, endDate);
+
     this.setState({
-      selectedStartDate: startDate,
-      selectedEndDate: endDate
+      selectedStartDate: modifiedRangeCompleteButDatesInversed ? endDate : startDate,
+      selectedEndDate: modifiedRangeCompleteButDatesInversed ? startDate : endDate
     });
   };
 

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -221,10 +221,7 @@ class DateRangePicker extends React.Component {
 
   _handleScrimClick = () => {
     this.props.onClose();
-
-    this.setState({
-      showSelectionPane: false
-    });
+    this._resetToPropValuesAndClose();
   };
 
   _toggleSelectionPane = () => {
@@ -269,6 +266,16 @@ class DateRangePicker extends React.Component {
     }
 
     return where;
+  };
+
+  _resetToPropValuesAndClose = () => {
+    this.setState({
+      focusedDay: this.props.selectedStartDate,
+      selectedStartDate: this.props.selectedStartDate,
+      selectedEndDate: this.props.selectedEndDate,
+      showCalendar: false,
+      showSelectionPane: false
+    });
   };
 
   render () {
@@ -421,12 +428,6 @@ class DateRangePicker extends React.Component {
                       <Button
                         aria-label='Cancel Date Range Selection'
                         onClick={() => {
-                          this.setState({
-                            focusedDay: this.props.selectedStartDate,
-                            showCalendar: false,
-                            selectedStartDate: this.props.selectedStartDate,
-                            selectedEndDate: this.props.selectedEndDate
-                          });
                           this._handleScrimClick();
                         }}
                         theme={this.props.theme}

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -224,11 +224,6 @@ class DateRangePicker extends React.Component {
     });
   };
 
-  _handleScrimClick = () => {
-    this.props.onClose();
-    this._resetToPropValuesAndClose();
-  };
-
   _toggleSelectionPane = () => {
     this.setState({
       showSelectionPane: !this.state.showSelectionPane
@@ -274,6 +269,8 @@ class DateRangePicker extends React.Component {
   };
 
   _resetToPropValuesAndClose = () => {
+    this.props.onClose();
+
     this.setState({
       focusedDay: this.props.selectedStartDate,
       selectedStartDate: this.props.selectedStartDate,
@@ -433,7 +430,7 @@ class DateRangePicker extends React.Component {
                       <Button
                         aria-label='Cancel Date Range Selection'
                         onClick={() => {
-                          this._handleScrimClick();
+                          this._resetToPropValuesAndClose();
                         }}
                         theme={this.props.theme}
                         type='secondary'
@@ -458,7 +455,7 @@ class DateRangePicker extends React.Component {
                               selectedEndDate
                             );
                           }
-                          this._handleScrimClick();
+                          this._resetToPropValuesAndClose();
                         }}
                         style={styles.applyButton}
                         theme={this.props.theme}
@@ -474,7 +471,7 @@ class DateRangePicker extends React.Component {
           </div>
         </div>
         {this.state.showSelectionPane ? (
-          <div onClick={this._handleScrimClick} style={styles.scrim} />
+          <div onClick={this._resetToPropValuesAndClose} style={styles.scrim} />
         ) : null}
       </div>
     );

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -115,7 +115,10 @@ class DateRangePicker extends React.Component {
 
     if (isUpdatedSelectedEndDate || isUpdatedSelectedStartDate) {
       this.setState({
-        currentDate: newProps.selectedEndDate ? newProps.selectedEndDate : newProps.selectedStartDate
+        focusedDay: isUpdatedSelectedEndDate ? newProps.selectedEndDate : this.state.focusedDay,
+        currentDate: newProps.selectedEndDate ? newProps.selectedEndDate : newProps.selectedStartDate,
+        selectedEndDate: isUpdatedSelectedEndDate ? newProps.selectedEndDate : this.state.selectedEndDate,
+        selectedStartDate: isUpdatedSelectedStartDate ? newProps.selectedStartDate : this.state.selectedStartDate
       });
     }
   }

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -156,19 +156,10 @@ class DateRangePicker extends React.Component {
       if (isLargeOrMediumWindowSize) this.setState({ selectedBox: SelectedBox.FROM });
     }
 
-    const modifiedRangeCompleteButDatesInversed = startDate && endDate && this._endDateIsBeforeStartDate(startDate, endDate);
-
-    if (modifiedRangeCompleteButDatesInversed) {
-      this.setState({
-        selectedStartDate: endDate,
-        selectedEndDate: startDate
-      });
-    } else {
-      this.setState({
-        selectedStartDate: startDate,
-        selectedEndDate: endDate
-      });
-    }
+    this.setState({
+      selectedStartDate: startDate,
+      selectedEndDate: endDate
+    });
   };
 
   _handleDefaultRangeSelection = (range) => {


### PR DESCRIPTION
### TLDR

- Consolidate reset logic for closing the range selector
- Fix `componentWillReceiveProps` logic

### Full Story

After more testing internally, I discovered that we had state issues as it pertained to Transactions and Spending both using the `DateRangePicker`.  If you set a range in one and then changed to the other, the date picker there retained the date range from the previous widget. This was caused by faulty logic in two locations. 1: Resetting on close and 2: handling new props in `componentWillReceiveProps`

Ugh!  I hate passing props off to state for components like this.  There are so many edge cases to get wrong but I can't think of a better way at the moment to handle this stand alone `DateRangePicker` component.

I've spent the entire afternoon testing internally and I'm pretty sure I have this right now.