### PR TITLE
Bump version of numeral to v 2.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5714,9 +5714,9 @@
       "dev": true
     },
     "numeral": {
-      "version": "1.5.6",
-      "resolved": "http://registry.npmjs.org/numeral/-/numeral-1.5.6.tgz",
-      "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
     },
     "nwsapi": {
       "version": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash": "^4.17.14",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.17",
-    "numeral": "^1.5.3",
+    "numeral": "^2.0.6",
     "prop-types": "^15.5.8",
     "radium": "^0.19.6",
     "react": "^16.5.2",


### PR DESCRIPTION
We're out of sync with numeral version used internally. This causes webpack to include two copies of numeral in the final bundle.

Tested with all components via the docs. The major breaking changes in numeral v 2 deal with localization which we are not doing anything with here. v 2 also no longer throws if an invalid number is supplied to a numeral call.