### PR TITLE
Removes RadioButton outline style from being over written

### DIFF
--- a/docs/components/Changelog.js
+++ b/docs/components/Changelog.js
@@ -8,6 +8,11 @@ class Changelog extends React.Component {
 
         <h2>MX React Components V 8.0.0</h2>
 
+        <h3>8.2.2</h3>
+        <ul>
+          <li>Removes the outline from being hidden on the RadioButton component.</li>
+        </ul>
+
         <h3>8.2.1</h3>
         <ul>
           <li>Restores the correct styling provided to the RadioButton component.</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -53,7 +53,6 @@ class RadioButton extends React.Component {
         backgroundColor: 'transparent',
         border: 'none',
         fontSize: theme.FontSizes.MEDIUM,
-        outline: 'none',
         ...this.props.style
       },
       radioButton: {


### PR DESCRIPTION
This change removes the `outline: 'none'` property on the RadioButton's inline styling. This will allow us to use the default outline style being served from the class `mx-radio-btn-item`.