### PR TITLE
Revert RadioButton styles to use correct class

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 8.0.0</h2>
 
+        <h3>8.2.1</h3>
+        <ul>
+          <li>Restores the correct styling provided to the RadioButton component.</li>
+        </ul>
+
         <h3>8.2.0</h3>
         <ul>
           <li>Updates the adjustColor function. Fixes issues with color wrap around.</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -30,7 +30,7 @@ class RadioButton extends React.Component {
     return (
       <button
         aria-checked={this.props.checked}
-        className={styles.component}
+        className="mx-radio-button-item"
         onClick={this.props.onClick}
         ref={this.props.elementRef}
         role="radio"

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -1,6 +1,5 @@
 const PropTypes = require('prop-types');
 const React = require('react');
-const { css } = require('glamor');
 
 import { withTheme } from './Theme';
 const { themeShape } = require('../constants/App');
@@ -34,6 +33,7 @@ class RadioButton extends React.Component {
         onClick={this.props.onClick}
         ref={this.props.elementRef}
         role="radio"
+        style={styles.component}
         {...this.props.elementProps}
       >
         <div className='mx-radio-button' style={styles.radioButton}>
@@ -46,18 +46,16 @@ class RadioButton extends React.Component {
 
   styles = (theme) => {
     return {
-      component: css({
+      component: {
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
         backgroundColor: 'transparent',
         border: 'none',
         fontSize: theme.FontSizes.MEDIUM,
-        ':focus': {
-          outline: 'dotted thin #333'
-        },
+        outline: 'none',
         ...this.props.style
-      }),
+      },
       radioButton: {
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
This change reverts the class name change and removes glamor from being used in component.