### PR TITLE
Fix missing parent selector syntax for pseudo-classes

### DIFF
--- a/docs/components/MessageBoxDocs.js
+++ b/docs/components/MessageBoxDocs.js
@@ -115,12 +115,12 @@ class MessageBoxDocs extends React.Component {
         border: Styles.Colors.GRAY_300,
         color: Styles.Colors.GRAY_900,
 
-        ':hover': {
+        '&:hover': {
           backgroundColor: StyleUtils.adjustColor(Styles.Colors.GRAY_300, -15),
           borderColor: StyleUtils.adjustColor(Styles.Colors.GRAY_300, -15)
         },
 
-        ':active': {
+        '&:active': {
           backgroundColor: StyleUtils.adjustColor(Styles.Colors.GRAY_300, -30),
           borderColor: StyleUtils.adjustColor(Styles.Colors.GRAY_300, -30)
         }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -28,7 +28,7 @@
         "@babel/preset-env": "^7.10.2",
         "@babel/preset-react": "^7.10.1",
         "babel-core": "^7.0.0-bridge.0",
-        "babel-eslint": "^9.0.0",
+        "babel-eslint": "^7.2.1",
         "babel-loader": "^8.1.0",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.2",
@@ -3888,6 +3888,78 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -3898,21 +3970,19 @@
       }
     },
     "node_modules/babel-eslint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=4"
       }
     },
     "node_modules/babel-jest": {
@@ -4011,6 +4081,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -4116,6 +4195,78 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babel-types/node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
       }
     },
     "node_modules/balanced-match": {
@@ -6372,19 +6523,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/eslint-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
@@ -8102,6 +8240,27 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -19455,6 +19614,65 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+          "dev": true
+        }
+      }
+    },
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -19463,17 +19681,15 @@
       "requires": {}
     },
     "babel-eslint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+      "integrity": "sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       }
     },
     "babel-jest": {
@@ -19553,6 +19769,15 @@
         }
       }
     },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -19629,6 +19854,75 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
       }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -21536,16 +21830,6 @@
         }
       }
     },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
     "eslint-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
@@ -22891,6 +23175,23 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        }
       }
     },
     "has-flag": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
     "babel-core": "^7.0.0-bridge.0",
-    "babel-eslint": "^9.0.0",
+    "babel-eslint": "^7.2.1",
     "babel-loader": "^8.1.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -131,12 +131,12 @@ class Button extends React.Component {
         fill: theme.Colors.WHITE,
         transition: 'all .2s ease-in',
 
-        ':hover': windowSizeIsSmall ? null : {
+        '&:hover': windowSizeIsSmall ? null : {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -15),
           borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -15),
           transition: 'all .2s ease-in'
         },
