### PR TITLE
Removed active styles and focus styles that clashed

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -177,8 +177,7 @@ class Select extends React.Component {
                     onClick={haltEvent(this._handleOptionClick.bind(null, option))}
                     style={Object.assign({},
                       styles.option,
-                      this.props.optionStyle,
-                      _isEqual(option, this.state.selected) ? styles.activeOption : null
+                      this.props.optionStyle
                     )}
                   >
                     {option.icon ? (
@@ -302,10 +301,6 @@ class Select extends React.Component {
           maxHeight: 260,
           overflow: 'auto'
         }, this.props.optionsStyle),
-      activeOption: {
-        fill: theme.Colors.PRIMARY,
-        color: theme.Colors.PRIMARY
-      },
       option: {
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
On the `Select` component we had some active and focus styles that clashed. I have removed some styles that cause this and have tested to make sure it still functions as should.