### PR TITLE
Adds ampersand to more css selectors that were indirectly called with…

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -358,14 +358,14 @@ class Calendar extends React.Component {
         marginBottom: 2,
         width: 35,
 
-        ':hover': {
+        '&:hover': {
           border: '1px solid ' + theme.Colors.PRIMARY
         }
       },
       calendarDayDisabled: {
         color: theme.Colors.GRAY_300,
 
-        ':hover': {
+        '&:hover': {
           cursor: 'default',
           border: 'none'
         }

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -144,11 +144,11 @@ class SelectionPane extends React.Component {
         width: '50%',
         fontSize: theme.FontSizes.SMALL,
 
-        ':hover': {
+        '&:hover': {
           backgroundColor: theme.Colors.GRAY_100
         },
 
-        ':focus': {
+        '&:focus': {
           backgroundColor: theme.Colors.GRAY_100
         }
       },

--- a/src/components/SelectFullScreen.js
+++ b/src/components/SelectFullScreen.js
@@ -197,7 +197,7 @@ class SelectFullScreen extends React.Component {
         whiteSpace: 'nowrap',
         fontSize: theme.FontSizes.MEDIUM,
 
-        ':hover': {
+        '&:hover': {
           backgroundColor: theme.Colors.PRIMARY,
           color: theme.Colors.WHITE,
           opacity: 1

--- a/src/components/SimpleSelect.js
+++ b/src/components/SimpleSelect.js
@@ -134,7 +134,7 @@ class SimpleSelect extends React.Component {
         height: 40,
         padding: theme.Spacing.MEDIUM,
 
-        ':hover': {
+        '&:hover': {
           backgroundColor: theme.Colors.PRIMARY,
           color: theme.Colors.WHITE,
           cursor: 'pointer',

--- a/src/components/TypeAhead.js
+++ b/src/components/TypeAhead.js
@@ -353,7 +353,7 @@ class TypeAhead extends React.Component {
         width: '100%',
         minHeight: '35px',
 
-        ':focus': {
+        '&:focus': {
           backgroundColor: '#FFFFFF',
           boxShadow: 'none',
           color: theme.Colors.GRAY_700,
@@ -376,7 +376,7 @@ class TypeAhead extends React.Component {
         outline: 'none',
         WebkitAppearance: 'none',
 
-        ':focus': {
+        '&:focus': {
           borderWidth: 0,
           boxShadow: 'none',
           outline: 'none'
@@ -423,12 +423,12 @@ class TypeAhead extends React.Component {
         paddingLeft: '10px',
         lineHeight: '1em',
 
-        ':focus': {
+        '&:focus': {
           border: 'none',
           boxShadow: 'none',
           outline: 'none'
         },
-        ':hover': {
+        '&:hover': {
           backgroundColor: theme.Colors.PRIMARY,
           color: theme.Colors.WHITE
         }


### PR DESCRIPTION
The Date Range selector and the ListBox component were not correctly applying some focus and hover styles. I believe they were missed because they aren't directly called with the css function where they are defined but are passed as props to other components that called them with css. I updated all those selectors to include the `&` character which seems to have resolved the issue!