### PR TITLE
Reduces Drawer title from an h1 to an h2

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -282,9 +282,9 @@ class Drawer extends React.Component {
                     />
                   }
                 </span>
-                <h1 id={titleUniqueId} style={styles.title}>
+                <h2 id={titleUniqueId} style={styles.title}>
                   {this.props.title}
-                </h1>
+                </h2>
                 <div style={styles.headerMenu}>
                   {menu}
                 </div>


### PR DESCRIPTION
I wrongly assumed that the drawer title should be an h1.  For accessibility reasons it actually needs to be an h2.  This PR corrects that assumption. 