### PR TITLE
Add bool and function to toggle data label changing on hover

### DIFF
--- a/docs/components/DonutChartDocs.js
+++ b/docs/components/DonutChartDocs.js
@@ -160,7 +160,7 @@ class DonutChartDocs extends React.Component {
 
         <h5>shouldToggleDataLabelOnHover <label>Boolean</label></h5>
         <p>Default: true</p>
-        <p>When set to true, on slice hover, the defaultLabelText with change to display the data corresponding with the slice.</p>
+        <p>When set to true, on slice hover, the defaultLabelText will change to display the data corresponding with the slice.</p>
 
         <h5>width <label>Number</label></h5>
         <p>Default: 150</p>

--- a/docs/components/DonutChartDocs.js
+++ b/docs/components/DonutChartDocs.js
@@ -153,10 +153,14 @@ class DonutChartDocs extends React.Component {
 
         <h5>showDataLabel <label>Boolean</label></h5>
         <p>Default: true</p>
-        <p>If set to true, the defaultLabelText will be displayed in the center of the chart. On slice hover, the defaultLabelText with change to display the data corresponding with the slice.</p>
+        <p>If set to true, the defaultLabelText will be displayed in the center of the chart.</p>
 
         <h5>theme <label>Object</label></h5>
         <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
+
+        <h5>toggleDataLabelOnHover <label>Boolean</label></h5>
+        <p>Default: true</p>
+        <p>When set to true, on slice hover, the defaultLabelText with change to display the data corresponding with the slice.</p>
 
         <h5>width <label>Number</label></h5>
         <p>Default: 150</p>

--- a/docs/components/DonutChartDocs.js
+++ b/docs/components/DonutChartDocs.js
@@ -158,7 +158,7 @@ class DonutChartDocs extends React.Component {
         <h5>theme <label>Object</label></h5>
         <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
 
-        <h5>toggleDataLabelOnHover <label>Boolean</label></h5>
+        <h5>shouldToggleDataLabelOnHover <label>Boolean</label></h5>
         <p>Default: true</p>
         <p>When set to true, on slice hover, the defaultLabelText with change to display the data corresponding with the slice.</p>
 

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -38,7 +38,7 @@ class DonutChart extends React.Component {
     showBaseArc: PropTypes.bool,
     showDataLabel: PropTypes.bool,
     theme: themeShape,
-    toggleDataLabelOnHover: PropTypes.bool,
+    shouldToggleDataLabelOnHover: PropTypes.bool,
 
     width: PropTypes.number
   };
@@ -64,7 +64,7 @@ class DonutChart extends React.Component {
     padAngle: 0.02,
     showBaseArc: true,
     showDataLabel: true,
-    toggleDataLabelOnHover: true,
+    shouldToggleDataLabelOnHover: true,
     width: 150
   };
 
@@ -326,7 +326,7 @@ class DonutChart extends React.Component {
       } else {
         const activeDataSet = this.props.data[this.state.activeIndex] || {};
         const color = this.state.activeIndex === -1 ? colors[0] : colors[this.state.activeIndex];
-        const activeAndDataLabelHover = this.state.activeIndex !== -1 && this.props.toggleDataLabelOnHover
+        const activeAndDataLabelHover = this.state.activeIndex !== -1 && this.props.shouldToggleDataLabelOnHover
         const text = activeAndDataLabelHover ? activeDataSet.name : this.props.defaultLabelText
         const value = activeAndDataLabelHover? this.props.formatter(activeDataSet.value): this.props.formatter(this.props.defaultLabelValue)
 

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -37,8 +37,8 @@ class DonutChart extends React.Component {
     padAngle: PropTypes.number,
     showBaseArc: PropTypes.bool,
     showDataLabel: PropTypes.bool,
-    toggleDataLabelOnHover: PropTypes.bool,
     theme: themeShape,
+    toggleDataLabelOnHover: PropTypes.bool,
 
     width: PropTypes.number
   };
@@ -329,7 +329,7 @@ class DonutChart extends React.Component {
         const activeAndDataLabelHover = this.state.activeIndex !== -1 && this.props.toggleDataLabelOnHover
         const text = activeAndDataLabelHover ? activeDataSet.name : this.props.defaultLabelText
         const value = activeAndDataLabelHover? this.props.formatter(activeDataSet.value): this.props.formatter(this.props.defaultLabelValue)
-        
+
         return (
           <div
             className='mx-donutchart-data'

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -62,9 +62,9 @@ class DonutChart extends React.Component {
     onMouseLeave () {},
     opacity: 1,
     padAngle: 0.02,
+    shouldToggleDataLabelOnHover: true,
     showBaseArc: true,
     showDataLabel: true,
-    shouldToggleDataLabelOnHover: true,
     width: 150
   };
 
@@ -328,7 +328,7 @@ class DonutChart extends React.Component {
         const color = this.state.activeIndex === -1 ? colors[0] : colors[this.state.activeIndex];
         const activeAndDataLabelHover = this.state.activeIndex !== -1 && this.props.shouldToggleDataLabelOnHover
         const text = activeAndDataLabelHover ? activeDataSet.name : this.props.defaultLabelText
-        const value = activeAndDataLabelHover? this.props.formatter(activeDataSet.value): this.props.formatter(this.props.defaultLabelValue)
+        const value = this.props.formatter(activeAndDataLabelHover ? activeDataSet.value : this.props.defaultValue)
 
         return (
           <div

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -328,7 +328,7 @@ class DonutChart extends React.Component {
         const color = this.state.activeIndex === -1 ? colors[0] : colors[this.state.activeIndex];
         const activeAndDataLabelHover = this.state.activeIndex !== -1 && this.props.shouldToggleDataLabelOnHover
         const text = activeAndDataLabelHover ? activeDataSet.name : this.props.defaultLabelText
-        const value = this.props.formatter(activeAndDataLabelHover ? activeDataSet.value : this.props.defaultValue)
+        const value = this.props.formatter(activeAndDataLabelHover ? activeDataSet.value : this.props.defaultLabelValue)
 
         return (
           <div

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -35,10 +35,10 @@ class DonutChart extends React.Component {
     onMouseLeave: PropTypes.func,
     opacity: PropTypes.number,
     padAngle: PropTypes.number,
+    shouldToggleDataLabelOnHover: PropTypes.bool,
     showBaseArc: PropTypes.bool,
     showDataLabel: PropTypes.bool,
     theme: themeShape,
-    shouldToggleDataLabelOnHover: PropTypes.bool,
 
     width: PropTypes.number
   };

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -37,7 +37,9 @@ class DonutChart extends React.Component {
     padAngle: PropTypes.number,
     showBaseArc: PropTypes.bool,
     showDataLabel: PropTypes.bool,
+    toggleDataLabelOnHover: PropTypes.bool,
     theme: themeShape,
+
     width: PropTypes.number
   };
 
@@ -62,6 +64,7 @@ class DonutChart extends React.Component {
     padAngle: 0.02,
     showBaseArc: true,
     showDataLabel: true,
+    toggleDataLabelOnHover: true,
     width: 150
   };
 
@@ -323,9 +326,10 @@ class DonutChart extends React.Component {
       } else {
         const activeDataSet = this.props.data[this.state.activeIndex] || {};
         const color = this.state.activeIndex === -1 ? colors[0] : colors[this.state.activeIndex];
-        const text = this.state.activeIndex === -1 ? this.props.defaultLabelText : activeDataSet.name;
-        const value = this.state.activeIndex === -1 ? this.props.formatter(this.props.defaultLabelValue) : this.props.formatter(activeDataSet.value);
-
+        const activeAndDataLabelHover = this.state.activeIndex !== -1 && this.props.toggleDataLabelOnHover
+        const text = activeAndDataLabelHover ? activeDataSet.name : this.props.defaultLabelText
+        const value = activeAndDataLabelHover? this.props.formatter(activeDataSet.value): this.props.formatter(this.props.defaultLabelValue)
+        
         return (
           <div
             className='mx-donutchart-data'


### PR DESCRIPTION
Issue: https://github.com/mxenabled/mx-react-components/issues/818

**Change:**

Add an additional boolean value that allows you to toggle this hover functionality on or off. For specific cases where there is no relevant data associated with a slice and you want to hover over a slice without animation AND without updating the data label in the center of the chart.

Update docs to describe new bool. 