### PR TITLE
add space in addition to enter to trigger calendar and date picker dates

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -9,6 +9,7 @@ const Icon = require('./Icon');
 
 const { themeShape } = require('../constants/App');
 
+import { isEnterOrSpaceKey } from '../utils/KeyPress'
 const StyleUtils = require('../utils/Style');
 
 export const getNewDateStateChange = ({
@@ -113,8 +114,7 @@ class Calendar extends React.Component {
 
   _handleDayKeyDown = (e, day) => {
     if (keycode(e) === 'up' || keycode(e) === 'down') e.preventDefault();
-
-    if (keycode(e) === 'enter')
+    if (isEnterOrSpaceKey(e))
       this.props.onDateSelect(day.unix(), e);
 
     const newDateStateChange = getNewDateStateChange({

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -13,6 +13,7 @@ const MXFocusTrap = require('../components/MXFocusTrap');
 const { SelectedBox } = require('../constants/DateRangePicker');
 const { themeShape } = require('../constants/App');
 
+import { isEnterOrSpaceKey } from '../utils/KeyPress'
 const StyleUtils = require('../utils/Style');
 
 const MonthTable = require('./DateRangePicker/MonthTable');
@@ -213,7 +214,7 @@ class DateRangePicker extends React.Component {
       }
 
       this.setState({ focusedDay: day.unix() });
-    } else if (keycode(e) === 'enter') {
+    } else if (isEnterOrSpaceKey(e)) {
       e.preventDefault();
       e.stopPropagation();
       this._handleDateSelect(date);


### PR DESCRIPTION
Since the individual dates in the Calendar and DateRangePicker components are roled as "buttons" they should behave as such and allow for the user to activate them with either the enter or the space key. Previously they just allowed the enter key and space would not work.
