### PR TITLE
Fix structure of propTypes of TabsFactory

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -23,7 +23,8 @@ const TabsFactory = ({ type = 'standard', ...props }) => {
 };
 
 TabsFactory.propTypes = {
-  type: PropTypes.oneOf([...Object.keys(TabsTypes), ...Tabbable.PropTypes]),
+  type: PropTypes.oneOf([...Object.keys(TabsTypes)]),
+  ...Tabbable.PropTypes,
 }
 
 module.exports = TabsFactory;


### PR DESCRIPTION
This PR fixes the code that made docs crash. `propTypes` was refactored incorrectly.