### PR TITLE
Drawer Component - Close Animation and Close Button Aria Label

### DIFF
--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -129,6 +129,10 @@ class DrawerDocs extends React.Component {
         <h5>animateLeftDistance<label>Number</label></h5>
         <p>This number represents the percent of the screen visible between the left edge of the screen and the left edge of the drawer.</p>
 
+        <h5>animateOnClose<label>bool</label></h5>
+        <p>Default: true</p>
+        <p>If passsed as false, prevents the drawer animation from running on close. Good for situations where you want to use the drawer's back button for something other than closing the drawer.</p>
+
         <h5>breakPoints<label>Object</label></h5>
         <p>This object takes 2 properties:</p>
         <ul style={styles.unorderdLists}>
@@ -140,6 +144,9 @@ class DrawerDocs extends React.Component {
           &#60;	large and &#62; medium: drawer width is 20% from left side <br />
           &#60;&#61; medium: drawer width is 100%
         </p>
+
+        <h5>closeButtonAriaLabel<label>String</label></h5>
+        <p>A string to be used as an aria-label on the drawer's back button. If not present, the drawer uses the title prop to construct the aria label instead.</p>
 
         <h5>closeOnScrimClick<label>Boolean</label></h5>
         <p>Default: true</p>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -67,6 +67,7 @@ class Drawer extends React.Component {
   };
 
   static defaultProps = {
+    animateOnClose: true,
     beforeClose: () => {},
     closeOnScrimClick: true,
     duration: 500,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -23,6 +23,7 @@ class Drawer extends React.Component {
   static propTypes = {
     'aria-describedby': PropTypes.string,
     'aria-labelledby': PropTypes.string,
+    animateOnClose: PropTypes.bool,
     animateLeftDistance: PropTypes.number,
     beforeClose: PropTypes.func,
     breakPoints: PropTypes.shape({
@@ -30,6 +31,7 @@ class Drawer extends React.Component {
       medium: PropTypes.number
     }),
     buttonPrimaryColor: PropTypes.string,
+    closeButtonAriaLabel: PropTypes.string,
     closeOnScrimClick: PropTypes.bool,
     contentStyle: PropTypes.oneOfType([
       PropTypes.array,

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -234,7 +234,7 @@ class Drawer extends React.Component {
   render () {
     const { theme } = this.state;
     const styles = this.styles(theme);
-    const { headerMenu, focusTrapProps, navConfig } = this.props;
+    const { closeButtonAriaLabel, headerMenu, focusTrapProps, navConfig } = this.props;
     const mergedFocusTrapProps = {
       focusTrapOptions: {
         clickOutsideDeactivates: true
@@ -282,7 +282,7 @@ class Drawer extends React.Component {
                 <span style={styles.backArrow}>
                   {this.props.showCloseButton &&
                     <Button
-                      aria-label={`Close ${this.props.title} Drawer`}
+                      aria-label={closeButtonAriaLabel || `Close ${this.props.title} Drawer`}
                       buttonRef={ref => (this._closeButton = ref)}
                       className='mx-drawer-close'
                       icon='go-back'

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -170,10 +170,15 @@ class Drawer extends React.Component {
    */
   close = () => {
     this.props.beforeClose();
-    return this._animateComponent({ left: '100%' })
-      .then(() => {
-        this.props.onClose();
-      });
+
+    if (this.props.animateOnClose) {
+      return this._animateComponent({ left: '100%' })
+        .then(() => {
+          this.props.onClose();
+        });
+    } else {
+      this.props.onClose();
+    }
   };
 
   open = () => {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -177,7 +177,12 @@ class Drawer extends React.Component {
           this.props.onClose();
         });
     } else {
-      return this.props.onClose();
+      // To keep close's api normalized we return a promise just
+      // as the _animateComponent function does above.
+      return Promise.resolve()
+        .then(() => {
+          this.props.onClose();
+        });
     }
   };
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -23,8 +23,8 @@ class Drawer extends React.Component {
   static propTypes = {
     'aria-describedby': PropTypes.string,
     'aria-labelledby': PropTypes.string,
-    animateOnClose: PropTypes.bool,
     animateLeftDistance: PropTypes.number,
+    animateOnClose: PropTypes.bool,
     beforeClose: PropTypes.func,
     breakPoints: PropTypes.shape({
       large: PropTypes.number,
@@ -177,7 +177,7 @@ class Drawer extends React.Component {
           this.props.onClose();
         });
     } else {
-      this.props.onClose();
+      return this.props.onClose();
     }
   };
 


### PR DESCRIPTION
We have a need internally to prevent the close animation from happening where we want to use the back button to update content in the drawer.  This PR does that by adding two new props.

- `animateOnClose` (Default `true`) `Bool`
- `closeButtonAriaLabel` `String`