### PR TITLE
typo in search input

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -36,7 +36,7 @@ class SearchInput extends React.Component {
     const searchIconProps =
       { size: 20, style: styles.searchIcon };
     const closeIconProps =
-      { size: 20, style: styles.closeIconIcon };
+      { size: 20, style: styles.closeIcon };
 
     return (
       <div className='mx-search-input' style={Object.assign({}, styles.component, this.props.style)}>


### PR DESCRIPTION
Left a typo in there.

![screen shot 2018-07-17 at 3 12 13 pm](https://user-images.githubusercontent.com/1081167/42845637-d4327500-89d3-11e8-85b4-497492fa3647.png)

Icon is styled appropriately now.