### PR TITLE
Remove radium and use glamor for the Drawer component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -237,13 +237,12 @@ class Drawer extends React.Component {
           <div
             aria-describedby={this.props['aria-describedby']}
             aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
-            className={css(styles.componentMediaQueries)}
+            className={css({...styles.component, ...this.props.style})}
             ref={(ref) => (this._component = ref)}
             role={this.props.role}
-            style={{...styles.component, ...this.props.style}}
             tabIndex={0}
           >
-            <header className={`mx-drawer-header ${css(styles.headerMediaQueries)}`} style={{...styles.header, ...this.props.headerStyle}}>
+            <header className={`mx-drawer-header ${css({...styles.header, ...this.props.headerStyle})}`}>
               <span style={styles.backArrow}>
                 {this.props.showCloseButton
                   && <Button
@@ -288,8 +287,6 @@ class Drawer extends React.Component {
         width: '80%',
         backgroundColor: theme.Colors.GRAY_100,
         boxShadow: theme.ShadowHigh,
-      },
-      componentMediaQueries: {
         [`@media (max-width: ${this.state.breakPoints.medium}px)`]: {
           width: '100%'
         },
@@ -340,8 +337,6 @@ class Drawer extends React.Component {
         position: 'relative',
         height: HEADER_HEIGHT,
         boxSizing: 'border-box',
-      },
-      headerMediaQueries: {
         [`@media (max-width: ${this.state.breakPoints.medium}px)`]: {
           padding: '0 10px'
         }

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -8,9 +8,9 @@ const keycode = require('keycode');
 const PropTypes = require('prop-types');
 const React = require('react');
 const Velocity = require('velocity-animate');
-const { StyleRoot } = require('radium');
 
 import { withTheme } from './Theme';
+const { css } = require('glamor');
 const Button = require('../components/Button');
 const MXFocusTrap = require('../components/MXFocusTrap');
 
@@ -225,52 +225,50 @@ class Drawer extends React.Component {
     const titleUniqueId = _uniqueId('mx-drawer-title-');
 
     return (
-      <StyleRoot>
-        <MXFocusTrap {...mergedFocusTrapProps}>
-          <div className='mx-drawer' onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
-            <div
-              className='mx-drawer-scrim'
-              onClick={() => {
-                if (this.props.closeOnScrimClick) this.close();
-              }}
-              style={styles.scrim}
-            />
-            <div
-              aria-describedby={this.props['aria-describedby']}
-              aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
-              ref={(ref) => (this._component = ref)}
-              role={this.props.role}
-              style={{ ...styles.component, ...this.props.style }}
-              tabIndex={0}
-            >
-              <header className='mx-drawer-header' style={{ ...styles.header, ...this.props.headerStyle }}>
-                <span style={styles.backArrow}>
-                  {this.props.showCloseButton
-                    && <Button
-                      aria-label={closeButtonAriaLabel || `Close ${this.props.title} Drawer`}
-                      buttonRef={ref => (this._closeButton = ref)}
-                      className='mx-drawer-close'
-                      icon='go-back'
-                      onClick={this.close}
-                      theme={theme}
-                      type={'base'}
-                       />
-                  }
-                </span>
-                <h2 id={titleUniqueId} style={styles.title}>
-                  {this.props.title}
-                </h2>
-                <div className='mx-drawer-header-menu' style={styles.headerMenu}>
-                  {menu}
-                </div>
-              </header>
-              <div className='mx-drawer-content' style={{ ...styles.content, ...this.props.contentStyle }}>
-                {typeof this.props.children === 'function' ? this.props.children(this._getExposedDrawerFunctions()) : this.props.children}
+      <MXFocusTrap {...mergedFocusTrapProps}>
+        <div className={`mx-drawer ${css(styles.component)}`} onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp}>
+          <div
+            className='mx-drawer-scrim'
+            onClick={() => {
+              if (this.props.closeOnScrimClick) this.close();
+            }}
+            style={styles.scrim}
+          />
+          <div
+            aria-describedby={this.props['aria-describedby']}
+            aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
+            className={css({ ...styles.component, ...this.props.style })}
+            ref={(ref) => (this._component = ref)}
+            role={this.props.role}
+            tabIndex={0}
+          >
+            <header className={`mx-drawer-header ${css({ ...styles.header, ...this.props.headerStyle })}`}>
+              <span style={styles.backArrow}>
+                {this.props.showCloseButton
+                  && <Button
+                    aria-label={closeButtonAriaLabel || `Close ${this.props.title} Drawer`}
+                    buttonRef={ref => (this._closeButton = ref)}
+                    className='mx-drawer-close'
+                    icon='go-back'
+                    onClick={this.close}
+                    theme={theme}
+                    type={'base'}
+                     />
+                }
+              </span>
+              <h2 id={titleUniqueId} style={styles.title}>
+                {this.props.title}
+              </h2>
+              <div className='mx-drawer-header-menu' style={styles.headerMenu}>
+                {menu}
               </div>
+            </header>
+            <div className='mx-drawer-content' style={{ ...styles.content, ...this.props.contentStyle }}>
+              {typeof this.props.children === 'function' ? this.props.children(this._getExposedDrawerFunctions()) : this.props.children}
             </div>
           </div>
-        </MXFocusTrap>
-      </StyleRoot>
+        </div>
+      </MXFocusTrap>
     );
   }
 

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -226,7 +226,7 @@ class Drawer extends React.Component {
 
     return (
       <MXFocusTrap {...mergedFocusTrapProps}>
-        <div className={`mx-drawer ${css(styles.componentMediaQueries)}`} onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.component}>
+        <div className='mx-drawer' onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.componentWrapper}>
           <div
             className='mx-drawer-scrim'
             onClick={() => {

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -226,7 +226,7 @@ class Drawer extends React.Component {
 
     return (
       <MXFocusTrap {...mergedFocusTrapProps}>
-        <div className={`mx-drawer ${css(styles.component)}`} onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp}>
+        <div className={`mx-drawer ${css(styles.componentMediaQueries)}`} onKeyUp={typeof this.props.onKeyUp === 'function' ? this.props.onKeyUp : this._handleKeyUp} style={styles.component}>
           <div
             className='mx-drawer-scrim'
             onClick={() => {
@@ -237,12 +237,13 @@ class Drawer extends React.Component {
           <div
             aria-describedby={this.props['aria-describedby']}
             aria-labelledby={this.props['aria-labelledby'] || titleUniqueId}
-            className={css({ ...styles.component, ...this.props.style })}
+            className={css(styles.componentMediaQueries)}
             ref={(ref) => (this._component = ref)}
             role={this.props.role}
+            style={{...styles.component, ...this.props.style}}
             tabIndex={0}
           >
-            <header className={`mx-drawer-header ${css({ ...styles.header, ...this.props.headerStyle })}`}>
+            <header className={`mx-drawer-header ${css(styles.headerMediaQueries)}`} style={{...styles.header, ...this.props.headerStyle}}>
               <span style={styles.backArrow}>
                 {this.props.showCloseButton
                   && <Button
@@ -287,7 +288,8 @@ class Drawer extends React.Component {
         width: '80%',
         backgroundColor: theme.Colors.GRAY_100,
         boxShadow: theme.ShadowHigh,
-
+      },
+      componentMediaQueries: {
         [`@media (max-width: ${this.state.breakPoints.medium}px)`]: {
           width: '100%'
         },
@@ -338,6 +340,8 @@ class Drawer extends React.Component {
         position: 'relative',
         height: HEADER_HEIGHT,
         boxSizing: 'border-box',
+      },
+      headerMediaQueries: {
         [`@media (max-width: ${this.state.breakPoints.medium}px)`]: {
           padding: '0 10px'
         }


### PR DESCRIPTION
This removes Radium from the drawer component in favor of glamor.

Profile with Radium:

![screen shot 2018-10-24 at 2 36 23 pm](https://user-images.githubusercontent.com/2127504/47460854-9c2f0f80-d79c-11e8-8ad6-8cb0de4d6b10.png)

Profile without Radium:

![screen shot 2018-10-24 at 2 35 24 pm](https://user-images.githubusercontent.com/2127504/47460871-a5b87780-d79c-11e8-8cc3-457e4b8d4c16.png)

I see noticeable differences in opening speed and the drawer is only closing to about halfway on larger screens, would love for someone to test as well.