-        ':active': {
+        '&:active': {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
           borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
           transition: 'all .2s ease-in'
@@ -149,13 +149,13 @@ class Button extends React.Component {
         fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
 
-        ':hover': windowSizeIsSmall ? null : {
+        '&:hover': windowSizeIsSmall ? null : {
           backgroundColor: theme.Colors.PRIMARY,
           color: theme.Colors.WHITE,
           fill: theme.Colors.WHITE,
           transition: 'all .2s ease-in'
         },
-        ':active': {
+        '&:active': {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
           borderColor: StyleUtils.adjustColor(theme.Colors.PRIMARY, -30),
           color: theme.Colors.WHITE,
@@ -170,12 +170,12 @@ class Button extends React.Component {
         fill: theme.Colors.PRIMARY,
         transition: 'all .2s ease-in',
 
-        ':hover': windowSizeIsSmall ? null : {
+        '&:hover': windowSizeIsSmall ? null : {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.WHITE, -15),
           borderColor: StyleUtils.adjustColor(theme.Colors.WHITE, -15),
           transition: 'all .2s ease-in'
         },
-        ':active': {
+        '&:active': {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.WHITE, -30),
           borderColor: StyleUtils.adjustColor(theme.Colors.WHITE, -30),
           transition: 'all .2s ease-in'
@@ -187,13 +187,13 @@ class Button extends React.Component {
         color: theme.Colors.GRAY_700,
         fill: theme.Colors.GRAY_500,
         transition: 'all .2s ease-in',
-        ':hover': windowSizeIsSmall ? null : {
+        '&:hover': windowSizeIsSmall ? null : {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.GRAY_300, -15),
           borderColor: 'transparent',
           fill: theme.Colors.WHITE,
           transition: 'all .2s ease-in'
         },
-        ':active': {
+        '&:active': {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.GRAY_300, -30),
           borderColor: 'transparent',
           fill: theme.Colors.WHITE,
@@ -208,13 +208,13 @@ class Button extends React.Component {
         borderColor: 'transparent',
         borderRadius: 2,
         borderWidth: 1,
-        ':hover': windowSizeIsSmall ? null : {
+        '&:hover': windowSizeIsSmall ? null : {
           color: StyleUtils.adjustColor(theme.Colors.PRIMARY, -8),
           fill: StyleUtils.adjustColor(theme.Colors.PRIMARY, -8),
           transition: 'all .2s ease-in',
           borderColor: theme.Colors.GRAY_300
         },
-        ':active': {
+        '&:active': {
           color: StyleUtils.adjustColor(theme.Colors.PRIMARY, -16),
           fill: StyleUtils.adjustColor(theme.Colors.PRIMARY, -16),
           transition: 'all .2s ease-in',
@@ -228,10 +228,10 @@ class Button extends React.Component {
         borderWidth: 1,
         color: theme.Colors.PRIMARY,
         fill: theme.Colors.PRIMARY,
-        ':hover': windowSizeIsSmall ? null : {
+        '&:hover': windowSizeIsSmall ? null : {
           backgroundColor: theme.Colors.GRAY_100
         },
-        ':active': {
+        '&:active': {
           backgroundColor: StyleUtils.adjustColor(theme.Colors.GRAY_100, -15)
         }
       },

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -92,10 +92,10 @@ class ButtonGroup extends React.Component {
         color: theme.Colors.GRAY_300,
         cursor: 'default',
         fill: theme.Colors.GRAY_300,
-        ':hover': {
+        '&:hover': {
           backgroundColor: 'transparent'
         },
-        ':active': {
+        '&:active': {
           backgroundColor: 'transparent'
         }
       }

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -672,14 +672,14 @@ class DateRangePicker extends React.Component {
         marginBottom: 2,
         width: 30,
 
-        ':hover': {
+        '&:hover': {
           border: '1px solid' + theme.Colors.PRIMARY
         }
       },
       calendarDayDisabled: {
         color: theme.Colors.GRAY_300,
 
-        ':hover': {
+        '&:hover': {
           cursor: 'default',
           border: 'none'
         }
@@ -706,7 +706,7 @@ class DateRangePicker extends React.Component {
         backgroundColor: StyleUtils.adjustHexOpacity(theme.Colors.PRIMARY, 0.5),
         borderRadius: 0,
 
-        ':hover': {
+        '&:hover': {
           border: '1px solid' + theme.Colors.PRIMARY
         }
       },

--- a/src/components/DisplayInput.js
+++ b/src/components/DisplayInput.js
@@ -187,7 +187,7 @@ class DisplayInput extends React.Component {
         textAlign: 'left',
         width: '100%',
 
-        ':focus': {
+        '&:focus': {
           boxShadow: 'none',
           outline: 'none'
         }
@@ -243,7 +243,7 @@ class DisplayInput extends React.Component {
         WebkitAppearance: 'none',
         whiteSpace: 'nowrap',
 
-        ':focus-within': wrapperFocus
+        '&:focus-within': wrapperFocus
       }, this.props.style),
 
       wrapperFocus

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -259,7 +259,7 @@ class Select extends React.Component {
           padding: '8px 10px',
           position: 'relative',
           boxSizing: 'border-box',
-          ':focus': {
+          '&:focus': {
             outline: 'dotted thin ' + theme.Colors.GRAY_900,
             outlineOffset: '1px'
           }
@@ -311,8 +311,8 @@ class Select extends React.Component {
         padding: 10,
         whiteSpace: 'nowrap',
 
-        ':focus': focusedOption,
-        ':hover': focusedOption
+        '&:focus': focusedOption,
+        '&:hover': focusedOption
       },
       optionIcon: {
         marginRight: 5

--- a/src/components/tabs/PillTabs.js
+++ b/src/components/tabs/PillTabs.js
@@ -23,17 +23,17 @@ const PillTabs = ({
       borderColor: mergedTheme.Colors.GRAY_300,
       outline: 'none',
 
-      ':hover': {
+      '&:hover': {
         backgroundColor: mergedTheme.Colors.PRIMARY,
         color: mergedTheme.Colors.WHITE,
         fill: mergedTheme.Colors.WHITE
       },
-      ':focus': {
+      '&:focus': {
         backgroundColor: mergedTheme.Colors.PRIMARY,
         color: mergedTheme.Colors.WHITE,
         fill: mergedTheme.Colors.WHITE
       },
-      ':active': {
+      '&:active': {
         backgroundColor: StyleUtils.adjustColor(mergedTheme.Colors.PRIMARY, -15)
       }
     },
@@ -42,14 +42,14 @@ const PillTabs = ({
       color: mergedTheme.Colors.PRIMARY,
       cursor: 'default',
 
-      ':hover': {
+      '&:hover': {
         backgroundColor: 'transparent'
       },
-      ':focus': {
+      '&:focus': {
         backgroundColor: mergedTheme.Colors.WHITE,
         color: mergedTheme.Colors.PRIMARY
       },
-      ':active': {
+      '&:active': {
         backgroundColor: 'transparent'
       }
     }, activeTabStyles)

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -62,10 +62,10 @@ class Tab extends React.Component {
         fontStyle: theme.Fonts.SEMIBOLD,
         padding: theme.Spacing.MEDIUM,
         whiteSpace: 'nowrap',
-        ':hover': {
+        '&:hover': {
           color: theme.Colors.GRAY_700
         },
-        ':focus': {
+        '&:focus': {
           backgroundColor: theme.Colors.GRAY_300,
           color: theme.Colors.GRAY_700
         }
@@ -75,7 +75,7 @@ class Tab extends React.Component {
         color: theme.Colors.PRIMARY,
         borderBottom: '2px solid ' + theme.Colors.PRIMARY,
 
-        ':hover': {
+        '&:hover': {
           color: theme.Colors.PRIMARY
         }
       }, this.props.activeTabStyles)


### PR DESCRIPTION
Radium also uses the `:hover` syntax so determining which styles are
passed to Radium and which are passed to cssinjs is a little tricky.
Hopefully I got this right...