### PR TITLE
Select component children function handler and elementRef fix

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -199,7 +199,10 @@ class Select extends React.Component {
         <div className='mx-select-custom'
           onClick={haltEvent(this._open)}
           onKeyDown={this._handleKeyDown}
-          ref={ref => this.elementRef = ref}
+          ref={ref => {
+            this.elementRef = ref;
+            if (typeof this.props.elementRef === 'function') this.props.elementRef(ref);
+          }}
           style={styles.component}
           tabIndex='0'
         >

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -143,7 +143,7 @@ class Select extends React.Component {
       if (this.props.children) {
         return (
           <div className='mx-select-options' style={styles.options}>
-            {this.props.children}
+            {typeof this.props.children === 'function' ? this.props.children({ onOptionClick: this._handleOptionClick }) : this.props.children}
           </div>
         );
       } else {


### PR DESCRIPTION
When custom `children` are supplied to `Select` there is no way to let `Select` know that an option has been selected. This updates `Select` to pass `onOptionClick` handler to `children` when it's a function, the handler sets the selected option and also calls the `onChange` prop.

I also made it so the `elementRef` is actually called when provided.