### PR TITLE
Add new waffle icon to docs

### DIFF
--- a/src/constants/App.js
+++ b/src/constants/App.js
@@ -547,6 +547,10 @@ module.exports = {
       displayValue: 'Visit'
     },
     {
+      value: 'waffle',
+      displayValue: 'Waffle'
+    },
+    {
       value: 'windows',
       displayValue: 'Windows'
     },


### PR DESCRIPTION
New waffle icon wasn't showing up in the docs because we neglected to add it to the app constants.