### PR TITLE
Adds preventDefault and stopPropagation to calendar buttons

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -114,8 +114,11 @@ class Calendar extends React.Component {
 
   _handleDayKeyDown = (e, day) => {
     if (keycode(e) === 'up' || keycode(e) === 'down') e.preventDefault();
-    if (isEnterOrSpaceKey(e))
+    if (isEnterOrSpaceKey(e)) {
+      e.preventDefault();
+      e.stopPropagation();
       this.props.onDateSelect(day.unix(), e);
+    }
 
     const newDateStateChange = getNewDateStateChange({
       code: keycode(e),


### PR DESCRIPTION
Quick follow for https://github.com/mxenabled/mx-react-components/pull/926

I forgot to include `stopPropagation` and `preventDefault` so the spacebar was scrolling the screen down when it selected the button in the calendar... 🤦 

