### PR TITLE
Accessibility Fix: Hide DisplayInput if html input is hidden

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -92,7 +92,7 @@ class DisplayInput extends React.Component {
 
     return (
       <Container className='mx-display-input'>
-        <div style={Object.assign({}, styles.wrapper, this.props.isFocused ? styles.wrapperFocus : {})}>
+        <div aria-hidden={this.props.elementProps.disabled} style={Object.assign({}, styles.wrapper, this.props.isFocused ? styles.wrapperFocus : {})}>
           <Row>
             {this.props.label ? (
               <Column span={labelColumn}>


### PR DESCRIPTION
Fixes issue in Android TalkBack where disabled inputs are read out but not announced as disabled.