### PR TITLE
Changed className in drawer component for use in Cypress

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -271,7 +271,7 @@ class Drawer extends React.Component {
               tabIndex={0}
             >
               <header className='mx-drawer-header' style={{ ...styles.header, ...this.props.headerStyle }}>
-                <span style={styles.backArrow}>
+                <span className={`${titleUniqueId}-close`} style={styles.backArrow}>
                   {this.props.showCloseButton &&
                     <Button
                       aria-label={`Close ${this.props.title} Drawer`}


### PR DESCRIPTION
Made this change for Cypress testing. When trying to navigate out of the drawers that open when creating a sub budget, there was no easy way to distinguish between the elements in each drawer. As far as I can tell, the interpolation of this className is already mx-prefixed.