### PR TITLE
Focus Trap - Manage zIndex level of traps

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -238,92 +238,97 @@ class Drawer extends React.Component {
   };
 
   render () {
-    const { theme } = this.state;
-    const styles = this.styles(theme);
-    const { closeButtonAriaLabel, headerMenu, focusTrapProps, navConfig, portalTo } = this.props;
     const mergedFocusTrapProps = {
       focusTrapOptions: {
         clickOutsideDeactivates: true,
-        portalTo
+        portalTo: this.props.portalTo
       },
       paused: false,
-      ...focusTrapProps
+      ...this.props.focusTrapProps
     };
-
-    let menu = null;
-
-    // If headerMenu is a function then we want to pass the Drawer's
-    // exposed functions to the call.
-    if (typeof headerMenu === 'function') {
-      menu = headerMenu(this._getExposedDrawerFunctions());
-    // If headerMenu is a normal node/element then use directly.
-    } else if (headerMenu) {
-      menu = headerMenu;
-    // If no headerMenu and navConfig passed then use Drawer's
-    // _renderNav function to generate the menu.
-    } else if (navConfig) {
-      menu = this._renderNav(navConfig, styles, theme);
-    }
-    const titleUniqueId = _uniqueId('mx-drawer-title-');
 
     return (
       <StyleRoot>
         <MXFocusTrap {...mergedFocusTrapProps}>
-          <div className='mx-drawer' onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
-            <div
-              className='mx-drawer-scrim'
-              onClick={() => {
-                if (this.props.closeOnScrimClick) this.close();
-              }}
-              style={styles.scrim}
-            />
-            <div
-              aria-describedby={this.props['aria-describedby']}
-              aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
-              ref={(ref) => (this._component = ref)}
-              role={this.props.role}
-              style={{ ...styles.component, ...this.props.style }}
-              tabIndex={0}
-            >
-              <header className='mx-drawer-header' style={{ ...styles.header, ...this.props.headerStyle }}>
-                <span style={styles.backArrow}>
-                  {this.props.showCloseButton &&
-                    <Button
-                      aria-label={closeButtonAriaLabel || `Close ${this.props.title} Drawer`}
-                      buttonRef={ref => (this._closeButton = ref)}
-                      className='mx-drawer-close'
-                      icon='go-back'
-                      onClick={this.close}
-                      theme={theme}
-                      type={'base'}
-                    />
-                  }
-                </span>
-                <h2 id={titleUniqueId} style={styles.title}>
-                  {this.props.title}
-                </h2>
-                <div className='mx-drawer-header-menu' style={styles.headerMenu}>
-                  {menu}
+          {trapNumber => {
+            const { theme } = this.state;
+            const styles = this.styles(theme, trapNumber);
+            const { closeButtonAriaLabel, headerMenu, navConfig } = this.props;
+
+            let menu = null;
+
+            // If headerMenu is a function then we want to pass the Drawer's
+            // exposed functions to the call.
+            if (typeof headerMenu === 'function') {
+              menu = headerMenu(this._getExposedDrawerFunctions());
+            // If headerMenu is a normal node/element then use directly.
+            } else if (headerMenu) {
+              menu = headerMenu;
+            // If no headerMenu and navConfig passed then use Drawer's
+            // _renderNav function to generate the menu.
+            } else if (navConfig) {
+              menu = this._renderNav(navConfig, styles, theme);
+            }
+            const titleUniqueId = _uniqueId('mx-drawer-title-');
+
+            return (
+              <div className='mx-drawer' onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
+                <div
+                  className='mx-drawer-scrim'
+                  onClick={() => {
+                    if (this.props.closeOnScrimClick) this.close();
+                  }}
+                  style={styles.scrim}
+                />
+                <div
+                  aria-describedby={this.props['aria-describedby']}
+                  aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
+                  ref={(ref) => (this._component = ref)}
+                  role={this.props.role}
+                  style={{ ...styles.component, ...this.props.style }}
+                  tabIndex={0}
+                >
+                  <header className='mx-drawer-header' style={{ ...styles.header, ...this.props.headerStyle }}>
+                    <span style={styles.backArrow}>
+                      {this.props.showCloseButton &&
+                        <Button
+                          aria-label={closeButtonAriaLabel || `Close ${this.props.title} Drawer`}
+                          buttonRef={ref => (this._closeButton = ref)}
+                          className='mx-drawer-close'
+                          icon='go-back'
+                          onClick={this.close}
+                          theme={theme}
+                          type={'base'}
+                        />
+                      }
+                    </span>
+                    <h2 id={titleUniqueId} style={styles.title}>
+                      {this.props.title}
+                    </h2>
+                    <div className='mx-drawer-header-menu' style={styles.headerMenu}>
+                      {menu}
+                    </div>
+                  </header>
+                  <div className='mx-drawer-content' style={{ ...styles.content, ...this.props.contentStyle }}>
+                    {typeof this.props.children === 'function' ? this.props.children(this._getExposedDrawerFunctions()) : this.props.children}
+                  </div>
                 </div>
-              </header>
-              <div className='mx-drawer-content' style={{ ...styles.content, ...this.props.contentStyle }}>
-                {typeof this.props.children === 'function' ? this.props.children(this._getExposedDrawerFunctions()) : this.props.children}
               </div>
-            </div>
-          </div>
+            );
+          }}
         </MXFocusTrap>
       </ StyleRoot>
     );
   }
 
