### PR TITLE
Add a styles prop to Button that can override any style in the button

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -34,6 +34,7 @@ class Button extends React.Component {
     elementProps: {},
     onClick () {},
     isActive: false,
+    styles: {},
     type: 'primary'
   };
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -25,6 +25,7 @@ class Button extends React.Component {
     onClick: PropTypes.func,
     primaryColor: PropTypes.string,
     style: PropTypes.object,
+    styles: PropTypes.object,
     theme: themeShape,
     type: PropTypes.oneOf(buttonTypes)
   };
@@ -68,6 +69,9 @@ class Button extends React.Component {
     const mergedTheme = StyleUtils.mergeTheme(theme, primaryColor);
     const styles = this.styles(mergedTheme);
 
+    // We need to remove the styles prop from rest so we don't pass it to children.
+    delete rest.styles;
+
     return (
       <button
         className={'mx-button ' + css({ ...styles.component, ...styles[this.props.type], ...style }) + ' ' + (className || '')}
@@ -101,7 +105,7 @@ class Button extends React.Component {
     const windowSizeIsSmall = this._windowSizeIsSmall(theme);
 
     return {
-      component: Object.assign({
+      component: {
         borderRadius: 2,
         borderStyle: 'solid',
         borderWidth: 1,
@@ -114,8 +118,9 @@ class Button extends React.Component {
         cursor: this.props.type === 'disabled' ? 'default' : 'pointer',
         transition: 'all .2s ease-in',
         minWidth: 16,
-        position: 'relative'
-      }, this.props.style),
+        position: 'relative',
+        ...this.props.style
+      },
       children: {
         justifyContent: 'center',
         display: 'flex',
@@ -245,7 +250,8 @@ class Button extends React.Component {
       },
       buttonText: {
         marginLeft: (this.props.isActive && this.props.actionText) ? 10 : 0
-      }
+      },
+      ...this.props.styles
     };
   };
 }


### PR DESCRIPTION
I didn't move `style` prop around since that would be a major breaking change to the button's api. That prop only gets merged into the `component` style key.