### PR TITLE
Remove deprecated props #6

### DIFF
--- a/docs/components/SimpleInputDocs.js
+++ b/docs/components/SimpleInputDocs.js
@@ -46,9 +46,6 @@ class SimpleInputDocs extends React.Component {
         />
 
         <h3>Usage</h3>
-        <h5>baseColor <label>String</label></h5>
-        <p>The color of the <Code>input</Code> border on focus.</p>
-        <p>*This prop is deprecated, please use <Code>theme</Code> instead.</p>
 
         <h5>elementProps <label>Object</label></h5>
         <p>Pass props directly to the <Code>input</Code> element. ie. placeholder, value, onchange, etc.</p>
@@ -59,20 +56,8 @@ class SimpleInputDocs extends React.Component {
         <h5>focusOnLoad <label>Boolean</label></h5>
         <p>Focus <Code>input</Code> on load, default of false.</p>
 
-        <h5>handleResetClick <label>Function</label></h5>
-        <p>The function that will execute when <Code>rightIcon</Code> is clicked. This prop will not work properly unless <Code>rightIcon</Code> is also declared. </p>
-        <p>*This prop is deprecated, please use <Code>suffix</Code> by passing an element with a click handler instead.</p>
-
-        <h5>icon <label>String || Object</label></h5>
-        <p>The type of icon as a string or an object describing the props passed to the Icon component to display on the left side of the <Code>input</Code></p>
-        <p>*This prop is deprecated, please use <Code>prefix</Code> instead.</p>
-
         <h5>prefix <label>Node</label></h5>
         <p>Anything that can be rendered: numbers, strings, elements or an array(or fragment) containing these types that is placed on the left side of the <Code>input</Code>.</p>
-
-        <h5>rightIcon <label>String || Object</label></h5>
-        <p>The type of icon as a string or an object describing the props passed to the Icon component to display on the right side of the <Code>input</Code></p>
-        <p>*This prop is deprecated, please use <Code>suffix</Code> instead.</p>
 
         <h5>styles <label>Object</label></h5>
         <p>Allows style additions or overrides to specific component elements including:</p>

--- a/docs/components/SimpleSelectDocs.js
+++ b/docs/components/SimpleSelectDocs.js
@@ -15,13 +15,11 @@ class SimpleSelectDocs extends React.Component {
 
   _handleItemClick = (e, item) => {
     this._toggleMenu();
-    this.setState({ selectedItem: item });
+    this.setState({ selectedItem: item.text });
   };
 
   _toggleMenu = () => {
-    this.setState({
-      showMenu: !this.state.showMenu
-    });
+    this.setState(state => ({ showMenu: !state.showMenu }));
   };
 
   render () {
@@ -33,25 +31,30 @@ class SimpleSelectDocs extends React.Component {
         </h1>
 
         <h3>Demo</h3>
-        <div style={{ width: 177 }}>
-          <Button
-            icon='gear'
-            onClick={this._toggleMenu}
-            type='neutral'
-          >
-            Settings
-          </Button>
-          {this.state.showMenu ? (
-            <SimpleSelect
-              aria-label='Select a category'
-              items={[
-                { icon: 'auto', text: 'Auto', onClick: this._handleItemClick },
-                { icon: 'kids', isSelected: true, text: 'Kids', onClick: this._handleItemClick },
-                { icon: 'pets', text: 'Pets', onClick: this._handleItemClick }
-              ]}
-              onScrimClick={this._toggleMenu}
-            />
-          ) : null}
+        <div style={{ alignItems: 'center', display: 'flex', width: 177 }}>
+          <span>
+            <Button
+              icon='gear'
+              onClick={this._toggleMenu}
+              type='neutral'
+            >
+              Settings
+            </Button>
+            {this.state.showMenu ? (
+              <SimpleSelect
+                aria-label='Select a category'
+                items={[
+                  { icon: 'auto', text: 'Auto', onClick: this._handleItemClick },
+                  { icon: 'kids', isSelected: true, text: 'Kids', onClick: this._handleItemClick },
+                  { icon: 'pets', text: 'Pets', onClick: this._handleItemClick }
+                ]}
+                onScrimClick={this._toggleMenu}
+              />
+            ) : null}
+          </span>
+          <span style={{ marginLeft: 10 }}>
+            {this.state.selectedItem}
+          </span>
         </div>
 
         <h3>Usage</h3>
@@ -89,9 +92,7 @@ class SimpleSelectDocs extends React.Component {
     },
 
     _toggleMenu () {
-      this.setState({
-        showMenu: !this.state.showMenu
-      });
+      this.setState(state => ({ showMenu: !state.showMenu }));
     },
 
     <div>

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -9,13 +9,11 @@ const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
 const {
-  deprecatePrimaryColor,
   deprecateProp
 } = require('../utils/Deprecation');
 
 class SimpleInput extends React.Component {
   static propTypes = {
-    baseColor: PropTypes.string,
     elementProps: PropTypes.object,
     elementRef: PropTypes.func,
     focusOnLoad: PropTypes.bool,
@@ -53,8 +51,6 @@ class SimpleInput extends React.Component {
   };
 
   componentDidMount () {
-    deprecatePrimaryColor(this.props, 'baseColor');
-
     /**
      * TODO:
      * icon, rightIcon, and handleResetClick are deprecated in
@@ -90,7 +86,7 @@ class SimpleInput extends React.Component {
 
   render () {
     const { elementProps, icon, prefix, rightIcon, suffix } = this.props;
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.baseColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
     const leftIconProps = typeof icon === 'string' ?
       { size: 20, style: styles.icon, type: icon } :

--- a/src/components/SimpleInput.js
+++ b/src/components/SimpleInput.js
@@ -3,30 +3,17 @@ const React = require('react');
 const _merge = require('lodash/merge');
 
 import { withTheme } from './Theme';
-const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const {
-  deprecateProp
-} = require('../utils/Deprecation');
 
 class SimpleInput extends React.Component {
   static propTypes = {
     elementProps: PropTypes.object,
     elementRef: PropTypes.func,
     focusOnLoad: PropTypes.bool,
-    handleResetClick: PropTypes.func,
-    icon: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object
-    ]),
     prefix: PropTypes.node,
-    rightIcon: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object
-    ]),
     //keep style for backwards compatibility
     style: PropTypes.oneOfType([
       PropTypes.array,
@@ -51,18 +38,6 @@ class SimpleInput extends React.Component {
   };
 
   componentDidMount () {
-    /**
-     * TODO:
-     * icon, rightIcon, and handleResetClick are deprecated in
-     * favor of new props prefix and suffix. They should be removed
-     * in the next major release.
-     */
-    const componentDocsURL = 'simple-input';
-
-    deprecateProp(this.props, 'icon', 'prefix', componentDocsURL);
-    deprecateProp(this.props, 'rightIcon', 'suffix', componentDocsURL);
-    deprecateProp(this.props, 'handleResetClick', 'suffix', componentDocsURL);
-
     if (this.props.focusOnLoad && this.elementRef) {
       this.elementRef.focus();
     }
@@ -85,29 +60,15 @@ class SimpleInput extends React.Component {
   };
 
   render () {
-    const { elementProps, icon, prefix, rightIcon, suffix } = this.props;
+    const { elementProps, prefix, suffix } = this.props;
     const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
-    const leftIconProps = typeof icon === 'string' ?
-      { size: 20, style: styles.icon, type: icon } :
-      icon;
-    const rightIconProps = typeof rightIcon === 'string' ?
-      { size: 20, style: styles.rightIcon, type: rightIcon } :
-      rightIcon;
 
     return (
       <div
         className='mx-simple-input'
         style={this.state.focus ? { ...styles.wrapper, ...styles.activeWrapper } : styles.wrapper}
       >
-        {this.props.icon ? (
-          <Icon
-            elementProps={{
-              onClick: () => this.elementRef && this.elementRef.focus()
-            }}
-            {...leftIconProps}
-          />
-        ) : null}
         {prefix ? prefix : null}
         <input
           {...elementProps}
@@ -121,14 +82,6 @@ class SimpleInput extends React.Component {
           type={this.props.type}
         />
         {suffix ? suffix : null}
-        {this.props.rightIcon ? (
-          <Icon
-            elementProps={{
-              onClick: this.props.handleResetClick
-            }}
-            {...rightIconProps}
-          />
-        ) : null}
       </div>
     );
   }
@@ -149,15 +102,6 @@ class SimpleInput extends React.Component {
       }, this.props.style),
       activeWrapper: {
         border: '1px solid ' + theme.Colors.PRIMARY
-      },
-      icon: {
-        paddingRight: 7,
-        fill: theme.Colors.PRIMARY
-      },
-      rightIcon: {
-        paddingLeft: theme.Spacing.XSMALL,
-        fill: theme.Colors.GRAY_300,
-        cursor: 'pointer'
       },
       input: {
         flex: '1 0 0%',

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -20,7 +20,6 @@ class SimpleSelect extends React.Component {
     elementRef: PropTypes.func,
     focusTrapProps: PropTypes.object,
     iconSize: PropTypes.number,
-    iconStyles: PropTypes.object,
     items: PropTypes.array.isRequired,
     itemStyles: PropTypes.object,
     menuStyles: PropTypes.object,
@@ -40,7 +39,6 @@ class SimpleSelect extends React.Component {
   };
 
   componentDidMount () {
-    deprecateProp(this.props, 'iconStyles', 'styles', 'simple-select');
     deprecateProp(this.props, 'menuStyles', 'styles', 'simple-select');
   }
 
@@ -152,9 +150,9 @@ class SimpleSelect extends React.Component {
           fill: theme.Colors.WHITE
         }
       }, this.props.itemStyles),
-      icon: Object.assign({}, {
+      icon: {
         marginRight: theme.Spacing.SMALL
-      }, this.props.iconStyles),
+      },
       text: {
         whiteSpace: 'nowrap'
       },

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -12,14 +12,13 @@ const MXFocusTrap = require('./MXFocusTrap');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor, deprecateProp } = require('../utils/Deprecation');
+const { deprecateProp } = require('../utils/Deprecation');
 
 class SimpleSelect extends React.Component {
   static propTypes = {
     'aria-label': PropTypes.string,
     elementRef: PropTypes.func,
     focusTrapProps: PropTypes.object,
-    hoverColor: PropTypes.string,
     iconSize: PropTypes.number,
     iconStyles: PropTypes.object,
     items: PropTypes.array.isRequired,
@@ -41,7 +40,6 @@ class SimpleSelect extends React.Component {
   };
 
   componentDidMount () {
-    deprecatePrimaryColor(this.props, 'hoverColor');
     deprecateProp(this.props, 'iconStyles', 'styles', 'simple-select');
     deprecateProp(this.props, 'menuStyles', 'styles', 'simple-select');
   }
@@ -54,7 +52,7 @@ class SimpleSelect extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.hoverColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
 
     const mergedFocusTrapProps = {

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -12,7 +12,6 @@ const MXFocusTrap = require('./MXFocusTrap');
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecateProp } = require('../utils/Deprecation');
 
 class SimpleSelect extends React.Component {
   static propTypes = {
@@ -22,7 +21,6 @@ class SimpleSelect extends React.Component {
     iconSize: PropTypes.number,
     items: PropTypes.array.isRequired,
     itemStyles: PropTypes.object,
-    menuStyles: PropTypes.object,
     onScrimClick: PropTypes.func,
     scrimClickOnSelect: PropTypes.bool,
     style: PropTypes.object,
@@ -37,10 +35,6 @@ class SimpleSelect extends React.Component {
     items: [],
     onScrimClick () {}
   };
-
-  componentDidMount () {
-    deprecateProp(this.props, 'menuStyles', 'styles', 'simple-select');
-  }
 
   _handleKeyUp = (e) => {
     if (keycode(e) === 'esc') {
@@ -118,8 +112,7 @@ class SimpleSelect extends React.Component {
         height: 0,
         position: 'relative'
       }, this.props.style),
-
-      menu: Object.assign({}, {
+      menu: {
         alignSelf: 'stretch',
         backgroundColor: theme.Colors.WHITE,
         borderRadius: 3,
@@ -134,8 +127,7 @@ class SimpleSelect extends React.Component {
         top: 10,
         position: 'absolute',
         zIndex: 10
-      }, this.props.menuStyles),
-
+      },
       item: Object.assign({}, {
         display: 'flex',
         alignItems: 'center',

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -20,7 +20,6 @@ class SimpleSelect extends React.Component {
     focusTrapProps: PropTypes.object,
     iconSize: PropTypes.number,
     items: PropTypes.array.isRequired,
-    itemStyles: PropTypes.object,
     onScrimClick: PropTypes.func,
     scrimClickOnSelect: PropTypes.bool,
     style: PropTypes.object,
@@ -128,7 +127,7 @@ class SimpleSelect extends React.Component {
         position: 'absolute',
         zIndex: 10
       },
-      item: Object.assign({}, {
+      item: {
         display: 'flex',
         alignItems: 'center',
         boxSizing: 'border-box',
@@ -141,7 +140,7 @@ class SimpleSelect extends React.Component {
           cursor: 'pointer',
           fill: theme.Colors.WHITE
         }
-      }, this.props.itemStyles),
+      },
       icon: {
         marginRight: theme.Spacing.SMALL
       },

--- a/src/components/SimpleSlider.js
+++ b/src/components/SimpleSlider.js
@@ -9,7 +9,6 @@ import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
 
 const StyleUtils = require('../utils/Style');
-const { deprecatePrimaryColor } = require('../utils/Deprecation');
 
 class SimpleSlider extends React.Component {
   static propTypes = {
@@ -17,7 +16,6 @@ class SimpleSlider extends React.Component {
     elementRef: PropTypes.func,
     onPercentChange: PropTypes.func.isRequired,
     percent: PropTypes.number.isRequired,
-    selectedColor: PropTypes.string,
     styles: PropTypes.object,
     theme: themeShape
   };
@@ -33,8 +31,6 @@ class SimpleSlider extends React.Component {
   };
 
   componentDidMount () {
-    deprecatePrimaryColor(this.props, 'selectedColor');
-
     const component = ReactDOM.findDOMNode(this.rangeSelectorRef);
     const width = component.clientWidth;
     const leftPixels = this.props.percent * width;
@@ -93,7 +89,7 @@ class SimpleSlider extends React.Component {
   };
 
   render () {
-    const theme = StyleUtils.mergeTheme(this.props.theme, this.props.selectedColor);
+    const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
     const { disabled } = this.props;
 

--- a/src/components/__tests__/SimpleInput-test.js
+++ b/src/components/__tests__/SimpleInput-test.js
@@ -25,22 +25,6 @@ describe('SimpleInput', () => {
     expect(children.last().html()).toEqual('<span>Suffix</span>');
   });
 
-  it('should render a icon to the left of the input if icon prop provided', () => {
-    // NOTE: this will log a warning in the console
-    const wrapper = mount(<SimpleInput icon='cash' />);
-    const children = wrapper.find('.mx-simple-input').first().children();
-
-    expect(children.first().type()).toEqual(Icon);
-  });
-
-  it('should render a icon to the right of the input if rightIcon prop provided', () => {
-    // NOTE: this will log a warning in the console
-    const wrapper = mount(<SimpleInput rightIcon='cash' />);
-    const children = wrapper.find('.mx-simple-input').first().children();
-
-    expect(children.last().type()).toEqual(Icon);
-  });
-
   it('should provide a ref to the input via the elementRef prop', () => {
     let inputRef;
 

--- a/src/components/__tests__/SimpleInput-test.js
+++ b/src/components/__tests__/SimpleInput-test.js
@@ -1,7 +1,6 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { mount } from 'enzyme';
 
-const Icon = require('../Icon');
 const SimpleInput = require('../SimpleInput');
 
 describe('SimpleInput', () => {


### PR DESCRIPTION
https://github.com/mxenabled/mx-react-components/issues/778

Removes deprecated props for

- SimpleInput
- SimpleSelect
- SimpleSlider

![screen shot 2018-08-14 at 3 27 38 pm](https://user-images.githubusercontent.com/6463914/44119502-aea7a026-9fd6-11e8-9597-f969d093eefc.png)
![screen shot 2018-08-14 at 3 27 53 pm](https://user-images.githubusercontent.com/6463914/44119503-aebca87c-9fd6-11e8-854c-46a875054c8e.png)
![screen shot 2018-08-14 at 3 28 12 pm](https://user-images.githubusercontent.com/6463914/44119504-aed19980-9fd6-11e8-97f8-bac88abb9705.png)
