### PR TITLE
Adds new prop elementPropsForChartSVG

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 6.5.0</h2>
 
+        <h3>6.5.1</h3>
+        <ul>
+          <li>DonutChart - Adds new `elementPropsForChartSVG` property. (<a href='https://github.com/mxenabled/mx-react-components/issues/842'>#842</a>)</li>
+        </ul>
+
         <h3>6.5.0</h3>
         <ul>
           <li>MessageBox - Added the ability to set `aria-live` on parent element and `role` on content div. (<a href='https://github.com/mxenabled/mx-react-components/issues/840'>#840</a>)</li>

--- a/docs/components/DonutChartDocs.js
+++ b/docs/components/DonutChartDocs.js
@@ -121,7 +121,7 @@ class DonutChartDocs extends React.Component {
 
         <h5>elementPropsForChartSVG <label>Object</label></h5>
         <p>Default: Empty Object</p>
-        <p>element properties you wish to apply to the SVG element of the donut chart.</p>
+        <p>Element properties you wish to apply to the SVG element of the donut chart.</p>
 
         <h5>formatter <label>Function</label></h5>
         <p>A function used to format a value for display as a label.</p>

--- a/docs/components/DonutChartDocs.js
+++ b/docs/components/DonutChartDocs.js
@@ -119,6 +119,10 @@ class DonutChartDocs extends React.Component {
         <h5>defaultLabelValue <label>String</label></h5>
         <p>The value to display in the data label when not hovering over a slice.</p>
 
+        <h5>elementPropsForChartSVG <label>Object</label></h5>
+        <p>Default: Empty Object</p>
+        <p>element properties you wish to apply to the SVG element of the donut chart.</p>
+
         <h5>formatter <label>Function</label></h5>
         <p>A function used to format a value for display as a label.</p>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "A collection of generic React UI components",
   "main": "dist/Index.js",
   "files": [

--- a/src/components/DonutChart.js
+++ b/src/components/DonutChart.js
@@ -27,6 +27,7 @@ class DonutChart extends React.Component {
     dataPoints: PropTypes.array,
     defaultLabelText: PropTypes.string,
     defaultLabelValue: PropTypes.string,
+    elementPropsForChartSVG: PropTypes.object,
     formatter: PropTypes.func,
     height: PropTypes.number,
     id: PropTypes.string,
@@ -52,6 +53,7 @@ class DonutChart extends React.Component {
     data: [],
     dataPointRadius: 5,
     dataPoints: [],
+    elementPropsForChartSVG: {},
     formatter (value) {
       return value;
     },
@@ -365,6 +367,7 @@ class DonutChart extends React.Component {
       >
         {this._renderDataLabel(styles, colors)}
         <svg
+          {...this.props.elementPropsForChartSVG}
           className='mx-donutchart-svg'
           height={this.props.height}
           width={this.props.width}


### PR DESCRIPTION
To allow for adding element properties to the wrapping SVG element such as aria hidden for accessibility.