### PR TITLE
Fix spacing for the date range picker.

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -560,7 +560,7 @@ class DateRangePicker extends React.Component {
       selectionContainer: {
         display: 'flex',
         flexDirection: 'column',
-        flex: '1 0 auto',
+        flex: '1 0 auto'
       },
       row: {
         display: 'flex',


### PR DESCRIPTION
Fixes the spacing for the date range picker. Notice the bottom left corner. 


Before:

![image](https://user-images.githubusercontent.com/758371/44664938-b3db5900-a9e2-11e8-96b1-c188496a2815.png)


After:

![image](https://user-images.githubusercontent.com/758371/44664926-ab831e00-a9e2-11e8-8176-ffd7b92d9086.png)
