### PR TITLE
DisplayInput disabled fix

### DIFF
--- a/docs/components/DisplayInputDocs.js
+++ b/docs/components/DisplayInputDocs.js
@@ -68,6 +68,18 @@ class DisplayInputDocs extends React.Component {
           valid={true}
         />
         <DisplayInput
+          elementProps={{
+            disabled: true,
+            id: 'input-id',
+            onFocus: this._handleInputFocus,
+            placeholder: 'Disabled Input',
+            value: 'Disabled'
+          }}
+          label='Disabled Display Input'
+          status={this.state.statusMessage}
+          valid={true}
+        />
+        <DisplayInput
           childrenStyle={{ backgroundColor: Styles.Colors.GRAY_100 }}
           label='Display Children'
         >
@@ -130,7 +142,8 @@ class DisplayInputDocs extends React.Component {
         {`
           <DisplayInput
             elementProps={{
-              onChange: myOnChangeCallbackFunction
+              disabled: true,
+              onChange: myOnChangeCallbackFunction,
               placeholder: 'Type something'
             }}
             label='Display Input'

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -92,7 +92,7 @@ class DisplayInput extends React.Component {
 
     return (
       <Container className='mx-display-input'>
-        <div aria-hidden={this.props.elementProps.disabled} style={Object.assign({}, styles.wrapper, this.props.isFocused ? styles.wrapperFocus : {})}>
+        <div style={Object.assign({}, styles.wrapper, this.props.isFocused ? styles.wrapperFocus : {})}>
           <Row>
             {this.props.label ? (
               <Column span={labelColumn}>

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -73,6 +73,7 @@ class DisplayInput extends React.Component {
   render () {
     // Input properties
     const { elementProps } = this.props;
+    const { disabled, onChange, ...rest } = elementProps;
 
     // Methods
     const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
@@ -110,10 +111,12 @@ class DisplayInput extends React.Component {
               ) : (
                 <div style={styles.inputWrapper}>
                   <input
-                    {...elementProps}
+                    {...rest}
+                    aria-disabled={disabled}
                     aria-labelledby={this.props.label ? this._labelId : null}
                     id={this._inputId}
                     key='input'
+                    onChange={disabled ? null : onChange}
                     ref={this.props.elementRef}
                     style={styles.input}
                   />

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -72,8 +72,7 @@ class DisplayInput extends React.Component {
 
   render () {
     // Input properties
-    const { elementProps } = this.props;
-    const { disabled, onChange, ...rest } = elementProps;
+    const { disabled, onChange, ...rest } = this.props.elementProps;
 
     // Methods
     const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);


### PR DESCRIPTION
Before, we would hide the input via the `aria-hidden` attribute if `disabled: true` was passed int he `elementProps` prop.  This was not meeting a11y standards as visually impaired users became completely unaware of the field rather than being notified of it but that is was disabled.

This PR fixes the issue by desctructuring `disabled` and `onChange` from the `elementProps` prop and applying them correctly to the input.

I also updated the docs with an example of a disabled DisplayInput.

### Screen shot

Notice the `aria-disabled` attribute on the input

![screen shot 2018-08-13 at 2 33 18 pm](https://user-images.githubusercontent.com/6463914/44056879-d4941c68-9f06-11e8-83dd-b2625860db5e.png)
