### PR TITLE
Add localization to DateRangePicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mx-react-components",
-  "version": "8.5.1",
+  "version": "8.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mx-react-components",
-      "version": "8.5.1",
+      "version": "8.6.0",
       "license": "MIT",
       "dependencies": {
         "@mxenabled/cssinjs": "^0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mx-react-components",
-      "version": "8.6.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@mxenabled/cssinjs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.0",
+  "version": "9.0.0",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.5.1",
+  "version": "8.6.0",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/src/components/DateRangePicker/MonthTable.js
+++ b/src/components/DateRangePicker/MonthTable.js
@@ -34,6 +34,7 @@ class MonthTable extends React.Component {
       currentDate,
       focusedDay,
       getDateRangePosition,
+      getTranslation,
       handleDateHover,
       handleDateSelect,
       handleKeyDown,
@@ -72,20 +73,20 @@ class MonthTable extends React.Component {
        *      Thursday, April 13th, 2018, selected end date for range.
        * */
       let ariaLabelStateText = '';
-      const ariaLabelBeginningText = `Select ${selectedBox === SelectedBox.FROM ? 'start' : 'end'} date for range, `;
+      const ariaLabelBeginningText = `Select ${selectedBox === SelectedBox.FROM ? 'start' : 'end'} date for range`;
       const ariaLabelDateText = moment(startDate).format('dddd, MMMM Do, YYYY');
 
       if (!isSelectedDay && isActiveRange) {
-        ariaLabelStateText = ', within selected range';
+        ariaLabelStateText = 'within selected range.';
       } else if (isSelectedStartDay) {
-        ariaLabelStateText = ', selected start date for range.';
+        ariaLabelStateText = 'selected start date for range.';
       } else if (isSelectedEndDay) {
-        ariaLabelStateText = ', selected end date for range.';
+        ariaLabelStateText = 'selected end date for range.';
       }
 
       const day = (
         <a
-          aria-label={ariaLabelBeginningText + ariaLabelDateText + ariaLabelStateText}
+          aria-label={getTranslation(`${ariaLabelBeginningText}, %1, ${ariaLabelStateText}`, ariaLabelDateText)}
           aria-pressed={isSelectedDay}
           className={`${css({
             ...styles.calendarDay,
@@ -121,6 +122,7 @@ MonthTable.propTypes = {
   currentDate: PropTypes.number,
   focusedDay: PropTypes.number,
   getDateRangePosition: PropTypes.func,
+  getTranslation: PropTypes.func,
   handleDateHover: PropTypes.func,
   handleDateSelect: PropTypes.func,
   handleKeyDown: PropTypes.func,

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -16,6 +16,8 @@ class SelectionPane extends React.Component {
     defaultRanges: PropTypes.array,
     getFromButtonRef: PropTypes.func,
     getToButtonRef: PropTypes.func,
+    getTranslation: PropTypes.func,
+    locale: PropTypes.string,
     onDateBoxClick: PropTypes.func,
     selectedBox: PropTypes.string,
     selectedEndDate: PropTypes.number,
@@ -24,43 +26,53 @@ class SelectionPane extends React.Component {
     theme: themeShape
   };
 
+  componentDidMount() {
+    moment.locale(this.props.locale)
+  }
+
   _handleDateBoxClick = (date, selectedBox) => {
     this.props.onDateBoxClick(date, selectedBox);
+  }
+
+  _formatDate = (date) => {
+    const d = moment.unix(date).format('MMM D, YYYY')
+
+    return d.charAt(0).toUpperCase() + d.slice(1)
   }
 
   render () {
     const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
-    const { selectedStartDate, selectedEndDate } = this.props;
+    const { getTranslation, selectedStartDate, selectedEndDate } = this.props;
 
     return (
       <div className='mx-selection-pane' style={styles.container}>
         <div>
-          <label style={styles.boxLabel}>From</label>
+          <label style={styles.boxLabel}>{getTranslation('From')}</label>
           <button
-            aria-label={`Select Start Date, ${selectedStartDate ? 'Current start date is ' + moment.unix(selectedStartDate).format('MMM D, YYYY') : ''}`}
+            aria-label={getTranslation(`Select Start Date${selectedStartDate ? ', Current start date is' : ''} %1`, this._formatDate(selectedStartDate))}
             className='mx-selection-pane-from-field'
             onClick={() => this._handleDateBoxClick(selectedStartDate, SelectedBox.FROM)}
             ref={this.props.getFromButtonRef}
             style={{ ...styles.dateSelectBox, ...this.props.selectedBox === SelectedBox.FROM ? styles.selectedDateSelectBox : {}}}
           >
-            {selectedStartDate ? moment.unix(selectedStartDate).format('MMM D, YYYY') : 'Select Start Date'}
+            {selectedStartDate ? this._formatDate(selectedStartDate) : getTranslation('Select Start Date')}
           </button>
 
-          <label style={styles.boxLabel}>To</label>
+          <label style={styles.boxLabel}>{getTranslation('To')}</label>
           <button
-            aria-label={`Select End Date, ${selectedEndDate ? 'Current end date is ' + moment.unix(selectedEndDate).format('MMM D, YYYY') : ''}`}
+            aria-label={getTranslation(`Select End Date${selectedEndDate ? ', Current end date is' : ''} %1`, this._formatDate(selectedEndDate))}
             className='mx-selection-pane-to-field'
             onClick={() => this._handleDateBoxClick(selectedEndDate, SelectedBox.TO)}
             ref={this.props.getToButtonRef}
             style={{ ...styles.dateSelectBox, ...this.props.selectedBox === SelectedBox.TO ? styles.selectedDateSelectBox : {}}}
           >
-            {selectedEndDate ? moment.unix(selectedEndDate).format('MMM D, YYYY') : 'Select End Date'}
+            {selectedEndDate ? this._formatDate(selectedEndDate) : getTranslation('Select End Date')}
           </button>
         </div>
         <div>
           <div style={{ ...styles.defaultRangesTitle, color: theme.Colors.PRIMARY }}>
-            Select a Range
+            {getTranslation('Select a Range')}
           </div>
           <DefaultRanges {...this.props} styles={styles} theme={theme} />
         </div>

--- a/src/components/DateRangePicker/Selector.js
+++ b/src/components/DateRangePicker/Selector.js
@@ -8,6 +8,7 @@ const Icon = require('../Icon');
 class Selector extends React.Component {
   static propTypes = {
     currentDate: PropTypes.string,
+    getTranslation: PropTypes.func,
     handleNextClick: PropTypes.func,
     handlePreviousClick: PropTypes.func,
     setCurrentDate: PropTypes.func,
@@ -16,11 +17,12 @@ class Selector extends React.Component {
 
   render () {
     const styles = this.styles();
+    const { getTranslation } = this.props
 
     return (
       <div className='mx-selector' style={{ ...styles.container, ...this.props.style }}>
         <a
-          aria-label={`Previous ${this.props.type}`}
+          aria-label={getTranslation(this.props.type === 'Month' ? 'Previous Month' : 'Previous Year')}
           className='mx-selector-previous'
           onClick={this.props.handlePreviousClick}
           onKeyUp={e =>
@@ -35,14 +37,14 @@ class Selector extends React.Component {
           />
         </a>
         <h2
-          aria-label={`Currently in ${this.props.currentDate}`}
+          aria-label={getTranslation('Currently in %1', this.props.currentDate)}
           className='mx-selector-current-date'
           style={styles.currentDate}
         >
           {this.props.currentDate}
         </h2>
         <a
-          aria-label={`Next ${this.props.type}`}
+          aria-label={getTranslation(getTranslation(this.props.type === 'Month' ? 'Next Month' : 'Next Year'))}
           className='mx-selector-next'
           onClick={this.props.handleNextClick}
           onKeyUp={e => keycode(e) === 'enter' && this.props.handleNextClick(e)}
@@ -97,11 +99,12 @@ class MonthSelector extends React.Component {
 
   render () {
     const styles = this.styles();
+    const momentDate = moment.unix(this.props.currentDate).format('MMMM')
 
     return (
       <Selector
         {...this.props}
-        currentDate={moment.unix(this.props.currentDate).format('MMMM')}
+        currentDate={momentDate.charAt(0).toUpperCase() + momentDate.slice(1)}
         handleNextClick={this._handleNextClick}
         handlePreviousClick={this._handlePreviousClick}
         style={styles.monthSelector}


### PR DESCRIPTION
Issue: https://mxcom.atlassian.net/browse/MEW-452

#### Description
* Adds a required `getTranslation()` function prop to allow the consumer to translate strings

#### Testing
This can't really be tested until it's integrated into Serenity, but once that's complete, the visible text, aria and dates should all be localized to Spanish (and French)