### PR TITLE
Modal Accessibility via role and aria attributes

### DIFF
--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -3,7 +3,7 @@
 const React = require('react');
 const { Link } = require('react-router');
 
-const { Modal } = require('mx-react-components');
+const { Button, Modal } = require('mx-react-components');
 
 const Markdown = require('components/Markdown');
 
@@ -48,8 +48,8 @@ class ModalDocs extends React.Component {
 
         <h3>Demo</h3>
         <div style={{ fontFamily: 'Helvetica, Arial, sans-serif' }}>
-          <span className='button' onClick={this._handleModalClick}>Show Default Modal</span>
-          <span className='button' onClick={this._handleSmallModalClick}>Show Small Modal</span>
+          <Button className='button' onClick={this._handleModalClick}>Show Default Modal</Button>
+          <Button className='button' onClick={this._handleSmallModalClick}>Show Small Modal</Button>
         </div>
         {this.state.showModal ? (
           <Modal

--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -84,9 +84,9 @@ class ModalDocs extends React.Component {
             tooltipTitle='This is my tooltip title'
           >
             <div style={{ padding: 20, textAlign: 'center' }}>
-              <img src={`https://unsplash.it/${imageWidth}/${imageHeight}?random`} style={imageStyle} />
               <h2 id='title' style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</h2>
               <p id='description'>With a picture</p>
+              <img alt='Random picture from the internet' src={`https://unsplash.it/${imageWidth}/${imageHeight}?random`} style={imageStyle} />
             </div>
           </Modal>
         ) : null}
@@ -213,6 +213,7 @@ class ModalDocs extends React.Component {
             <div style={{ padding: 20, textAlign: 'center' }}>
               <h2 id='title' style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</h2>
               <p id='description'>With a picture</p>
+              <img alt='Random picture from the internet' src='https://unsplash.it/1000/600?random' style={imageStyle} />
             </div>
           </Modal>
   `}

--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -54,6 +54,7 @@ class ModalDocs extends React.Component {
         {this.state.showModal ? (
           <Modal
             aria-describedby='description'
+            aria-labelledby='title'
             buttons={[
               {
                 icon: 'close',
@@ -83,8 +84,8 @@ class ModalDocs extends React.Component {
             tooltipTitle='This is my tooltip title'
           >
             <div style={{ padding: 20, textAlign: 'center' }}>
-              <p style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</p>
               <img src={`https://unsplash.it/${imageWidth}/${imageHeight}?random`} style={imageStyle} />
+              <h2 id='title' style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</h2>
               <p id='description'>With a picture</p>
             </div>
           </Modal>
@@ -94,6 +95,9 @@ class ModalDocs extends React.Component {
 
         <h5>aria-describedby <label>string</label></h5>
         <p>An id of a child element that describes the Modal. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html'>WAI-ARIA documentation for aria-describedby</a></p>
+        <h5>aria-labelledby <label>string</label></h5>
+        <p>An id of a child element that is the title of the Modal. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/WAI/GL/wiki/Using_aria-labelledby_to_concatenate_a_label_from_several_text_nodes'>WAI-ARIA documentation for aria-labelledby</a></p>
+
         <h5>buttons <label>Array</label></h5>
         <p>An array of objects with the properties: actionText, className, isActive, icon, label, onClick, style, and type. Used to display button in the footer of the modal. Example:</p>
         <Markdown>
@@ -177,6 +181,7 @@ class ModalDocs extends React.Component {
   {`
           <Modal
             aria-describedby='description'
+            aria-labelledby='title'
             buttons={[
               {
                 icon: 'close',
@@ -206,8 +211,7 @@ class ModalDocs extends React.Component {
             tooltipTitle='This is my tooltip title'
           >
             <div style={{ padding: 20, textAlign: 'center' }}>
-              <p style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</p>
-              <img src='https://unsplash.it/1000/600?random' style={imageStyle} />
+              <h2 id='title' style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</h2>
               <p id='description'>With a picture</p>
             </div>
           </Modal>

--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -146,6 +146,10 @@ class ModalDocs extends React.Component {
         <h5>onRequestClose <label>Function</label></h5>
         <p>A method that is called when the close button or scrim area is clicked by a user. Use this method to tell the Modal when it should close.</p>
 
+        <h5>role <label>string</label></h5>
+        <p>Default: 'dialog'</p>
+        <p>The role applied to the wrapping div around the Modal's children.  Used for accessibility purposes.  See <a href='https://www.w3.org/TR/wai-aria-1.1/#usage_intro'>WAI-ARIA documentation</a> for more details on roles.</p>
+
         <h5>showCloseIcon <label>Boolean</label></h5>
         <p>Default: 'true'</p>
         <p>Determines if the close icon is displayed in the top right corner of the Modal.  The Modal can still be closed by clicking on the scrim.</p>

--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -53,6 +53,7 @@ class ModalDocs extends React.Component {
         </div>
         {this.state.showModal ? (
           <Modal
+            aria-describedby='description'
             buttons={[
               {
                 icon: 'close',
@@ -84,12 +85,15 @@ class ModalDocs extends React.Component {
             <div style={{ padding: 20, textAlign: 'center' }}>
               <p style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</p>
               <img src={`https://unsplash.it/${imageWidth}/${imageHeight}?random`} style={imageStyle} />
+              <p id='description'>With a picture</p>
             </div>
           </Modal>
         ) : null}
 
         <h3>Usage</h3>
 
+        <h5>aria-describedby <label>string</label></h5>
+        <p>An id of a child element that describes the Modal. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html'>WAI-ARIA documentation for aria-describedby</a></p>
         <h5>buttons <label>Array</label></h5>
         <p>An array of objects with the properties: actionText, className, isActive, icon, label, onClick, style, and type. Used to display button in the footer of the modal. Example:</p>
         <Markdown>
@@ -172,6 +176,7 @@ class ModalDocs extends React.Component {
         <Markdown>
   {`
           <Modal
+            aria-describedby='description'
             buttons={[
               {
                 icon: 'close',
@@ -203,6 +208,7 @@ class ModalDocs extends React.Component {
             <div style={{ padding: 20, textAlign: 'center' }}>
               <p style={{ fontFamily: 'Helvetica, Arial, sans-serif', textAlign: 'center' }}>I am a modal!</p>
               <img src='https://unsplash.it/1000/600?random' style={imageStyle} />
+              <p id='description'>With a picture</p>
             </div>
           </Modal>
   `}

--- a/docs/components/ModalDocs.js
+++ b/docs/components/ModalDocs.js
@@ -95,6 +95,10 @@ class ModalDocs extends React.Component {
 
         <h5>aria-describedby <label>string</label></h5>
         <p>An id of a child element that describes the Modal. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html'>WAI-ARIA documentation for aria-describedby</a></p>
+
+        <h5>aria-label <label>string</label></h5>
+        <p>A string applied as a label to the wrapping div around the Modal's children. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html'>WAI-ARIA documentation for aria-label</a></p>
+
         <h5>aria-labelledby <label>string</label></h5>
         <p>An id of a child element that is the title of the Modal. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/WAI/GL/wiki/Using_aria-labelledby_to_concatenate_a_label_from_several_text_nodes'>WAI-ARIA documentation for aria-labelledby</a></p>
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -17,6 +17,7 @@ class Modal extends React.Component {
   static propTypes = {
     'aria-describedby': PropTypes.string,
     'aria-label': PropTypes.string,
+    'aria-labelledby': PropTypes.string,
     buttons: PropTypes.arrayOf(PropTypes.shape({
       actionText: PropTypes.string,
       className: PropTypes.string,
@@ -207,6 +208,7 @@ class Modal extends React.Component {
             <div
               aria-describedby={this.props['aria-describedby']}
               aria-label={this.props['aria-label']}
+              aria-labelledby={this.props['aria-labelledby']}
               className='mx-modal-content'
               ref={ref => this._modalContent = ref}
               style={Object.assign({}, styles.content, this.props.contentStyle)}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -15,6 +15,7 @@ const { deprecatePrimaryColor, deprecatePropWithMessage } = require('../utils/De
 
 class Modal extends React.Component {
   static propTypes = {
+    'aria-describedby': PropTypes.string,
     'aria-label': PropTypes.string,
     buttons: PropTypes.arrayOf(PropTypes.shape({
       actionText: PropTypes.string,
@@ -204,6 +205,7 @@ class Modal extends React.Component {
           >
             {this._renderTitleBar(styles)}
             <div
+              aria-describedby={this.props['aria-describedby']}
               aria-label={this.props['aria-label']}
               className='mx-modal-content'
               ref={ref => this._modalContent = ref}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -52,7 +52,6 @@ class Modal extends React.Component {
   };
 
   static defaultProps = {
-    'aria-label': '',
     buttons: [],
     focusOnLoad: true,
     focusTrapProps: {},

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -37,6 +37,7 @@ class Modal extends React.Component {
     footerStyle: PropTypes.object,
     isRelative: PropTypes.bool,
     onRequestClose: PropTypes.func,
+    role: PropTypes.string,
     showCloseIcon: PropTypes.bool,
     showFooter: PropTypes.bool,
     showScrim: PropTypes.bool,
@@ -56,6 +57,7 @@ class Modal extends React.Component {
     focusOnLoad: true,
     focusTrapProps: {},
     isRelative: false,
+    role: 'dialog',
     showCloseIcon: true,
     showFooter: false,
     showScrim: true,
@@ -211,6 +213,7 @@ class Modal extends React.Component {
               aria-labelledby={this.props['aria-labelledby']}
               className='mx-modal-content'
               ref={ref => this._modalContent = ref}
+              role={this.props.role}
               style={Object.assign({}, styles.content, this.props.contentStyle)}
               tabIndex={0}
             >


### PR DESCRIPTION
### Modal Component

- Adds role prop which defaults to `dialog`
- Adds aria-describedby prop
- Adds aria-labelledby prop
- Updates the docs for Modal

Because of the above we can now use elements that our children of the modal to describe it's content for screen readers.  This is a vast improvement in accessibility for the Modal.  Here is the docs on the `dialog` role for clarity around the aria attributes added.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role