### PR TITLE
DateRangePicker | Reset selectedDefaultRange when selecting date

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -162,6 +162,7 @@ class DateRangePicker extends React.Component {
         return {
           currentDate: date,
           focusedDay: date,
+          selectedDefaultRange: '',
           selectedBox: isLargeOrMediumWindowSize ? this._getToggledSelectBox(state.selectedBox) : state.selectedBox,
           selectedStartDate: modifiedRangeCompleteButDatesInversed ? endDate : startDate,
           selectedEndDate: modifiedRangeCompleteButDatesInversed ? startDate : endDate,


### PR DESCRIPTION
 Set the selectedDefaultRange back to an empty string when selecting a date from the calendar. If you select something like "This Month" or "Last Month", it will continue to pass that in `onDateRangeSelect` even though a default date range is no longer selected. This change just resets that value back to an empty string.