### PR TITLE
Fix focus issue caused by close button not being present

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -98,7 +98,13 @@ class Drawer extends React.Component {
     window.addEventListener('resize', this._resizeThrottled);
 
     if (this.props.focusOnLoad) {
-      this._closeButton.focus();
+      // Close button might not be present depending on showCloseButtonProp
+      if (this.props.showCloseButton && this._closeButton) {
+        this._closeButton.focus();
+      // Fall back to focusing the component if no close button
+      } else if (this._component) {
+        this._component.focus();
+      }
     }
   }
 


### PR DESCRIPTION
I introduced a bug in https://github.com/mxenabled/mx-react-components/pull/739 where trying to focus the drawer's close button when the prop `showCloseButton` was set to false would cause an exception 💥

This fixes that issue.... 