### PR TITLE
Fix missed strings for localization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/src/components/DateRangePicker/MonthTable.js
+++ b/src/components/DateRangePicker/MonthTable.js
@@ -77,16 +77,16 @@ class MonthTable extends React.Component {
       const ariaLabelDateText = moment(startDate).format('dddd, MMMM Do, YYYY');
 
       if (!isSelectedDay && isActiveRange) {
-        ariaLabelStateText = 'within selected range.';
+        ariaLabelStateText = ', within selected range.';
       } else if (isSelectedStartDay) {
-        ariaLabelStateText = 'selected start date for range.';
+        ariaLabelStateText = ', selected start date for range.';
       } else if (isSelectedEndDay) {
-        ariaLabelStateText = 'selected end date for range.';
+        ariaLabelStateText = ', selected end date for range.';
       }
 
       const day = (
         <a
-          aria-label={getTranslation(`${ariaLabelBeginningText}, %1, ${ariaLabelStateText}`, ariaLabelDateText)}
+          aria-label={getTranslation(`${ariaLabelBeginningText}, %1${ariaLabelStateText}`, ariaLabelDateText)}
           aria-pressed={isSelectedDay}
           className={`${css({
             ...styles.calendarDay,


### PR DESCRIPTION
Issue: https://mxcom.atlassian.net/browse/MEW-452

#### Description
* Fixes translation for previously-missed aria labels
<img width="551" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/3dcd6093-00f1-45a1-b432-d1e68b6298c7">

#### Testing
This can't really be tested until it's integrated into Serenity, but once that's complete, the visible text, aria and dates should all be localized to Spanish (and French)