### PR TITLE
SimpleSelect - Wrap in Focus Trap

### DIFF
--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -55,6 +55,12 @@ class SimpleSelectDocs extends React.Component {
         </div>
 
         <h3>Usage</h3>
+        <h5>focusTrapProps<label>Object</label></h5>
+        <p>Default: Empty Object</p>
+        <p>The SimpleSelect component uses the <a href='https://github.com/davidtheclark/focus-trap-react'>Focus Trap React</a> library to prevent a user from tabing outside the SimpleSelect for accessibility reasons.</p>
+        <p>The focusTrapProps object provides a mechanism for passing the focus trap component props.</p>
+        <p>See the library documentation for details on what props it accepts and how to use them.</p>
+
         <h5>iconSize <label>Number</label></h5>
         <p>Default: 20</p>
         <p>The icon size used for icons in menu items if used.</p>

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -18,6 +18,7 @@ class SimpleSelect extends React.Component {
   static propTypes = {
     'aria-label': PropTypes.string,
     elementRef: PropTypes.func,
+    focusTrapProps: PropTypes.object,
     hoverColor: PropTypes.string,
     iconSize: PropTypes.number,
     iconStyles: PropTypes.object,
@@ -33,6 +34,7 @@ class SimpleSelect extends React.Component {
 
   static defaultProps = {
     'aria-label': '',
+    focusTrapProps: {},
     scrimClickOnSelect: false,
     items: [],
     onScrimClick () {}
@@ -61,8 +63,15 @@ class SimpleSelect extends React.Component {
     const theme = StyleUtils.mergeTheme(this.props.theme, this.props.hoverColor);
     const styles = this.styles(theme);
 
+    const mergedFocusTrapProps = {
+      focusTrapOptions: {
+        clickOutsideDeactivates: true
+      },
+      ...this.props.focusTrapProps
+    };
+
     return (
-      <MXFocusTrap>
+      <MXFocusTrap {...mergedFocusTrapProps}>
         <div ref={this.props.elementRef} style={styles.component}>
           <Listbox
             aria-label={this.props['aria-label']}

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -7,6 +7,7 @@ const _merge = require('lodash/merge');
 import { withTheme } from './Theme';
 const Icon = require('./Icon');
 const { Listbox, Option } = require('./accessibility/Listbox');
+const MXFocusTrap = require('./MXFocusTrap');
 
 const { themeShape } = require('../constants/App');
 
@@ -61,52 +62,54 @@ class SimpleSelect extends React.Component {
     const styles = this.styles(theme);
 
     return (
-      <div ref={this.props.elementRef} style={styles.component}>
-        <Listbox
-          aria-label={this.props['aria-label']}
-          style={styles.menu}
-          useGlobalKeyHandler={true}
-        >
-          {this.props.children ?
-            this.props.children :
-            (this.props.items.map((item, i) => {
-              const { icon, isSelected, onClick, text, ...rest } = item;
+      <MXFocusTrap>
+        <div ref={this.props.elementRef} style={styles.component}>
+          <Listbox
+            aria-label={this.props['aria-label']}
+            style={styles.menu}
+            useGlobalKeyHandler={true}
+          >
+            {this.props.children ?
+              this.props.children :
+              (this.props.items.map((item, i) => {
+                const { icon, isSelected, onClick, text, ...rest } = item;
 
-              return (
-                <Option
-                  isSelected={isSelected}
-                  key={i}
-                  label={text}
-                  onClick={e => {
-                    if (this.props.scrimClickOnSelect) {
-                      e.stopPropagation();
-                      this.props.onScrimClick();
-                    }
+                return (
+                  <Option
+                    isSelected={isSelected}
+                    key={i}
+                    label={text}
+                    onClick={e => {
+                      if (this.props.scrimClickOnSelect) {
+                        e.stopPropagation();
+                        this.props.onScrimClick();
+                      }
 
-                    if (onClick && typeof onClick === 'function') {
-                      onClick(e, item);
-                    }
-                  }}
-                  style={styles.item}
-                  {...rest}
-                >
-                  {icon ? (
-                    <Icon size={this.props.iconSize || 20} style={styles.icon} type={icon} />
-                  ) : null}
-                  <div style={styles.text}>{text}</div>
-                </Option>
-              );
-            })
-          )}
-        </Listbox>
-        <div
-          onClick={e => {
-            e.stopPropagation();
-            this.props.onScrimClick();
-          }}
-          style={styles.scrim}
-        />
-      </div>
+                      if (onClick && typeof onClick === 'function') {
+                        onClick(e, item);
+                      }
+                    }}
+                    style={styles.item}
+                    {...rest}
+                  >
+                    {icon ? (
+                      <Icon size={this.props.iconSize || 20} style={styles.icon} type={icon} />
+                    ) : null}
+                    <div style={styles.text}>{text}</div>
+                  </Option>
+                );
+              })
+            )}
+          </Listbox>
+          <div
+            onClick={e => {
+              e.stopPropagation();
+              this.props.onScrimClick();
+            }}
+            style={styles.scrim}
+          />
+        </div>
+      </MXFocusTrap>
     );
   }
 

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -11,7 +11,7 @@ const { Listbox, Option } = require('./accessibility/Listbox');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
+const { deprecatePrimaryColor, deprecateProp } = require('../utils/Deprecation');
 
 class SimpleSelect extends React.Component {
   static propTypes = {
@@ -39,16 +39,10 @@ class SimpleSelect extends React.Component {
 
   componentDidMount () {
     deprecatePrimaryColor(this.props, 'hoverColor');
+    deprecateProp(this.props, 'iconStyles', 'styles', 'simple-select');
+    deprecateProp(this.props, 'menuStyles', 'styles', 'simple-select');
 
     window.addEventListener('keydown', this._handleKeyDown);
-
-    if (this.props.iconStyles) {
-      console.warn('The iconStyles prop is deprecated and will be removed in a future release. Please use styles.');
-    }
-
-    if (this.props.menuStyles) {
-      console.warn('The menuStyles prop is deprecated and will be removed in a future release. Please use styles.');
-    }
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
- Wraps the SimpleSelect component in the MXFocusTrap to prevent tabbing off of the options.
- Adds focusTrapOptions prop to SimpleSelect to allow managing the focus trap.
- Updated the SimpleSelect docs.
- Cleaned up deprecation warnings in componentDidMount.

Tested internally and found no issue in the areas where we use the SimpleSelect.  I also verified that we were not doing anything crazy with refs now that we're wrapping in the focus trap.  All tests are also passing internally. 👍 

<img width="844" alt="screen shot 2018-04-25 at 2 44 05 pm" src="https://user-images.githubusercontent.com/6463914/39271755-259229aa-4897-11e8-889c-c5b307e61ca2.png">
