### PR TITLE
Spin & Loader | Updating the default direction of spin

### DIFF
--- a/docs/components/LoaderDocs.js
+++ b/docs/components/LoaderDocs.js
@@ -1,11 +1,11 @@
 // eslint-disable react/jsx-indent rule added for proper <Markdown /> formatting
 /* eslint-disable react/jsx-indent */
-const React = require('react');
-const { Link } = require('react-router');
+const React = require('react')
+const { Link } = require('react-router')
 
-const { Loader } = require('mx-react-components');
+const { Loader } = require('mx-react-components')
 
-const Markdown = require('components/Markdown');
+const Markdown = require('components/Markdown')
 
 class LoaderDocs extends React.Component {
   render() {
@@ -13,11 +13,13 @@ class LoaderDocs extends React.Component {
       <div>
         <h1>
           Loader
-          <label>A loading scrim that can be placed over the entire page or relative to a element.</label>
+          <label>
+            A loading scrim that can be placed over the entire page or relative to a element.
+          </label>
         </h1>
 
         <h3>Demo</h3>
-        <div className='flex'>
+        <div className="flex">
           <div style={style}>
             <Loader isLoading={true} isRelative={true} />
           </div>
@@ -25,35 +27,81 @@ class LoaderDocs extends React.Component {
             <Loader isLoading={true} isRelative={true} isSmall={true} />
           </div>
           <div style={style}>
-            <Loader color='red' isLoading={true} isRelative={true} />
+            <Loader color="red" isLoading={true} isRelative={true} />
           </div>
-          <div style={Object.assign({}, style, { backgroundImage: 'url("../images/sample-image.jpg")' })}>
-            <Loader isLoading={true} isRelative={true}>Custom Loading Message</Loader>
+          <div style={style}>
+            <Loader direction="counterclockwise" isLoading={true} isRelative={true} />
+          </div>
+          <div
+            style={Object.assign({}, style, {
+              backgroundImage: 'url("../images/sample-image.jpg")',
+            })}
+          >
+            <Loader isLoading={true} isRelative={true}>
+              Custom Loading Message
+            </Loader>
           </div>
         </div>
 
         <h3>Usage</h3>
-        <h5>color <label>String</label></h5>
+        <h5>
+          color <label>String</label>
+        </h5>
         <p>A CSS hex value or color keyword that sets the color of the loading circle.</p>
 
-        <h5>isLoading <label>Boolean</label></h5>
-        <p>If this is set to 'true', then the loader element will be displayed. If it's set to 'false', then an empty 'div' will be rendered.</p>
+        <h5>
+          direction <label>String</label>
+        </h5>
+        <p>Default: 'clockwise'</p>
+        <p>
+          Sets the spin direction of the loader. Available options: 'clockwise', 'counterclockwise'
+        </p>
 
-        <h5>isRelative <label>Boolean</label></h5>
-        <p>If this is set to 'true', then the loader will be bound by the closest parent component with a 'position: relative'.</p>
+        <h5>
+          isLoading <label>Boolean</label>
+        </h5>
+        <p>
+          If this is set to 'true', then the loader element will be displayed. If it's set to
+          'false', then an empty 'div' will be rendered.
+        </p>
 
-        <h5>isSmall <label>Boolean</label></h5>
-        <p>If this is set to 'true', then the word "Loading" will not be displayed and the loading cirle's size will be reduced to 30x30 pixels.</p>
+        <h5>
+          isRelative <label>Boolean</label>
+        </h5>
+        <p>
+          If this is set to 'true', then the loader will be bound by the closest parent component
+          with a 'position: relative'.
+        </p>
 
-        <h5>children <label>Node</label></h5>
+        <h5>
+          isSmall <label>Boolean</label>
+        </h5>
+        <p>
+          If this is set to 'true', then the word "Loading" will not be displayed and the loading
+          cirle's size will be reduced to 30x30 pixels.
+        </p>
+
+        <h5>
+          children <label>Node</label>
+        </h5>
         <p>Default: 'LOADING...'</p>
         <p>If set, this value will be displayed below the loading circle.</p>
 
-        <h5>styles <label>Object</label></h5>
-        <p>A nested object that allows you to set styles on any of the elements in the component. See the `styles` method in the component code for a full list of available keys and values.</p>
+        <h5>
+          styles <label>Object</label>
+        </h5>
+        <p>
+          A nested object that allows you to set styles on any of the elements in the component. See
+          the `styles` method in the component code for a full list of available keys and values.
+        </p>
 
-        <h5>theme <label>Object</label></h5>
-        <p>Customize the component&apos;s look. See <Link to='/components/theme'>Theme</Link> for more information.</p>
+        <h5>
+          theme <label>Object</label>
+        </h5>
+        <p>
+          Customize the component&apos;s look. See <Link to="/components/theme">Theme</Link> for
+          more information.
+        </p>
 
         <h3>Example</h3>
         <Markdown>
@@ -68,7 +116,7 @@ class LoaderDocs extends React.Component {
   `}
         </Markdown>
       </div>
-    );
+    )
   }
 }
 
@@ -79,7 +127,7 @@ const style = {
   width: '33.3%',
   paddingTop: '20%',
   margin: '20px',
-  position: 'relative'
-};
+  position: 'relative',
+}
 
-module.exports = LoaderDocs;
+module.exports = LoaderDocs

--- a/docs/components/SpinDocs.js
+++ b/docs/components/SpinDocs.js
@@ -1,35 +1,47 @@
-const React = require('react');
+const React = require('react')
 
-const { Icon, Spin } = require('mx-react-components');
+const { Icon, Spin } = require('mx-react-components')
 
-const Markdown = require('components/Markdown');
+const Markdown = require('components/Markdown')
 
 class SpinDocs extends React.Component {
-  render () {
+  render() {
     return (
       <div>
         <h1>
           Spin
-          <label>A component used to rotate an element 360 degrees at a specified interval using CSS animations.</label>
+          <label>
+            A component used to rotate an element 360 degrees at a specified interval using CSS
+            animations.
+          </label>
         </h1>
 
         <h3>Demo</h3>
         <Spin>
           <Icon
             size={50}
-            type='sync'
+            style={{
+              transform: 'rotateX(180deg)',
+            }}
+            type="sync"
           />
         </Spin>
 
         <h3>Usage</h3>
-        <h5>children <label>Node</label></h5>
+        <h5>
+          children <label>Node</label>
+        </h5>
         <p>An element that you wish to spin.</p>
 
-        <h5>direction <label>String</label></h5>
-        <p>Default: 'counterclockwise'</p>
+        <h5>
+          direction <label>String</label>
+        </h5>
+        <p>Default: 'clockwise'</p>
         <p>The direction of the spin. Available Options: counterclockwise, clockwise.</p>
 
-        <h5>speed <label>Number</label></h5>
+        <h5>
+          speed <label>Number</label>
+        </h5>
         <p>Default: 1000</p>
         <p>The time it takes the element to make 1 full rotation in milliseconds.</p>
 
@@ -45,8 +57,8 @@ class SpinDocs extends React.Component {
           `}
         </Markdown>
       </div>
-    );
+    )
   }
 }
 
