### PR TITLE
The primaryColor prop should take precedence

### DIFF
--- a/src/utils/Style.js
+++ b/src/utils/Style.js
@@ -82,7 +82,7 @@ const StyleUtils = {
   mergeTheme (theme, primaryColor) {
     const primaryColorTheme = primaryColor && { Colors: { PRIMARY: primaryColor } };
 
-    return _merge({}, StyleConstants, primaryColorTheme, theme);
+    return _merge({}, StyleConstants, theme, primaryColorTheme);
   },
 
   /**

--- a/src/utils/__tests__/Style-test.js
+++ b/src/utils/__tests__/Style-test.js
@@ -1,0 +1,24 @@
+import StyleUtils from '../Style';
+import StyleConstants from '../../constants/Style';
+
+describe('StyleUtils', () => {
+  describe('mergeTheme', () => {
+    let theme;
+
+    beforeEach(() => {
+      theme = {
+        Colors: { PRIMARY: '#F00' }
+      };
+    });
+
+    it('should give precedence to the theme prop over StyleConstants', () => {
+      expect(StyleUtils.mergeTheme(theme).Colors.PRIMARY).toEqual(theme.Colors.PRIMARY);
+      expect(StyleUtils.mergeTheme({}).Colors.PRIMARY).toBeDefined();
+      expect(StyleUtils.mergeTheme({}).Colors.PRIMARY).toEqual(StyleConstants.Colors.PRIMARY);
+    });
+
+    it('should give precedence to the primaryColor prop over theme', () => {
+      expect(StyleUtils.mergeTheme(theme, '#C0FFEE').Colors.PRIMARY).toEqual('#C0FFEE');
+    });
+  });
+});


### PR DESCRIPTION
Even though the `primaryColor` prop is deprecated it should still take precedence. This fixes a bug with f6eff0179d6fda8e7c885a3c81c839d76a26d15e that was not noticed until the `ThemeProvider` was introduced.