### PR TITLE
Fix date range picker button style

### DIFF
--- a/docs/components/DateRangePickerDocs.js
+++ b/docs/components/DateRangePickerDocs.js
@@ -30,12 +30,14 @@ class DateRangePickerDocs extends React.Component {
         </h1>
 
         <h3>Demo</h3>
-        <DateRangePicker
-          onDateRangeSelect={this._handleDateRangeSelect}
-          selectedEndDate={this.state.selectedEndDate}
-          selectedStartDate={this.state.selectedStartDate}
-          showDefaultRanges={true}
-        />
+        <div style={{ width: '50%' }}>
+          <DateRangePicker
+            onDateRangeSelect={this._handleDateRangeSelect}
+            selectedEndDate={this.state.selectedEndDate}
+            selectedStartDate={this.state.selectedStartDate}
+            showDefaultRanges={true}
+          />
+        </div>
 
         <h3>Usage</h3>
         <h5>defaultRanges <label>Array of range option objects</label></h5>

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -549,6 +549,7 @@ class DateRangePicker extends React.Component {
       // Selected Date styles
       selectedDateButton: {
         alignItems: 'center',
+        backgroundColor: 'unset',
         border: 'none',
         display: 'flex',
         justifyContent: 'space-between'

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -549,7 +549,7 @@ class DateRangePicker extends React.Component {
       // Selected Date styles
       selectedDateButton: {
         alignItems: 'center',
-        backgroundColor: 'unset',
+        backgroundColor: 'transparent',
         border: 'none',
         display: 'flex',
         justifyContent: 'space-between',

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -553,6 +553,7 @@ class DateRangePicker extends React.Component {
         border: 'none',
         display: 'flex',
         justifyContent: 'space-between',
+        margin: 0,
         padding: 0
       },
       selectedDateIcon: {

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -554,7 +554,8 @@ class DateRangePicker extends React.Component {
         display: 'flex',
         justifyContent: 'space-between',
         margin: 0,
-        padding: 0
+        padding: 0,
+        width: '100%'
       },
       selectedDateIcon: {
         fill: theme.Colors.PRIMARY,

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -552,7 +552,8 @@ class DateRangePicker extends React.Component {
         backgroundColor: 'unset',
         border: 'none',
         display: 'flex',
-        justifyContent: 'space-between'
+        justifyContent: 'space-between',
+        padding: 0
       },
       selectedDateIcon: {
         fill: theme.Colors.PRIMARY,


### PR DESCRIPTION
I just recently changed the selected date in the DateRangePicker from a link to a button and in doing so, I jacked up its styling.  This PR fixes that mistake to restore how it used to look.

### Broken

![screen shot 2018-06-14 at 10 53 21 am](https://user-images.githubusercontent.com/6463914/41428676-02b5a652-6fc8-11e8-8781-b3772285c98e.png)

### Fixed

![screen shot 2018-06-14 at 10 52 29 am](https://user-images.githubusercontent.com/6463914/41428675-02918416-6fc8-11e8-846c-d608e7f616ec.png)
