### PR TITLE
DateRangePicker | Use end of day for selected end date

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -165,7 +165,7 @@ class DateRangePicker extends React.Component {
           selectedDefaultRange: '',
           selectedBox: isLargeOrMediumWindowSize ? this._getToggledSelectBox(state.selectedBox) : state.selectedBox,
           selectedStartDate: modifiedRangeCompleteButDatesInversed ? endDate : startDate,
-          selectedEndDate: modifiedRangeCompleteButDatesInversed ? startDate : endDate,
+          selectedEndDate: modifiedRangeCompleteButDatesInversed ? moment.unix(startDate).endOf('day').unix() : moment.unix(endDate).endOf('day').unix(),
           showCalendar: false
         };
       },


### PR DESCRIPTION
#### Description

We have an issue in MoneyMap with the date range picker showing the date before the selected end date. https://gitlab.mx.com/mx/money-experiences/moneymap/moneymap-issues/-/issues/3328#note_1482946

#### Solution

We've been switching to date-fns in MoneyMap over moment recently. This has caused some issues with conversion with timezones. Because of this, we need to make sure that the end date that is getting passed from the mx-react-components `DateRangePicker` is actually the end of the day instead of the start of the day. My changes just use moment to pass the unix timestamp for the end of the day.

I've tested this in the date range picker for the both the Spending widget and the Transactions widget and the dates have been showing up correctly