### PR TITLE
Accessibility Tweaks for Calendar, DateRangePicker, and Drawer

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -205,7 +205,7 @@ class Calendar extends React.Component {
                 }}
                 onKeyDown={e => this._handleDayKeyDown(e, day)}
                 ref={dayAnchorTag => (this[day.unix()] = dayAnchorTag)}
-                role='option'
+                role='button'
                 style={Object.assign(
                   {},
                   styles.calendarDay,
@@ -255,7 +255,7 @@ class Calendar extends React.Component {
             aria-label={`Go back a month to ${previousMonthText}`}
             onClick={this._handlePreviousClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handlePreviousClick()}
-            role='option'
+            role='button'
             tabIndex={0}
           >
             <Icon
@@ -269,7 +269,7 @@ class Calendar extends React.Component {
             aria-label={`Go forward a month to ${nextMonthText}`}
             onClick={this._handleNextClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handleNextClick()}
-            role='option'
+            role='button'
             tabIndex={0}
           >
             <Icon

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -283,9 +283,8 @@ class Calendar extends React.Component {
           {daysOfWeek.map((day) => {
             return (
               <div
-                aria-label={`Column Header for ${day.label}`}
+                aria-hidden={true}
                 key={day.label}
-                role='option'
                 style={styles.calendarWeekDay}
               >
                 {day.value}

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -205,6 +205,7 @@ class Calendar extends React.Component {
                 }}
                 onKeyDown={e => this._handleDayKeyDown(e, day)}
                 ref={dayAnchorTag => (this[day.unix()] = dayAnchorTag)}
+                role='option'
                 style={Object.assign(
                   {},
                   styles.calendarDay,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -250,7 +250,7 @@ class Calendar extends React.Component {
 
     return (
       <div style={styles.component}>
-        <div style={styles.calendarHeader}>
+        <div style={styles.calendarHeaderBar}>
           <a
             aria-label={`Go back a month to ${previousMonthText}`}
             onClick={this._handlePreviousClick}
@@ -264,7 +264,7 @@ class Calendar extends React.Component {
               type='caret-left'
             />
           </a>
-          <div aria-label={currentMonthText}>{currentMonthText}</div>
+          <h2 aria-label={`Currently in ${currentMonthText}`} style={styles.calendarHeaderMonthText}>{currentMonthText}</h2>
           <a
             aria-label={`Go forward a month to ${nextMonthText}`}
             onClick={this._handleNextClick}
@@ -311,7 +311,7 @@ class Calendar extends React.Component {
       },
 
       //Calendar Header
-      calendarHeader: {
+      calendarHeaderBar: {
         alignItems: 'center',
         color: theme.Colors.GRAY_700,
         display: 'flex',
@@ -325,6 +325,11 @@ class Calendar extends React.Component {
       calendayHeaderNav: {
         width: 35,
         cursor: 'pointer'
+      },
+      calendarHeaderMonthText: {
+        fontSize: theme.FontSizes.LARGE,
+        margin: 0,
+        fontFamily: theme.Fonts.SEMIBOLD
       },
 
       //Calendar week

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -254,6 +254,7 @@ class Calendar extends React.Component {
             aria-label={`Go back a month to ${previousMonthText}`}
             onClick={this._handlePreviousClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handlePreviousClick()}
+            role='option'
             tabIndex={0}
           >
             <Icon
@@ -267,6 +268,7 @@ class Calendar extends React.Component {
             aria-label={`Go forward a month to ${nextMonthText}`}
             onClick={this._handleNextClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handleNextClick()}
+            role='option'
             tabIndex={0}
           >
             <Icon
@@ -279,7 +281,12 @@ class Calendar extends React.Component {
         <div style={styles.calendarWeekHeader}>
           {daysOfWeek.map((day) => {
             return (
-              <div aria-label={day.label} key={day.label} style={styles.calendarWeekDay}>
+              <div
+                aria-label={`Column Header for ${day.label}`}
+                key={day.label}
+                role='option'
+                style={styles.calendarWeekDay}
+              >
                 {day.value}
               </div>
             );

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -250,7 +250,7 @@ class Calendar extends React.Component {
 
     return (
       <div style={styles.component}>
-        <div style={styles.calendarHeaderBar}>
+        <div style={styles.calendarHeader}>
           <a
             aria-label={`Go back a month to ${previousMonthText}`}
             onClick={this._handlePreviousClick}
@@ -264,7 +264,7 @@ class Calendar extends React.Component {
               type='caret-left'
             />
           </a>
-          <h2 aria-label={`Currently in ${currentMonthText}`} style={styles.calendarHeaderMonthText}>{currentMonthText}</h2>
+          <div aria-label={`Currently in ${currentMonthText}`} role='heading'>{currentMonthText}</div>
           <a
             aria-label={`Go forward a month to ${nextMonthText}`}
             onClick={this._handleNextClick}
@@ -311,7 +311,7 @@ class Calendar extends React.Component {
       },
 
       //Calendar Header
-      calendarHeaderBar: {
+      calendarHeader: {
         alignItems: 'center',
         color: theme.Colors.GRAY_700,
         display: 'flex',
@@ -325,11 +325,6 @@ class Calendar extends React.Component {
       calendayHeaderNav: {
         width: 35,
         cursor: 'pointer'
-      },
-      calendarHeaderMonthText: {
-        fontSize: theme.FontSizes.LARGE,
-        margin: 0,
-        fontFamily: theme.Fonts.SEMIBOLD
       },
 
       //Calendar week

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -311,6 +311,7 @@ class DateRangePicker extends React.Component {
           onClick={this._toggleSelectionPane}
           onKeyDown={(e) => keycode(e) === 'enter' && this._toggleSelectionPane()}
           ref={this.props.elementRef}
+          role='button'
           style={styles.selectedDateWrapper}
           tabIndex={0}
         >

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -402,7 +402,7 @@ class DateRangePicker extends React.Component {
                               ].map(day => {
                                 return (
                                   <div
-                                    aria-label={`Column Header for ${day.value}`}
+                                    aria-hidden={true}
                                     key={day.value}
                                     role='option'
                                     style={styles.calendarWeekDay}

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -402,7 +402,7 @@ class DateRangePicker extends React.Component {
                               ].map(day => {
                                 return (
                                   <div
-                                    aria-label={day.value}
+                                    aria-label={`Column Header for ${day.value}`}
                                     key={day.value}
                                     role='option'
                                     style={styles.calendarWeekDay}

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -404,6 +404,7 @@ class DateRangePicker extends React.Component {
                                   <div
                                     aria-label={day.value}
                                     key={day.value}
+                                    role='option'
                                     style={styles.calendarWeekDay}
                                   >
                                     {day.label}

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -404,7 +404,6 @@ class DateRangePicker extends React.Component {
                                   <div
                                     aria-hidden={true}
                                     key={day.value}
-                                    role='option'
                                     style={styles.calendarWeekDay}
                                   >
                                     {day.label}

--- a/src/components/DateRangePicker/Selector.js
+++ b/src/components/DateRangePicker/Selector.js
@@ -29,7 +29,13 @@ class Selector extends React.Component {
         >
           <Icon size={20} style={styles.calendarHeaderNav} type='caret-left' />
         </a>
-        <div style={styles.currentDate}>{this.props.currentDate}</div>
+        <div
+          aria-label={`Currently in ${this.props.currentDate}`}
+          role='heading'
+          style={styles.currentDate}
+        >
+          {this.props.currentDate}
+        </div>
         <a
           aria-label={`Next ${this.props.type}`}
           onClick={this.props.handleNextClick}

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -98,7 +98,7 @@ class Drawer extends React.Component {
     window.addEventListener('resize', this._resizeThrottled);
 
     if (this.props.focusOnLoad) {
-      this._component.focus();
+      this._closeButton.focus();
     }
   }
 
@@ -268,6 +268,7 @@ class Drawer extends React.Component {
                   {this.props.showCloseButton &&
                     <Button
                       aria-label={`Close ${this.props.title} Drawer`}
+                      buttonRef={ref => (this._closeButton = ref)}
                       icon='go-back'
                       onClick={this.close}
                       theme={theme}

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -6,8 +6,6 @@ const Style = {
      * still allow screen readers to read them.
      * Verified working in Chrome, Firefox, Safari, IE 11, and Edge
      *
-     * Used for H1 Budgets title
-     *
      * See https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
      *
      * We've used the HTML 5 boiler plate version here as it has corrected some minor

--- a/src/constants/Style.js
+++ b/src/constants/Style.js
@@ -1,4 +1,32 @@
 const Style = {
+  AccessibilityStyles: {
+
+    /**
+     * Recommended way to hide elements visually but
+     * still allow screen readers to read them.
+     * Verified working in Chrome, Firefox, Safari, IE 11, and Edge
+     *
+     * Used for H1 Budgets title
+     *
+     * See https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+     *
+     * We've used the HTML 5 boiler plate version here as it has corrected some minor
+     * issues with the version in the linked article above.
+     * https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css#L130
+     **/
+    VISUALLY_HIDDEN: {
+      border: 0,
+      clip: 'rect(0 0 0 0)',
+      height: 1,
+      margin: -1,
+      overflow: 'hidden',
+      padding: 0,
+      position: 'absolute',
+      width: 1,
+      whiteSpace: 'nowrap'
+    }
+  },
+
   BreakPoints: {
     large: 1200,
     medium: 768,


### PR DESCRIPTION
Turns out that iOS and Android voice over can care less about aria labels unless you use appropriate roles and/or appropriate semantic HTML like an h tag.

This fixes that issue by adding roles to the various items in the `Calendar`, `DateRangePicker`, and `Selector` components. 

I also... 

- tweaked a couple of aria labels
- hid the calendar day of week column headers from screen readers so that the mobile voice over apps wouldn't force a user to cycle through them before getting to the dates in the calendar. Don't worry, the dates call out their day of week.
- Switched to focusing the close button on mount for the Drawer. Focusing the entire content was problematic as it would look like we were trying to focus something off screen and/or would leave the thing that opened the drawer focused.
- Adds a new `AccessibilityStyles` object to the `Style` constants with an `VISUALLY_HIDDEN` style that we can use via theme to hide things from visual users but still allow the screen reader to read them.