### PR TITLE
Ensure withTheme wrapped components work with ref

### DIFF
--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -13,7 +13,7 @@ const {
   deprecateProp
 } = require('../utils/Deprecation');
 
-class Input extends React.Component {
+class SimpleInput extends React.Component {
   static propTypes = {
     baseColor: PropTypes.string,
     elementProps: PropTypes.object,
@@ -176,4 +176,4 @@ class Input extends React.Component {
   };
 }
 
-module.exports = withTheme(Input);
+module.exports = withTheme(SimpleInput);

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -40,14 +40,16 @@ class ThemeContext extends React.Component {
   * `theme` can still be provided as a prop to the themed component to override the theme.
   */
 export function withTheme (Component) {
-  function ThemedComponent (props) {
-    return (
-      <ThemeContext>
-        {theme => (
-          <Component {...props} theme={props.theme || theme} />
-        )}
-      </ThemeContext>
-    );
+  class ThemedComponent extends React.Component {
+    render () {
+      return (
+        <ThemeContext>
+          {theme => (
+            <Component {...this.props} theme={this.props.theme || theme} />
+          )}
+        </ThemeContext>
+      );
+    }
   }
   ThemedComponent.propTypes = { theme: themeShape };
   ThemedComponent.displayName = `withTheme(${Component.displayName || Component.name})`;

--- a/src/components/__tests__/Theme-test.js
+++ b/src/components/__tests__/Theme-test.js
@@ -1,13 +1,30 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { mount } from 'enzyme';
 
 import { ThemeProvider, withTheme } from '../Theme';
 
-const ThemedComponent = withTheme(({ theme }) => (
+const ThemedFunctionalComponent = withTheme(({ theme }) => (
   <div style={{ color: theme ? theme.Colors.PRIMARY : DEFAULT_COLOR }}>
-    Hello Theme!
+    Hello Functional Theme!
   </div>
 ));
+
+const ThemedComponent = withTheme(
+  class Hello extends React.Component {
+    static propTypes = { theme: PropTypes.object }
+
+    render () {
+      const theme = this.props.theme;
+
+      return (
+        <div style={{ color: theme ? theme.Colors.PRIMARY : DEFAULT_COLOR }}>
+          Hello Theme!
+        </div>
+      );
+    }
+  }
+);
 
 const DEFAULT_COLOR = '#F00';
 const THEME = {
@@ -33,5 +50,19 @@ describe('Theme', () => {
     const div = wrapper.find(ThemedComponent).find('div').first();
 
     expect(div.prop('style')).toEqual({ color: DEFAULT_COLOR });
+  });
+
+  it('works with refs on React.Component components', () => {
+    let elementRef;
+
+    mount(<div><ThemedComponent ref={ref => (elementRef = ref)} /></div>);
+    expect(elementRef).toBeInstanceOf(ThemedComponent);
+  });
+
+  it('works with refs on functional stateless components', () => {
+    let elementRef;
+
+    mount(<div><ThemedFunctionalComponent ref={ref => (elementRef = ref)} /></div>);
+    expect(elementRef).toBeInstanceOf(ThemedFunctionalComponent);
   });
 });


### PR DESCRIPTION
Components themed using `withTheme` were not working with `ref` props. This converts the wrapping component in `withTheme` from a functional component to a `React.Component` which fixes the problem.