### PR TITLE
Fix modal focus

### DIFF
--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -111,6 +111,10 @@ class ModalDocs extends React.Component {
         <h5>contentStyle <label>Object</label></h5>
         <p>A style object used to style the content div that wrapps the modal&#39;s content</p>
 
+        <h5>focusOnLoad <label>Boolean</label></h5>
+        <p>Default: 'true'</p>
+        <p>The modal will try to focus its content on mount.  This prop provides a way to over ride that functionality in case you wish to focus another element instead.</p>
+
         <h5>footerContent <label>Node</label></h5>
         <p>A node used to add jsx to the footer element of the modal.</p>
 

--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -115,6 +115,12 @@ class ModalDocs extends React.Component {
         <p>Default: 'true'</p>
         <p>The modal will try to focus its content on mount.  This prop provides a way to over ride that functionality in case you wish to focus another element instead.</p>
 
+        <h5>focusTrapProps<label>Object</label></h5>
+        <p>Default: Empty Object</p>
+        <p>The Modal component uses the <a href='https://github.com/davidtheclark/focus-trap-react'>Focus Trap React</a> library to prevent a user from tabing outside the Modal for accessibility reasons.</p>
+        <p>The focusTrapProps object provides a mechanism for passing the focus trap component props.</p>
+        <p>See the library documentation for details on what props it accepts and how to use them.</p>
+
         <h5>footerContent <label>Node</label></h5>
         <p>A node used to add jsx to the footer element of the modal.</p>
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -191,7 +191,6 @@ class Modal extends React.Component {
       focusTrapOptions: {
         clickOutsideDeactivates: true
       },
-      paused: false,
       ...this.props.focusTrapProps
     };
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -11,7 +11,7 @@ const _merge = require('lodash/merge');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
+const { deprecatePrimaryColor, deprecatePropWithMessage } = require('../utils/Deprecation');
 
 class Modal extends React.Component {
   static propTypes = {
@@ -70,14 +70,14 @@ class Modal extends React.Component {
 
   componentDidMount () {
     deprecatePrimaryColor(this.props, 'color');
+    deprecatePropWithMessage(
+      this.props,
+      'isOpen',
+      'Please handle Modal opening from its parent.',
+      'modal'
+    );
 
     if (this.props.focusOnLoad) this._modalContent.focus();
-
-    /*eslint-disable */
-    if (this.props.hasOwnProperty('isOpen')) {
-      console.warn('WARNING: The prop "isOpen" is deprecated in this version of the component. Please handle Modal opening from its parent.');
-    }
-    /*eslint-enable */
   }
 
   _handleTooltipToggle = (show) => {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -29,6 +29,7 @@ class Modal extends React.Component {
     })),
     color: PropTypes.string,
     contentStyle: PropTypes.object,
+    focusTrapProps: PropTypes.object,
     footerContent: PropTypes.node,
     footerStyle: PropTypes.object,
     isRelative: PropTypes.bool,
@@ -49,6 +50,7 @@ class Modal extends React.Component {
   static defaultProps = {
     'aria-label': '',
     buttons: [],
+    focusTrapProps: {},
     isRelative: false,
     showCloseIcon: true,
     showFooter: false,
@@ -182,9 +184,16 @@ class Modal extends React.Component {
   render () {
     const theme = StyleUtils.mergeTheme(this.props.theme, this.props.color);
     const styles = this.styles(theme);
+    const mergedFocusTrapProps = {
+      focusTrapOptions: {
+        clickOutsideDeactivates: true
+      },
+      paused: false,
+      ...this.props.focusTrapProps
+    };
 
     return (
-      <MXFocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+      <MXFocusTrap {...mergedFocusTrapProps}>
         <div className='mx-modal' style={Object.assign({}, styles.scrim, this.props.isRelative && styles.relative)}>
           <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)} />
           <div

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -29,6 +29,7 @@ class Modal extends React.Component {
     })),
     color: PropTypes.string,
     contentStyle: PropTypes.object,
+    focusOnLoad: PropTypes.bool,
     focusTrapProps: PropTypes.object,
     footerContent: PropTypes.node,
     footerStyle: PropTypes.object,
@@ -50,6 +51,7 @@ class Modal extends React.Component {
   static defaultProps = {
     'aria-label': '',
     buttons: [],
+    focusOnLoad: true,
     focusTrapProps: {},
     isRelative: false,
     showCloseIcon: true,
@@ -69,7 +71,8 @@ class Modal extends React.Component {
   componentDidMount () {
     deprecatePrimaryColor(this.props, 'color');
 
-    this._modalContent.focus();
+    if (this.props.focusOnLoad) this._modalContent.focus();
+
     /*eslint-disable */
     if (this.props.hasOwnProperty('isOpen')) {
       console.warn('WARNING: The prop "isOpen" is deprecated in this version of the component. Please handle Modal opening from its parent.');

--- a/src/utils/Deprecation.js
+++ b/src/utils/Deprecation.js
@@ -8,5 +8,10 @@ module.exports = {
     if (props[deprecatedPropName]) {
       console.warn(`The ${deprecatedPropName} prop is deprecated and will be removed in a future release. Use ${replacementPropName} instead. http://mxenabled.github.io/mx-react-components/#/components/${componentDocsURL}`);
     }
+  },
+  deprecatePropWithMessage (props, deprecatedPropName, message, componentDocsURL) {
+    if (props[deprecatedPropName]) {
+      console.warn(`The ${deprecatedPropName} prop is deprecated and will be removed in a future release. ${message} http://mxenabled.github.io/mx-react-components/#/components/${componentDocsURL}`);
+    }
   }
 };


### PR DESCRIPTION
- Adds new prop focusOnLoad to control focusing the Modal on mount
- Adds new prop focusTrapProps to control focus trap
- Cleans up deprecation warning for the `isOpen` prop
- Updates the Docs with the changes

This will be included in the 5.2.3 release in https://github.com/mxenabled/mx-react-components/pull/731