### PR TITLE
Remove month name transformations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.0",
+  "version": "8.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mx-react-components",
-      "version": "8.6.0",
+      "version": "8.6.2",
       "license": "MIT",
       "dependencies": {
         "@mxenabled/cssinjs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -284,7 +284,7 @@ class DateRangePicker extends React.Component {
   };
 
   render () {
-    const { children, getTranslation = (string) => string, placeholderText } = this.props;
+    const { children, getTranslation, placeholderText } = this.props;
     const theme = StyleUtils.mergeTheme(this.props.theme);
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize(theme);
     const styles = this.styles(theme, isLargeOrMediumWindowSize);

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -244,9 +244,7 @@ class DateRangePicker extends React.Component {
   };
 
   _formatMomentDate = (date, format = 'MMMM Do, YYYY') => {
-    const d = moment.unix(date).format(format)
-
-    return d.charAt(0).toUpperCase() + d.slice(1)
+    return moment.unix(date).format(format)
   }
 
   _getDateRangePosition = (selectedStart, selectedEnd, active, date) => {
@@ -286,7 +284,7 @@ class DateRangePicker extends React.Component {
   };
 
   render () {
-    const { children, getTranslation, placeholderText } = this.props;
+    const { children, getTranslation = (string) => string, placeholderText } = this.props;
     const theme = StyleUtils.mergeTheme(this.props.theme);
     const isLargeOrMediumWindowSize = this._isLargeOrMediumWindowSize(theme);
     const styles = this.styles(theme, isLargeOrMediumWindowSize);
@@ -328,7 +326,7 @@ class DateRangePicker extends React.Component {
     ]
 
     const weekDayNames = moment.weekdays()
-    const weekDayObject = moment.weekdaysMin().map((d, index) => ({ label: d.charAt(0).toUpperCase(), value: weekDayNames[index].charAt(0).toUpperCase()}))
+    const weekDayObject = moment.weekdaysMin().map((d, index) => ({ label: d, value: weekDayNames[index]}))
 
     const mergedFocusTrapProps = {
       focusTrapOptions: {

--- a/src/components/DateRangePicker/SelectionPane.js
+++ b/src/components/DateRangePicker/SelectionPane.js
@@ -35,9 +35,7 @@ class SelectionPane extends React.Component {
   }
 
   _formatDate = (date) => {
-    const d = moment.unix(date).format('MMM D, YYYY')
-
-    return d.charAt(0).toUpperCase() + d.slice(1)
+    return moment.unix(date).format('MMM D, YYYY')
   }
 
   render () {

--- a/src/components/DateRangePicker/Selector.js
+++ b/src/components/DateRangePicker/Selector.js
@@ -99,12 +99,11 @@ class MonthSelector extends React.Component {
 
   render () {
     const styles = this.styles();
-    const momentDate = moment.unix(this.props.currentDate).format('MMMM')
 
     return (
       <Selector
         {...this.props}
-        currentDate={momentDate.charAt(0).toUpperCase() + momentDate.slice(1)}
+        currentDate={moment.unix(this.props.currentDate).format('MMMM')}
         handleNextClick={this._handleNextClick}
         handlePreviousClick={this._handlePreviousClick}
         style={styles.monthSelector}


### PR DESCRIPTION
Issue: https://mxcom.atlassian.net/browse/MEW-452

#### Description
* Remove capitalization of months in other languages and locales, since other languages like Spanish do not capitalize the months. English will remain capitalized automagically.

English dates:  
![image](https://github.com/mxenabled/mx-react-components/assets/12092523/e4ad84d5-5e20-43a8-a7fd-e05133b6cff7)

Spanish dates:  
![image](https://github.com/mxenabled/mx-react-components/assets/12092523/ab1510db-b283-4b57-b434-107c0c94e10b)

#### Testing
This can't really be tested until it's integrated into Serenity, but once that's complete, the visible text, aria and dates should all be localized to Spanish (and French)