### PR TITLE
update some hover and focus styles that were not correctly applied po…

### DIFF
--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -144,11 +144,11 @@ class SelectionPane extends React.Component {
         width: '50%',
         fontSize: theme.FontSizes.SMALL,
 
-        ':hover': {
+        '&:hover': {
           backgroundColor: theme.Colors.GRAY_100
         },
 
-        ':focus': {
+        '&:focus': {
           backgroundColor: theme.Colors.GRAY_100
         }
       },


### PR DESCRIPTION
The hover styles were not applying to the "Select a Date Range" section of the Date Range Picker component. This update fixes that.

<img width="281" alt="Screen Shot 2022-08-01 at 1 07 11 PM" src="https://user-images.githubusercontent.com/20406346/182204498-e8a35fc9-d991-4c69-8882-d029f09898f9.png">

(very feint grey on hover)