### PR TITLE
Add search to dropdown component

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 6.1.0</h2>
 
+          <h3>6.1.11</h3>
+          <ul>
+            <li>Select - Add ability to search dropdown options via withSearch prop. (<a href='https://github.com/mxenabled/mx-react-components/issues/832'>#832</a>)</li>
+          </ul>
+
           <h3>6.1.10</h3>
           <ul>
             <li>Modal - Revert tabindex change due to Focus Trap error</li>

--- a/docs/components/SelectDocs.js
+++ b/docs/components/SelectDocs.js
@@ -6,6 +6,7 @@ const { Link } = require('react-router');
 const { Select } = require('mx-react-components');
 
 const Markdown = require('components/Markdown');
+const Code = require('components/Code');
 
 const options = [
   {
@@ -108,6 +109,7 @@ class SelectDocs extends React.Component {
         <p>If set to 'false', then the element will be marked as invalid and a red border will be placed around the element.</p>
         
         <h5>withSearch <label>Boolean</label></h5>
+        <p>Default: <Code>false</Code></p>
         <p>If set to true, the component renders with the Search component to support longer lists of options</p>
 
         <h3>Example</h3>

--- a/docs/components/SelectDocs.js
+++ b/docs/components/SelectDocs.js
@@ -106,6 +106,9 @@ class SelectDocs extends React.Component {
 
         <h5>valid <label>Boolean</label></h5>
         <p>If set to 'false', then the element will be marked as invalid and a red border will be placed around the element.</p>
+        
+        <h5>withSearch <label>Boolean</label></h5>
+        <p>If set to true, the component renders with the Search component to support longer lists of options</p>
 
         <h3>Example</h3>
         <Markdown>

--- a/docs/components/SelectDocs.js
+++ b/docs/components/SelectDocs.js
@@ -62,10 +62,20 @@ class SelectDocs extends React.Component {
         </h1>
 
         <h3>Demo</h3>
+
+        <h5>Default:</h5>
         <Select
           key='default'
           options={options}
           valid={true}
+        />
+
+        <h5>With prop: <Code>withSearch</Code></h5>
+        <Select
+          key='withSearch'
+          options={options}
+          valid={true}
+          withSearch={true}
         />
 
         <h3>Usage</h3>

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,4 +1,5 @@
 const _isEqual = require('lodash/isEqual');
+const _includes = require('lodash/includes');
 const keycode = require('keycode');
 const PropTypes = require('prop-types');
 const Radium = require('radium');
@@ -164,7 +165,7 @@ class Select extends React.Component {
                 onChange={this._onSearchInputChange}
               />}
             {this.props.options
-              .filter(option => this.state.searchTerm ? option.displayValue.toLowerCase().includes(this.state.searchTerm) : true)
+              .filter(option => this.state.searchTerm ? _includes(option.displayValue.toLowerCase(), this.state.searchTerm) : true)
               .map(option => {
                 return (
                   <Option

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -50,7 +50,8 @@ class Select extends React.Component {
     onChange () {},
     options: [],
     placeholderText: 'Select One',
-    valid: true
+    valid: true,
+    withSearch: false,
   };
 
   constructor (props) {
@@ -59,16 +60,13 @@ class Select extends React.Component {
     this.state = {
       isOpen: false,
       selected: props.selected,
-      options: props.options,
+      searchTerm: "",
     };
   }
 
   componentWillReceiveProps (newProps) {
     if (!_isEqual(newProps.selected, this.props.selected)) {
       this.setState({ selected: newProps.selected });
-    }
-    if(!_isEqual(newProps.options, this.props.options)) {
-      this.setState({ options: newProps.options })
     }
   }
 
@@ -90,7 +88,7 @@ class Select extends React.Component {
   };
 
   _close = () => {
-    this.setState({ isOpen: false, options: this.props.options });
+    this.setState({ isOpen: false, searchTerm: "" });
     this.elementRef.focus();
   };
 
@@ -139,12 +137,8 @@ class Select extends React.Component {
     }
   };
 
-  _handleSearch = (e) => {
-    const filteredOptions = this.props.options.filter((item) => {
-      return item.displayValue.toLowerCase().includes(e.target.value)
-    })
-
-    this.setState({ options: filteredOptions })
+  _onSearchInputChange = e => {
+    this.setState({ searchTerm: e.target.value })
   }
 
   _renderOptions = (styles) => {
@@ -166,34 +160,37 @@ class Select extends React.Component {
             {this.props.withSearch && 
               <SearchInput
                 focusOnLoad={true}
-                onChange={(e) => this._handleSearch(e)}
+                onChange={e => this._onSearchInputChange(e)}
               />}
-            {this.state.options.map(option => {
-              return (
-                <Option
-                  className='mx-select-option'
-                  isSelected={_isEqual(option, this.state.selected)}
-                  key={option.displayValue + option.value}
-                  label={option.displayValue}
-                  onClick={haltEvent(this._handleOptionClick.bind(null, option))}
-                  style={Object.assign({},
-                    styles.option,
-                    this.props.optionStyle,
-                    _isEqual(option, this.state.selected) ? styles.activeOption : null
-                  )}
-                >
-                  {option.icon ? (
-                    <Icon
-                      size={20}
-                      style={styles.optionIcon}
-                      type={option.icon}
-                    />
-                  ) : null}
-                  <div style={styles.optionText}>{option.displayValue}</div>
-                  {_isEqual(option, this.state.selected) ? <Icon size={20} type='check' /> : null }
-                </Option>
-              );
-            })}
+            {this.props.options
+              .filter(option => this.state.searchTerm ? option.displayValue.toLowerCase().includes(this.state.searchTerm) : true)
+                .map(option => {
+                  return (
+                    <Option
+                      className='mx-select-option'
+                      isSelected={_isEqual(option, this.state.selected)}
+                      key={option.displayValue + option.value}
+                      label={option.displayValue}
+                      onClick={haltEvent(this._handleOptionClick.bind(null, option))}
+                      style={Object.assign({},
+                        styles.option,
+                        this.props.optionStyle,
+                        _isEqual(option, this.state.selected) ? styles.activeOption : null
+                      )}
+                    >
+                      {option.icon ? (
+                        <Icon
+                          size={20}
+                          style={styles.optionIcon}
+                          type={option.icon}
+                        />
+                      ) : null}
+                      <div style={styles.optionText}>{option.displayValue}</div>
+                      {_isEqual(option, this.state.selected) ? <Icon size={20} type='check' /> : null }
+                    </Option>
+                  );
+                }
+            )}
           </Listbox>
         );
       }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -164,11 +164,11 @@ class Select extends React.Component {
             style={styles.options}
           >
             {this.props.withSearch && 
-            <SearchInput
-              focusOnLoad={true}
-              onChange={(e) => this._handleSearch(e)}
-            />}
-            {this.props.options.map(option => {
+              <SearchInput
+                focusOnLoad={true}
+                onChange={(e) => this._handleSearch(e)}
+              />}
+            {this.state.options.map(option => {
               return (
                 <Option
                   className='mx-select-option'

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -160,36 +160,36 @@ class Select extends React.Component {
             {this.props.withSearch && 
               <SearchInput
                 focusOnLoad={true}
-                onChange={e => this._onSearchInputChange(e)}
+                onChange={this._onSearchInputChange}
               />}
             {this.props.options
               .filter(option => this.state.searchTerm ? option.displayValue.toLowerCase().includes(this.state.searchTerm) : true)
-                .map(option => {
-                  return (
-                    <Option
-                      className='mx-select-option'
-                      isSelected={_isEqual(option, this.state.selected)}
-                      key={option.displayValue + option.value}
-                      label={option.displayValue}
-                      onClick={haltEvent(this._handleOptionClick.bind(null, option))}
-                      style={Object.assign({},
-                        styles.option,
-                        this.props.optionStyle,
-                        _isEqual(option, this.state.selected) ? styles.activeOption : null
-                      )}
-                    >
-                      {option.icon ? (
-                        <Icon
-                          size={20}
-                          style={styles.optionIcon}
-                          type={option.icon}
-                        />
-                      ) : null}
-                      <div style={styles.optionText}>{option.displayValue}</div>
-                      {_isEqual(option, this.state.selected) ? <Icon size={20} type='check' /> : null }
-                    </Option>
-                  );
-                }
+              .map(option => {
+                return (
+                  <Option
+                    className='mx-select-option'
+                    isSelected={_isEqual(option, this.state.selected)}
+                    key={option.displayValue + option.value}
+                    label={option.displayValue}
+                    onClick={haltEvent(this._handleOptionClick.bind(null, option))}
+                    style={Object.assign({},
+                      styles.option,
+                      this.props.optionStyle,
+                      _isEqual(option, this.state.selected) ? styles.activeOption : null
+                    )}
+                  >
+                    {option.icon ? (
+                      <Icon
+                        size={20}
+                        style={styles.optionIcon}
+                        type={option.icon}
+                      />
+                    ) : null}
+                    <div style={styles.optionText}>{option.displayValue}</div>
+                    {_isEqual(option, this.state.selected) ? <Icon size={20} type='check' /> : null }
+                  </Option>
+                );
+              }
             )}
           </Listbox>
         );

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -8,6 +8,7 @@ const ReactDOM = require('react-dom');
 import { css } from 'glamor'
 import { withTheme } from './Theme';
 const Icon = require('./Icon');
+const SearchInput = require('./SearchInput')
 const { Listbox, Option } = require('./accessibility/Listbox');
 
 const { themeShape } = require('../constants/App');
@@ -41,7 +42,8 @@ class Select extends React.Component {
     selected: optionShape,
     selectedStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     theme: themeShape,
-    valid: PropTypes.bool
+    valid: PropTypes.bool,
+    withSearch: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -56,13 +58,17 @@ class Select extends React.Component {
 
     this.state = {
       isOpen: false,
-      selected: props.selected
+      selected: props.selected,
+      options: props.options,
     };
   }
 
   componentWillReceiveProps (newProps) {
     if (!_isEqual(newProps.selected, this.props.selected)) {
       this.setState({ selected: newProps.selected });
+    }
+    if(!_isEqual(newProps.options, this.props.options)) {
+      this.setState({ options: newProps.options })
     }
   }
 
@@ -84,7 +90,7 @@ class Select extends React.Component {
   };
 
   _close = () => {
-    this.setState({ isOpen: false });
+    this.setState({ isOpen: false, options: this.props.options });
     this.elementRef.focus();
   };
 
@@ -133,6 +139,14 @@ class Select extends React.Component {
     }
   };
 
+  _handleSearch = (e) => {
+    const filteredOptions = this.props.options.filter((item) => {
+      return item.displayValue.toLowerCase().includes(e.target.value)
+    })
+
+    this.setState({ options: filteredOptions })
+  }
+
   _renderOptions = (styles) => {
     if (this.state.isOpen) {
       if (this.props.children) {
@@ -149,6 +163,11 @@ class Select extends React.Component {
             ref={(ref) => this.optionList = ref}
             style={styles.options}
           >
+            {this.props.withSearch && 
+            <SearchInput
+              focusOnLoad={true}
+              onChange={(e) => this._handleSearch(e)}
+            />}
             {this.props.options.map(option => {
               return (
                 <Option

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -138,7 +138,7 @@ class Select extends React.Component {
   };
 
   _onSearchInputChange = e => {
-    this.setState({ searchTerm: e.target.value })
+    this.setState({ searchTerm: e.target.value.toLowerCase() })
   }
 
   _renderOptions = (styles) => {
@@ -156,6 +156,7 @@ class Select extends React.Component {
             className='mx-select-options'
             ref={(ref) => this.optionList = ref}
             style={styles.options}
+            withSearch={this.props.withSearch}
           >
             {this.props.withSearch && 
               <SearchInput

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -76,7 +76,8 @@ class Listbox extends React.Component {
         break;
       case 'enter':
       case 'space':
-        if (this.props.withSearch && this.state.focusedIndex <= 0) return
+        // Allow space for text input when options are not in focus, otherwise space acts as a selection
+        if (this.props.withSearch && this.state.focusedIndex >= 0) return
         e.preventDefault();
         e.stopPropagation();
         e.target.click();

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -23,11 +23,13 @@ const _findIndex = require('lodash/findIndex');
 class Listbox extends React.Component {
   static propTypes = {
     'aria-label': PropTypes.string.isRequired,
-    useGlobalKeyHandler: PropTypes.bool
+    useGlobalKeyHandler: PropTypes.bool,
+    withSearch: PropTypes.bool
   };
 
   static defaultProps = {
-    useGlobalKeyHandler: false
+    useGlobalKeyHandler: false,
+    withSearch: false
   };
 
   constructor (props) {
@@ -74,6 +76,7 @@ class Listbox extends React.Component {
         break;
       case 'enter':
       case 'space':
+        if (this.props.withSearch && this.state.focusedIndex <= 0) return
         e.preventDefault();
         e.stopPropagation();
         e.target.click();

--- a/src/components/accessibility/Listbox.js
+++ b/src/components/accessibility/Listbox.js
@@ -77,7 +77,7 @@ class Listbox extends React.Component {
       case 'enter':
       case 'space':
         // Allow space for text input when options are not in focus, otherwise space acts as a selection
-        if (this.props.withSearch && this.state.focusedIndex >= 0) return
+        if (this.props.withSearch && this.state.focusedIndex <= 0) return
         e.preventDefault();
         e.stopPropagation();
         e.target.click();


### PR DESCRIPTION
https://github.com/mxenabled/mx-react-components/issues/832
Adds the ability to include search component to select component via `withSearch` prop 

Utilizes `Search` component within `select` component to be able to filter longer lists of options.
`withSearch` default to false, so this change will not affect existing calls to the `select` component

<img width="340" alt="Screen Shot 2019-07-25 at 2 52 50 PM" src="https://user-images.githubusercontent.com/31394784/61908137-45519480-aeec-11e9-9d20-d8fa9460bee5.png">
