### PR TITLE
Get end of last day of last year, not the beginning of the last day of last year

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -76,7 +76,7 @@ class DateRangePicker extends React.Component {
       },
       {
         displayValue: 'Last Year',
-        getEndDate: () => moment().startOf('year').subtract(1, 'd').unix(),
+        getEndDate: () => moment().endOf('year').subtract(1, 'y').unix(),
         getStartDate: () => moment().startOf('year').subtract(1, 'y').unix()
       }
     ],


### PR DESCRIPTION
Rather than using `startOf('year').subtract(1, 'd')`, I switched it to `endOf('year').subtract(1, 'y')` so that it would get the end of the last day of last year rather than the beginning of the last day of last year.