-  styles = (theme) => {
+  styles = (theme, trapNumber = 1) => {
     const HEADER_HEIGHT = this._getHeaderHeight();
 
     return _merge({}, {
       component: {
         border: '1px solid ' + theme.Colors.GRAY_300,
         boxSizing: 'border-box',
-        zIndex: 1001,
+        zIndex: trapNumber * 1002,
         top: 0,
         bottom: 0,
         left: '100%',
@@ -345,7 +350,7 @@ class Drawer extends React.Component {
         position: 'fixed',
         right: 0,
         top: 0,
-        zIndex: 999
+        zIndex: trapNumber * 1000
       },
       content: {
         backgroundColor: theme.Colors.WHITE,
@@ -353,7 +358,7 @@ class Drawer extends React.Component {
         height: `calc(100% - ${HEADER_HEIGHT})`
       },
       scrim: {
-        zIndex: 1000,
+        zIndex: trapNumber * 1001,
         position: 'fixed',
         top: 0,
         right: 0,

--- a/src/components/MXFocusTrap.js
+++ b/src/components/MXFocusTrap.js
@@ -35,6 +35,8 @@ class MXFocusTrap extends React.Component {
     });
     traps.push(this);
 
+    this._trapNumber = traps.length;
+
     this._siblingNodeToRenderNextTo = this._getSiblingNodeToRenderNextTo(
       _get(this.props, 'focusTrapOptions.portalTo', null)
     );
@@ -83,7 +85,7 @@ class MXFocusTrap extends React.Component {
       return ReactDOM.createPortal(
         (
           <FocusTrap {...this.props} paused={this.state.paused}>
-            {this.props.children}
+            {this.props.children(this._trapNumber)}
           </FocusTrap>
         ),
         this._siblingNodeToRenderNextTo.parentNode
@@ -93,7 +95,7 @@ class MXFocusTrap extends React.Component {
     // Render in normal location
     return (
       <FocusTrap {...this.props} paused={this.state.paused}>
-        {this.props.children}
+        {this.props.children(this._trapNumber)}
       </FocusTrap>
     );
   }

--- a/src/components/MXFocusTrap.js
+++ b/src/components/MXFocusTrap.js
@@ -85,7 +85,7 @@ class MXFocusTrap extends React.Component {
       return ReactDOM.createPortal(
         (
           <FocusTrap {...this.props} paused={this.state.paused}>
-            {this.props.children(this._trapNumber)}
+            {typeof this.props.children === 'function' ? this.props.children(this._trapNumber) : this.props.children}
           </FocusTrap>
         ),
         this._siblingNodeToRenderNextTo.parentNode
@@ -95,7 +95,7 @@ class MXFocusTrap extends React.Component {
     // Render in normal location
     return (
       <FocusTrap {...this.props} paused={this.state.paused}>
-        {this.props.children(this._trapNumber)}
+        {typeof this.props.children === 'function' ? this.props.children(this._trapNumber) : this.props.children}
       </FocusTrap>
     );
   }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -189,8 +189,6 @@ class Modal extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.color);
-    const styles = this.styles(theme);
     const mergedFocusTrapProps = {
       focusTrapOptions: {
         clickOutsideDeactivates: true,
@@ -201,53 +199,60 @@ class Modal extends React.Component {
 
     return (
       <MXFocusTrap {...mergedFocusTrapProps}>
-        <div className='mx-modal' style={Object.assign({}, styles.scrim, this.props.isRelative && styles.relative)}>
-          <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)} />
-          <div
-            style={Object.assign({}, styles.container, this.props.style)}
-          >
-            {this._renderTitleBar(styles)}
-            <div
-              aria-describedby={this.props['aria-describedby']}
-              aria-label={this.props['aria-label']}
-              aria-labelledby={this.props['aria-labelledby']}
-              className='mx-modal-content'
-              ref={ref => this._modalContent = ref}
-              role={this.props.role}
-              style={Object.assign({}, styles.content, this.props.contentStyle)}
-              tabIndex={0}
-            >
-              {this.props.children}
-              {this._renderTooltip(styles, theme)}
-            </div>
-            {this._renderFooter(styles, theme)}
-            {this.props.showCloseIcon && (
-              <button
-                aria-label='Close Modal'
-                className='mx-modal-close'
-                onClick={this.props.onRequestClose}
-                onKeyUp={e => e.keyCode === 13 && this.props.onRequestClose()}
-                role='button'
-                style={styles.close}
-                tabIndex={0}
+        {trapNumber => {
+          const theme = StyleUtils.mergeTheme(this.props.theme, this.props.color);
+          const styles = this.styles(theme, trapNumber);
+
+          return (
+            <div className='mx-modal' style={Object.assign({}, styles.scrim, this.props.isRelative && styles.relative)}>
+              <div className='mx-modal-scrim' onClick={this.props.onRequestClose} style={Object.assign({}, styles.scrim, styles.overlay, this.props.isRelative && styles.relative)} />
+              <div
+                style={Object.assign({}, styles.container, this.props.style)}
               >
-                <Icon
-                  size={24}
-                  style={styles.closeIcon}
-                  type='close-solid'
-                />
-              </button>
-            )}
-          </div>
-        </div>
+                {this._renderTitleBar(styles)}
+                <div
+                  aria-describedby={this.props['aria-describedby']}
+                  aria-label={this.props['aria-label']}
+                  aria-labelledby={this.props['aria-labelledby']}
+                  className='mx-modal-content'
+                  ref={ref => this._modalContent = ref}
+                  role={this.props.role}
+                  style={Object.assign({}, styles.content, this.props.contentStyle)}
+                  tabIndex={0}
+                >
+                  {this.props.children}
+                  {this._renderTooltip(styles, theme)}
+                </div>
+                {this._renderFooter(styles, theme)}
+                {this.props.showCloseIcon && (
+                  <button
+                    aria-label='Close Modal'
+                    className='mx-modal-close'
+                    onClick={this.props.onRequestClose}
+                    onKeyUp={e => e.keyCode === 13 && this.props.onRequestClose()}
+                    role='button'
+                    style={styles.close}
+                    tabIndex={0}
+                  >
+                    <Icon
+                      size={24}
+                      style={styles.closeIcon}
+                      type='close-solid'
+                    />
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        }}
       </MXFocusTrap>
     );
   }
 
-  styles = theme => {
+  styles = (theme, trapNumber = 1) => {
     return _merge({}, {
       scrim: {
-        zIndex: 1000,
+        zIndex: trapNumber * 1000,
         position: 'fixed',
         top: 0,
         right: 0,
@@ -277,7 +282,7 @@ class Modal extends React.Component {
         fontFamily: theme.FontFamily,
         boxSizing: 'border-box',
         position: 'relative',
-        zIndex: 1001,
+        zIndex: trapNumber * 1001,
         backgroundColor: theme.Colors.WHITE,
         boxShadow: theme.ShadowHigh,
         borderRadius: 2,

--- a/src/components/__tests__/MXFocusTrap-test.js
+++ b/src/components/__tests__/MXFocusTrap-test.js
@@ -20,12 +20,22 @@ class WrappedMXFocusTrap extends React.Component {
           Modal Content
           {this.state.renderParentTrap ? (
             <MXFocusTrap focusTrapOptions={{ portalTo: '#app' }}>
-              <button>"Outer Focusable Button"</button>
-              {this.state.renderChildTrap ? (
-                <MXFocusTrap focusTrapOptions={{ portalTo: '#app' }}>
-                  <button>"Inner Focusable Button"</button>
-                </MXFocusTrap>
-              ) : null}
+              {trapNumber => {
+                return (
+                  <div>
+                    <button id='outer' style={{ zIndex: trapNumber }}>"Outer Focusable Button"</button>
+                    {this.state.renderChildTrap ? (
+                      <MXFocusTrap focusTrapOptions={{ portalTo: '#app' }}>
+                        {secondTrapNumber => {
+                          return (
+                            <button id='inner' style={{ zIndex: secondTrapNumber }}>"Inner Focusable Button"</button>
+                          );
+                        }}
+                      </MXFocusTrap>
+                    ) : null}
+                  </div>
+                );
+              }}
             </MXFocusTrap>
           ) : null}
         </div>
@@ -72,5 +82,17 @@ describe('MXFocusTrap', () => {
 
     wrapper.setState({ renderChildTrap: false });
     expect(parentTrap.html()).toContain('aria-hidden="false"');
+  });
+
+  it('should have the correct zIndex based upon trap number', () => {
+    wrapper.setState({ renderParentTrap: true });
+    const outerButton = wrapper.find('#outer').first();
+
+    expect(outerButton.html()).toContain('z-index: 1');
+
+    wrapper.setState({ renderChildTrap: true });
+    const innerButton = wrapper.find('#inner').first();
+
+    expect(innerButton.html()).toContain('z-index: 2');
   });
 });


### PR DESCRIPTION
When we use React Portals to render Focus Trapped content(Drawers, Modals) the content is appended to the DOM location chosen.  This causes issues where Multiple Drawers/Modals are rendered at once since all of the Drawer/Modals have the same z index value.

This PR solves the issue by passing a `trapNumber` to the children of the `MXFocusTrap` component so that they can use it to appropriately set zIndex values.  I also added extra tests for the `trapNumber` being passed to children.

FYI: I researched React Portals to see if we could prepend instead of append but it doesn't currently take any additional options to do so. :(

![screen shot 2018-08-02 at 12 13 56 pm](https://user-images.githubusercontent.com/6463914/43602655-d19902ce-964d-11e8-9aa2-57cb9b00a3d2.png)
![screen shot 2018-08-02 at 12 14 38 pm](https://user-images.githubusercontent.com/6463914/43602656-d1b7a378-964d-11e8-8f3a-0189b8a78baa.png)
![screen shot 2018-08-02 at 12 15 02 pm](https://user-images.githubusercontent.com/6463914/43602657-d1f4b3a8-964d-11e8-84b3-72cd7ec1e1f1.png)