### PR TITLE
Remove deprecated props #3

### DIFF
--- a/docs/components/Components.js
+++ b/docs/components/Components.js
@@ -161,6 +161,7 @@ class Components extends React.Component {
 
           <div className='links'>
             <h3>General</h3>
+            <Link to='/components/drawer'>Drawer</Link>
             <Link to='/components/icon'>Icon</Link>
             <Link to='/components/raja-icon'>Raja Icon</Link>
             <Link to='/components/loader'>Loader</Link>
@@ -182,7 +183,6 @@ class Components extends React.Component {
             <Link to='/components/date-range-picker'>Date Range Picker</Link>
             <Link to='/components/date-time-picker'>Date Time Picker</Link>
             <Link to='/components/display-input'>Display Input</Link>
-            <Link to='/components/drawer'>Drawer</Link>
             <Link to='/components/file-upload'>File Upload</Link>
             <Link to='/components/radio-button'>Radio Button</Link>
             <Link to='/components/range-selector'>Range Selector</Link>

--- a/docs/components/DrawerDocs.js
+++ b/docs/components/DrawerDocs.js
@@ -216,14 +216,6 @@ class DrawerDocs extends React.Component {
         <p>Default: ''</p>
         <p>This will be displayed in the header of the drawer component. It is also used to make the aria label for the drawer's close button more descriptive.</p>
 
-        <h5>DEPRECATED: navConfig <label>Object</label></h5>
-        <p>This object requires 3 properties:</p>
-        <ul style={styles.unorderdLists}>
-          <li style={styles.listItem}><h5 style={styles.h5ListItem}>label <label>String</label></h5>This will be displayed between the two arrow buttons.</li>
-          <li style={styles.listItem}><h5 style={styles.h5ListItem}>onPreviousClick <label>Function</label></h5> This function will be called when the left arrow is clicked.</li>
-          <li style={styles.listItem}><h5 style={styles.h5ListItem}>onNextClick <label>Function</label></h5> this function will be called when the right arrow is clicked.</li>
-        </ul>
-
         <h3>Normal Example</h3>
         <Markdown>
   {`

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -12,7 +12,6 @@ const Row = require('./grid/Row');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 const MAX_HOUR = 23;
 const MAX_MINUTE = 59;
@@ -28,7 +27,6 @@ class DatePicker extends React.Component {
     locale: PropTypes.string,
     minimumDate: PropTypes.number,
     onDateSelect: PropTypes.func,
-    primaryColor: PropTypes.string,
     selectedDate: PropTypes.number,
     showIcons: PropTypes.bool,
     styles: PropTypes.object,
@@ -69,10 +67,6 @@ class DatePicker extends React.Component {
     showCalendar: false,
     editTime: false
   };
-
-  componentDidMount () {
-    deprecatePrimaryColor(this.props);
-  }
 
   _toggleCalendar = () => {
     this.setState({
@@ -148,7 +142,7 @@ class DatePicker extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
     const spans = this.spans();
 

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -12,7 +12,6 @@ const Row = require('../components/grid/Row');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class DisplayInput extends React.Component {
   static propTypes = {
@@ -24,7 +23,6 @@ class DisplayInput extends React.Component {
     label: PropTypes.string,
     labelStyle: PropTypes.object,
     placeholder: PropTypes.string,
-    primaryColor: PropTypes.string,
     showHint: PropTypes.bool,
     status: PropTypes.shape({
       type: PropTypes.string,
@@ -46,10 +44,6 @@ class DisplayInput extends React.Component {
   componentWillMount () {
     this._labelId = _uniqueId('DI');
     this._inputId = this.props.elementProps.id || _uniqueId('DI');
-  }
-
-  componentDidMount () {
-    deprecatePrimaryColor(this.props);
   }
 
   _isLargeOrMediumWindowSize = (theme) => {
@@ -75,7 +69,7 @@ class DisplayInput extends React.Component {
     const { elementProps } = this.props;
 
     // Methods
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const hasChildren = !!this.props.children;
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize(theme);
     const showHint = this.props.showHint && !this.props.status && isLargeOrMediumWindowSize;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -17,7 +17,6 @@ const MXFocusTrap = require('../components/MXFocusTrap');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class Drawer extends React.Component {
   static propTypes = {
@@ -30,7 +29,6 @@ class Drawer extends React.Component {
       large: PropTypes.number,
       medium: PropTypes.number
     }),
-    buttonPrimaryColor: PropTypes.string,
     closeButtonAriaLabel: PropTypes.string,
     closeOnScrimClick: PropTypes.bool,
     contentStyle: PropTypes.oneOfType([
@@ -86,7 +84,7 @@ class Drawer extends React.Component {
   constructor (props) {
     super(props);
 
-    const theme = StyleUtils.mergeTheme(props.theme, props.buttonPrimaryColor);
+    const theme = StyleUtils.mergeTheme(props.theme);
     const breakPoints = props.breakPoints || theme.BreakPoints;
 
     this.state = { breakPoints, theme };
@@ -97,7 +95,6 @@ class Drawer extends React.Component {
   }
 
   componentDidMount () {
-    deprecatePrimaryColor(this.props, 'buttonPrimaryColor');
     this.open();
     window.addEventListener('resize', this._resizeThrottled);
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -48,11 +48,6 @@ class Drawer extends React.Component {
       PropTypes.object
     ]),
     maxWidth: PropTypes.number,
-    navConfig: PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      onNextClick: PropTypes.func.isRequired,
-      onPreviousClick: PropTypes.func.isRequired
-    }),
     onClose: PropTypes.func.isRequired,
     onKeyUp: PropTypes.func,
     onOpen: PropTypes.func,
@@ -212,32 +207,10 @@ class Drawer extends React.Component {
     this._animateComponent({ left: this._getAnimationDistance() }, { duration: 0 });
   };
 
-  _renderNav = (navConfig, styles, theme) => {
-    return (
-      <nav style={styles.nav}>
-        <Button
-          icon='caret-left'
-          onClick={navConfig.onPreviousClick}
-          theme={theme}
-          type='base'
-        />
-        <span style={styles.navLabel}>
-          {navConfig.label}
-        </span>
-        <Button
-          icon='caret-right'
-          onClick={navConfig.onNextClick}
-          theme={theme}
-          type='base'
-        />
-      </nav>
-    );
-  };
-
   render () {
     const { theme } = this.state;
     const styles = this.styles(theme);
-    const { closeButtonAriaLabel, headerMenu, focusTrapProps, navConfig, portalTo } = this.props;
+    const { closeButtonAriaLabel, headerMenu, focusTrapProps, portalTo } = this.props;
     const mergedFocusTrapProps = {
       focusTrapOptions: {
         clickOutsideDeactivates: true,
@@ -247,20 +220,8 @@ class Drawer extends React.Component {
       ...focusTrapProps
     };
 
-    let menu = null;
+    const menu = typeof headerMenu === 'function' ? headerMenu(this._getExposedDrawerFunctions()) : headerMenu;
 
-    // If headerMenu is a function then we want to pass the Drawer's
-    // exposed functions to the call.
-    if (typeof headerMenu === 'function') {
-      menu = headerMenu(this._getExposedDrawerFunctions());
-    // If headerMenu is a normal node/element then use directly.
-    } else if (headerMenu) {
-      menu = headerMenu;
-    // If no headerMenu and navConfig passed then use Drawer's
-    // _renderNav function to generate the menu.
-    } else if (navConfig) {
-      menu = this._renderNav(navConfig, styles, theme);
-    }
     const titleUniqueId = _uniqueId('mx-drawer-title-');
 
     return (
@@ -400,16 +361,6 @@ class Drawer extends React.Component {
         textAlign: 'right',
         whiteSpace: 'nowrap',
         width: '25%'
-      },
-      navLabel: {
-        padding: '7px 14px',
-        position: 'relative',
-        bottom: 5,
-
-        '@media (max-width: 750px)': {
-          display: 'none',
-          padding: 0
-        }
       }
     }, this.props.styles);
   };


### PR DESCRIPTION
https://github.com/mxenabled/mx-react-components/issues/778

Removes deprecated props for 

- DateTimePicker
- DisplayInput
- Drawer

![screen shot 2018-08-14 at 11 27 10 am](https://user-images.githubusercontent.com/6463914/44107576-14d58c22-9fb5-11e8-91ca-626c5e117e8a.png)
![screen shot 2018-08-14 at 11 27 24 am](https://user-images.githubusercontent.com/6463914/44107577-14ee6d46-9fb5-11e8-918e-e1f70eb9c41b.png)
![screen shot 2018-08-14 at 11 27 38 am](https://user-images.githubusercontent.com/6463914/44107578-1504b074-9fb5-11e8-91c5-de25788c9111.png)
