### PR TITLE
Remove expanded aria label from date range picker

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -317,8 +317,7 @@ class DateRangePicker extends React.Component {
       <div className='mx-date-range-picker' style={styles.component}>
         <button
           aria-controls='calendarMenu'
-          aria-expanded={this.state.showSelectionPane}
-          aria-haspopup='menu'
+          aria-haspopup={true}
           aria-label={`${placeholderText}${
             this.props.selectedStartDate && this.props.selectedEndDate
               ? `, ${selectedStartDateFromPropsAsMoment.format('MMMM Do, YYYY')} to ${selectedEndDateFromPropsAsMoment.format('MMMM Do, YYYY')} currently selected`


### PR DESCRIPTION
Having both "aria-expanded" and "aria-popup" was being misread by Android TalkBack. This commit will remove the expanded label to make it more clear to the user that the element is a popup overlay and not expanded content.