-module.exports = SpinDocs;
+module.exports = SpinDocs

--- a/docs/components/SpinDocs.js
+++ b/docs/components/SpinDocs.js
@@ -37,7 +37,7 @@ class SpinDocs extends React.Component {
           direction <label>String</label>
         </h5>
         <p>Default: 'clockwise'</p>
-        <p>The direction of the spin. Available Options: counterclockwise, clockwise.</p>
+        <p>The direction of the spin. Available Options: 'counterclockwise', 'clockwise'.</p>
 
         <h5>
           speed <label>Number</label>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1382,20 +1382,17 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-          "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
         }
       }
     },
     "acorn-jsx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.0.3"
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.1.0",
@@ -3410,13 +3407,22 @@
       "dev": true
     },
     "espree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -6115,9 +6121,9 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "3.0.3",
@@ -9439,9 +9445,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
         "ajv": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1368,9 +1368,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
     },
     "acorn-globals": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,9 +1219,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,21 +1235,18 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-          "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
     },
     "acorn-jsx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.0.3"
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.1.0",
@@ -2657,13 +2654,22 @@
       "dev": true
     },
     "espree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -5125,9 +5131,9 @@
       "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -12,6 +12,7 @@ const StyleUtils = require('../utils/Style');
 class Loader extends React.Component {
   static propTypes = {
     color: PropTypes.string,
+    direction: PropTypes.oneOf(['counterclockwise', 'clockwise']),
     isLoading: PropTypes.bool,
     isRelative: PropTypes.bool,
     isSmall: PropTypes.bool,
@@ -20,6 +21,7 @@ class Loader extends React.Component {
   };
 
   static defaultProps = {
+    direction: 'clockwise',
     isLoading: false,
     isRelative: false,
     isSmall: false,
@@ -34,7 +36,7 @@ class Loader extends React.Component {
       return (
         <div className='mx-loader' style={styles.component}>
           <div className='mx-loader-content' style={styles.content}>
-            <Spin>
+            <Spin direction={this.props.direction}>
               <div style={styles.circle} />
             </Spin>
             {this.props.isSmall ? (

--- a/src/components/Spin.js
+++ b/src/components/Spin.js
@@ -9,7 +9,7 @@ class Spin extends React.Component {
   };
 
   static defaultProps = {
-    direction: 'counterclockwise',
+    direction: 'clockwise',
     speed: 1000
   };
 


### PR DESCRIPTION
#### Description

The direction of our `Spin` and `Loader` components have gone from counterclockwise to clockwise. In Serenity, there are many instances where they are going opposite directions.

#### Solution

Rather than changing each individual instances of the `Spin` and `Loader` components, I've changed them both to default to spin in a clockwise direction. I've also added `direction` to the `Loader` API, accepting either 'clockwise' or 'counterclockwise' as valid inputs. This gets passed on to the `Spin` component inside of Loader.

Docs have been updated to note that the default direction is now clockwise, details about the new `direction` prop of the `Loader` API, and a demo showing the `Loader` spinning counterclockwise.

Also ran `npm audit fix` to update vulnerable dependencies because there were so many that the pipeline was failing.

Note: A bunch of the changes to this file were prettier changes