### PR TITLE
MBD/updated prop type from string to include node

### DIFF
--- a/src/components/MessageBox.js
+++ b/src/components/MessageBox.js
@@ -16,7 +16,7 @@ class MessageBox extends React.Component {
     color: PropTypes.string,
     icon: PropTypes.string,
     isSmall: PropTypes.bool,
-    message: PropTypes.string,
+    message: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     styles: PropTypes.object,
     theme: themeShape,
     title: PropTypes.string


### PR DESCRIPTION
in the message box redesign released in the 6.0.0 release, the message prop was only a string. however, due to certain instances where this component is utilized, it makes more sense to change this prop type to oneOfType node or string