### PR TITLE
DateRangePicker | Pass displayValue as a param to onDateRangeSelect 

### DIFF
--- a/docs/components/DateRangePickerDocs.js
+++ b/docs/components/DateRangePickerDocs.js
@@ -143,7 +143,7 @@ class DateRangePickerDocs extends React.Component {
         <p>A function to be called when the user presses the cancel button or clicks on the scrim to cancel the date selection. Can be useful for analytics.</p>
 
         <h5>onDateRangeSelect <label>Function</label></h5>
-        <p>A function to be called when the user has applied their selected date range. The range's start and end dates are passed as arguements to the call.</p>
+        <p>A function to be called when the user has applied their selected date range. The range's start date, end date, and display value are passed as arguements to the call.</p>
 
         <h5>onOpen <label>Function</label></h5>
         <p>A function to be called when the user opens the calendar. Can be useful for analytics.</p>

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -98,6 +98,7 @@ class DateRangePicker extends React.Component {
       currentDate: props.selectedEndDate || moment().startOf('day').unix(),
       focusedDay: props.selectedEndDate || moment().startOf('day').unix(),
       selectedBox: SelectedBox.FROM,
+      selectedDefaultRange: '',
       selectedStartDate: this.props.selectedStartDate,
       selectedEndDate: this.props.selectedEndDate,
       showSelectionPane: false
@@ -184,6 +185,7 @@ class DateRangePicker extends React.Component {
 
   _handleDefaultRangeSelection = (range) => {
     this.setState({
+      selectedDefaultRange: range.displayValue,
       selectedStartDate: range.getStartDate(),
       selectedEndDate: range.getEndDate(),
       focusedDay: range.getEndDate()
@@ -308,7 +310,7 @@ class DateRangePicker extends React.Component {
     const styles = this.styles(theme, isLargeOrMediumWindowSize);
     const shouldShowCalendarIcon = StyleUtils.getWindowSize(theme.BreakPoints) !== 'small';
     const showCalendar = isLargeOrMediumWindowSize || this.state.showCalendar;
-    const { selectedEndDate, selectedStartDate } = this.state;
+    const { selectedDefaultRange, selectedEndDate, selectedStartDate } = this.state;
     const selectedEndDateFromPropsAsMoment = moment.unix(this.props.selectedEndDate);
     const selectedStartDateFromPropsAsMoment = moment.unix(this.props.selectedStartDate);
 
@@ -493,7 +495,8 @@ class DateRangePicker extends React.Component {
                         onClick={() => {
                           this.props.onDateRangeSelect(
                             selectedStartDate,
-                            selectedEndDate
+                            selectedEndDate,
+                            selectedDefaultRange
                           );
 
                           this._resetToPropValuesAndClose();


### PR DESCRIPTION
Add state in DateRangePicker to keep track of `displayValue` to pass into `onDateRangeSelect`. In MM, we're expecting to receive a 3rd parameter in `_handleDateRangeSelect`, which we end up passing to the DateRangePicker as `onDateRangeSelect`. We check for the value of `"This Month"` or `"Last Month"` to determine if the `dateRangeType` should be monthly or not. I added this piece of state to DateRangePicker so we could keep track of the `displayValue` and pass it into `onDateRangeSelect` when it is called.

Also updated the docs to specify that there is an extra argument that will be passed into `onDateRangeSelect`. The other two arguments are maintaining the same order as before.

#### Issue

https://gitlab.mx.com/mx/moneymap/-/issues/3023