### PR TITLE
Don't clobber the className when it's passed as a prop

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -16,6 +16,7 @@ class Button extends React.Component {
     'aria-label': PropTypes.string,
     actionText: PropTypes.string,
     buttonRef: PropTypes.func,
+    className: PropTypes.string,
     elementProps: PropTypes.object,
     icon: PropTypes.string,
     isActive: PropTypes.bool,
@@ -61,13 +62,13 @@ class Button extends React.Component {
   render () {
     // Manually consume everything that isn't going to be passed down to the button so we don't have to keep adding props one at a time.
     // Keep elementProps for backwards compatibility.
-    const { actionText, buttonRef, children, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props;
+    const { actionText, buttonRef, children, className, elementProps, icon, isActive, primaryColor, style, theme, ...rest } = this.props;
     const mergedTheme = StyleUtils.mergeTheme(theme, primaryColor);
     const styles = this.styles(mergedTheme);
 
     return (
       <button
-        className={css({ ...styles.component, ...styles[this.props.type], ...style })}
+        className={css({ ...styles.component, ...styles[this.props.type], ...style }) + ' ' + className}
         disabled={this.props.type === 'disabled'}
         ref={buttonRef}
         {...rest}

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -27,6 +27,15 @@ describe('Button', () => {
     expect(button.html()).toContain('aria-pressed');
   });
 
+  it('merges className when provided as a prop', () => {
+    const button = shallow(<Button className='foo' />);
+    const className = button.find('button').prop('className');
+
+    expect(className).toContain('foo');
+    // the glamor class should also be present
+    expect(className).toContain('css-');
+  });
+
   describe('non element props', () => {
     it('should not pass down non element props being used elsewhere', () => {
       const button = shallow(<Button icon='foo' />);


### PR DESCRIPTION
The footer buttons in the Modal component set a `className` prop which was clobbering the `className` in Button, which is needed for glamor css styling. This fixes the issue and adds a test to prevent regressions.

Here's how the Modal footer looked while broken (taken from the docs page):

![screen shot 2018-04-12 at 2 13 59 pm](https://user-images.githubusercontent.com/4348/38701911-63964be0-3e5c-11e8-952d-15d0ac446d92.png)

Here is it fixed:

![screen shot 2018-04-12 at 2 14 17 pm](https://user-images.githubusercontent.com/4348/38701921-698e6262-3e5c-11e8-92d6-eed79735ff91.png)
