### PR TITLE
Final casing update

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 6.6.0</h2>
 
+          <h3>6.6.5</h3>
+          <ul>
+            <li>No Change from 6.6.4. This release just replaces the 6.6.4 release that had issues with the dist folder and file case sensitivity. 6.6.4 has been unpublished.</li>
+          </ul>
+
           <h3>6.6.4</h3>
           <ul>
             <li>No Change from 6.6.3. This release just replaces the 6.6.3 release that had issues with the dist folder. 6.6.3 has been unpublished.</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "6.6.4-b",
+  "version": "6.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "6.6.4-b",
+  "version": "6.6.5",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "babel src --out-dir dist --ignore '**/**/__tests__'",
-    "release": "npm install && npm run test && npm run build",
+    "release": "npm install && npm run test && rm -rf dist && npm run build",
     "dev-release": "npm install && npm run build -- --watch",
     "test": "jest && eslint src",
     "watch": "jest --watch --coverage=false"


### PR DESCRIPTION
Adds a command in the build script that will remove dist before building, which should prevent any old instances of `Index.js` from persisting.