### PR TITLE
feat: added disabled to Display Input component

### DIFF
--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -107,6 +107,7 @@ class DisplayInput extends React.Component {
                     {...rest}
                     aria-disabled={disabled}
                     aria-labelledby={this.props.label ? this._labelId : null}
+                    disabled={disabled}
                     id={this._inputId}
                     key='input'
                     onChange={disabled ? null : onChange}


### PR DESCRIPTION
Added `disabled` attribute to the Display Input's input element to disable focusing when disbaled is `true`