### PR TITLE
Drawer Accessibility via role and aria attributes

### DIFF
--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -237,7 +237,6 @@ class DrawerDocs extends React.Component {
       title='Demo'
     >
       <p id='description'>This is a demo drawer</p>
-      <div>// Content Here</div>
     </Drawer>
   `}
         </Markdown>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -42,6 +42,7 @@ class DrawerDocs extends React.Component {
 
     return (
       <Drawer
+        aria-describedby='description'
         breakPoints={{ large: 1200, medium: 1100 }}
         contentStyle={styles.content}
         headerMenu={({ close }) => (
@@ -62,7 +63,7 @@ class DrawerDocs extends React.Component {
           return (
             <div>
               {this.state.clickedMenu && <code>You clicked: {this.state.clickedMenu.text}</code>}
-              <p>
+              <p id='description'>
                 Drawer Component
               </p>
               <p>
@@ -114,6 +115,13 @@ class DrawerDocs extends React.Component {
         {this.state.demoDrawerOpen && this._renderDrawer()}
 
         <h3>Usage</h3>
+
+        <h5>aria-describedby <label>string</label></h5>
+        <p>An id of a child element that describes the Drawer. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html'>WAI-ARIA documentation for aria-describedby</a></p>
+
+        <h5>aria-labelledby <label>string</label></h5>
+        <p>An id of a child element that would be considered the title of the Drawer. If not provided, the drawer defaults to the title header within the drawer that is populated by the title prop. Used by screen readers for accessibility purposes. See <a href='https://www.w3.org/WAI/GL/wiki/Using_aria-labelledby_to_concatenate_a_label_from_several_text_nodes'>WAI-ARIA documentation for aria-labelledby</a></p>
+
         <h5>children<label>DOM Node/Element or Function</label></h5>
         <p>Children of the Drawer component can be a component, DOM node/element, or a function.</p>
         <p>If children is a function, the function is called and passed an object of exposed drawer functions. Currently the Drawer's close function is the only exposed function in the object and has a key of `close`. The returned value of the function call must be a component or DOM node/element. This is handy if you need to close the drawer from the drawer's content area and want to ensure the drawer's animation is run before close. See the second example below for more details.</p>
@@ -176,6 +184,10 @@ class DrawerDocs extends React.Component {
 
         <h5>onKeyUp<label>Function</label></h5>
         <p>An event handler for the key up event of the drawer. If no handler is passed then the drawer will close when the esc key is pressed.</p>
+
+        <h5>role <label>string</label></h5>
+        <p>Default: 'dialog'</p>
+        <p>The role applied to the wrapping div around the Drawer's children.  Used for accessibility purposes.  See <a href='https://www.w3.org/TR/wai-aria-1.1/#usage_intro'>WAI-ARIA documentation</a> for more details on roles.</p>
 
         <h5>showCloseButton<label>Boolean</label></h5>
         <p>Default: true</p>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -223,6 +223,7 @@ class DrawerDocs extends React.Component {
     },
 
     <Drawer
+      aria-describedby='description'
       breakPoints={{ large: 1200, medium: 1100 }}
       contentStyle={styles.content}
       headerMenu={(
@@ -235,7 +236,8 @@ class DrawerDocs extends React.Component {
       onClose={this._handleDrawerClose}
       title='Demo'
     >
-      // Content Here
+      <p id='description'>This is a demo drawer</p>
+      <div>// Content Here</div>
     </Drawer>
   `}
         </Markdown>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -21,6 +21,7 @@ const { deprecatePrimaryColor } = require('../utils/Deprecation');
 class Drawer extends React.Component {
   static propTypes = {
     'aria-describedby': PropTypes.string,
+    'aria-labelledby': PropTypes.string,
     animateLeftDistance: PropTypes.number,
     beforeClose: PropTypes.func,
     breakPoints: PropTypes.shape({
@@ -252,6 +253,7 @@ class Drawer extends React.Component {
             />
             <div
               aria-describedby={this.props['aria-describedby']}
+              aria-labelledby={this.props['aria-labelledby'] || 'mx-drawer-title'}
               ref={(ref) => (this._component = ref)}
               role='dialog'
               style={Object.assign({}, styles.component, this.props.style)}
@@ -269,7 +271,7 @@ class Drawer extends React.Component {
                     />
                   }
                 </span>
-                <h1 style={styles.title}>
+                <h1 id='mx-drawer-title' style={styles.title}>
                   {this.props.title}
                 </h1>
                 <div style={styles.headerMenu}>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -243,7 +243,7 @@ class Drawer extends React.Component {
     } else if (navConfig) {
       menu = this._renderNav(navConfig, styles, theme);
     }
-    const titleUniqueId = _uniqueId('mx-drawer-titile-');
+    const titleUniqueId = _uniqueId('mx-drawer-title-');
 
     return (
       <StyleRoot>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -257,12 +257,11 @@ class Drawer extends React.Component {
               aria-describedby={this.props['aria-describedby']}
               aria-labelledby={this.props['aria-labelledby'] || 'mx-drawer-title'}
               ref={(ref) => (this._component = ref)}
-              role='dialog'
-              style={Object.assign({}, styles.component, this.props.style)}
               role={this.props.role}
+              style={{ ...styles.component, ...this.props.style }}
               tabIndex={0}
             >
-              <header style={Object.assign({}, styles.header, this.props.headerStyle)}>
+              <header style={{ ...styles.header, ...this.props.headerStyle }}>
                 <span style={styles.backArrow}>
                   {this.props.showCloseButton &&
                     <Button
@@ -281,7 +280,7 @@ class Drawer extends React.Component {
                   {menu}
                 </div>
               </header>
-              <div style={Object.assign({}, styles.content, this.props.contentStyle)}>
+              <div style={{ ...styles.content, ...this.props.contentStyle }}>
                 {typeof this.props.children === 'function' ? this.props.children(this._getExposedDrawerFunctions()) : this.props.children}
               </div>
             </div>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -55,6 +55,7 @@ class Drawer extends React.Component {
     onClose: PropTypes.func.isRequired,
     onKeyUp: PropTypes.func,
     onOpen: PropTypes.func,
+    role: PropTypes.string,
     showCloseButton: PropTypes.bool,
     showScrim: PropTypes.bool,
     styles: PropTypes.object,
@@ -71,6 +72,7 @@ class Drawer extends React.Component {
     focusTrapProps: {},
     maxWidth: 960,
     onOpen: () => {},
+    role: 'dialog',
     showCloseButton: true,
     showScrim: true,
     title: ''
@@ -257,6 +259,7 @@ class Drawer extends React.Component {
               ref={(ref) => (this._component = ref)}
               role='dialog'
               style={Object.assign({}, styles.component, this.props.style)}
+              role={this.props.role}
               tabIndex={0}
             >
               <header style={Object.assign({}, styles.header, this.props.headerStyle)}>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -20,6 +20,7 @@ const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class Drawer extends React.Component {
   static propTypes = {
+    'aria-describedby': PropTypes.string,
     animateLeftDistance: PropTypes.number,
     beforeClose: PropTypes.func,
     breakPoints: PropTypes.shape({
@@ -250,7 +251,7 @@ class Drawer extends React.Component {
               style={styles.scrim}
             />
             <div
-              aria-label={this.props.title}
+              aria-describedby={this.props['aria-describedby']}
               ref={(ref) => (this._component = ref)}
               role='dialog'
               style={Object.assign({}, styles.component, this.props.style)}

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -3,6 +3,7 @@ const _isEqual = require('lodash/isEqual');
 const _isNumber = require('lodash/isNumber');
 const _merge = require('lodash/merge');
 const _throttle = require('lodash/throttle');
+const _uniqueId = require('lodash/uniqueId');
 const keycode = require('keycode');
 const PropTypes = require('prop-types');
 const React = require('react');
@@ -242,6 +243,7 @@ class Drawer extends React.Component {
     } else if (navConfig) {
       menu = this._renderNav(navConfig, styles, theme);
     }
+    const titleUniqueId = _uniqueId('mx-drawer-titile-');
 
     return (
       <StyleRoot>
@@ -255,7 +257,7 @@ class Drawer extends React.Component {
             />
             <div
               aria-describedby={this.props['aria-describedby']}
-              aria-labelledby={this.props['aria-labelledby'] || 'mx-drawer-title'}
+              aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
               ref={(ref) => (this._component = ref)}
               role={this.props.role}
               style={{ ...styles.component, ...this.props.style }}
@@ -273,7 +275,7 @@ class Drawer extends React.Component {
                     />
                   }
                 </span>
-                <h1 id='mx-drawer-title' style={styles.title}>
+                <h1 id={titleUniqueId} style={styles.title}>
                   {this.props.title}
                 </h1>
                 <div style={styles.headerMenu}>


### PR DESCRIPTION
### Drawer Component

- Adds role prop which defaults to `dialog`
- Adds aria-describedby prop
- Adds aria-labelledby prop
- Updates the docs for Drawer

Because of the above we can now use elements that our children of the drawer to describe it's content for screen readers.  This is a vast improvement in accessibility for the Drawer.  Here is the docs on the `dialog` role for clarity around the aria attributes added.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role