### PR TITLE
Remove deprecated props #5

### DIFF
--- a/docs/components/RadioButtonDocs.js
+++ b/docs/components/RadioButtonDocs.js
@@ -35,7 +35,6 @@ class RadioButtonDocs extends React.Component {
           activeButtonStyle={{ backgroundColor: '#FBB600' }}
           buttonStyle={{ height: 30, width: 30 }}
           checked={this.state.selected === 'custom'}
-          color='#FBB600'
           onClick={this._handleRadioClick.bind(null, 'custom')}
           style={{ marginTop: 20 }}
         >
@@ -71,7 +70,6 @@ class RadioButtonDocs extends React.Component {
               activeButtonStyle={{ backgroundColor: '#FBB600' }}
               buttonStyle={{ height: 30, width: 30 }}
               checked={true}
-              color='#FBB600'
               onClick={this._handleRadioClick}
               style={{ marginTop: 20 }}
             >

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -5,14 +5,12 @@ import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class RadioButton extends React.Component {
   static propTypes = {
     activeButtonStyle: PropTypes.object,
     buttonStyle: PropTypes.object,
     checked: PropTypes.bool,
-    color: PropTypes.string,
     elementRef: PropTypes.func,
     onClick: PropTypes.func,
     style: PropTypes.object,
@@ -23,12 +21,8 @@ class RadioButton extends React.Component {
     onClick: () => {}
   };
 
-  componentDidMount () {
-    deprecatePrimaryColor(this.props);
-  }
-
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.color);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
 
     return (

--- a/src/components/RangeSelector.js
+++ b/src/components/RangeSelector.js
@@ -8,7 +8,6 @@ import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class RangeSelector extends React.Component {
   static propTypes = {
@@ -21,7 +20,6 @@ class RangeSelector extends React.Component {
     onLowerDragStop: PropTypes.func,
     onUpperDragStop: PropTypes.func,
     presets: PropTypes.array,
-    selectedColor: PropTypes.string,
     theme: themeShape,
     updateOnDrag: PropTypes.bool,
     upperBound: PropTypes.number
@@ -61,7 +59,6 @@ class RangeSelector extends React.Component {
   }
 
   componentDidMount () {
-    deprecatePrimaryColor(this.props);
     this._setDefaultRangeValues();
 
     window.addEventListener('resize', _throttle(this._setDefaultRangeValues, 300));
@@ -231,7 +228,7 @@ class RangeSelector extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.selectedColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
 
     return (

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -12,7 +12,6 @@ const { Listbox, Option } = require('./accessibility/Listbox');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 // returns a function that takes a click event, stops it, then calls the callback
 const haltEvent = callback => e => {
@@ -37,7 +36,6 @@ class Select extends React.Component {
     optionStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     optionTextStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     placeholderText: PropTypes.string,
-    primaryColor: PropTypes.string,
     scrimStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     selected: optionShape,
     selectedStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
@@ -59,10 +57,6 @@ class Select extends React.Component {
       isOpen: false,
       selected: props.selected
     };
-  }
-
-  componentDidMount () {
-    deprecatePrimaryColor(this.props);
   }
 
   componentWillReceiveProps (newProps) {
@@ -190,7 +184,7 @@ class Select extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.primaryColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
     const selected = this.state.selected || this.props.selected || { displayValue: this.props.placeholderText, value: '' };
 


### PR DESCRIPTION
https://github.com/mxenabled/mx-react-components/issues/778

Removes deprecated props in

- RadioButton
- RangeSelector
- Select

![screen shot 2018-08-14 at 2 38 18 pm](https://user-images.githubusercontent.com/6463914/44117439-80bf2b44-9fd0-11e8-8f8c-b66942e7b8e6.png)
![screen shot 2018-08-14 at 2 38 33 pm](https://user-images.githubusercontent.com/6463914/44117440-80d3b938-9fd0-11e8-8645-fb2e3046cace.png)
![screen shot 2018-08-14 at 2 38 56 pm](https://user-images.githubusercontent.com/6463914/44117441-80e82864-9fd0-11e8-96c5-2491b1665119.png)
