### PR TITLE
Apply glamour and remove radium to Button Group

### DIFF
--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const Radium = require('radium');
+
+import { css } from 'glamor';
 
 import { withTheme } from './Theme';
 const Button = require('./Button');
@@ -50,14 +51,15 @@ class ButtonGroup extends React.Component {
 
           return (
             <Button
+              className={css(isDisabled && styles.disabled)}
               key={i}
               style={Object.assign({},
                 styles.component,
                 isFirstChild && styles.firstChild,
                 isLastChild && styles.lastChild,
                 isOnlyChild && styles.onlyChild,
-                isDisabled && styles.disabled,
-                style)}
+                style
+              )}
               theme={theme}
               type={this.props.type}
               {...rest}
@@ -107,4 +109,4 @@ class ButtonGroup extends React.Component {
   };
 }
 
-module.exports = withTheme(Radium(ButtonGroup));
+module.exports = withTheme(ButtonGroup);


### PR DESCRIPTION
- So I move only `styles.disabled` into glamor, the rest of it I use regular in-line style. 

- For some reasons, if I put it all into glamor, the style will be overwritten.