### PR TITLE
Calendar | translates strings, uses localized dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.3",
+  "version": "8.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mx-react-components",
-      "version": "8.6.3",
+      "version": "8.7.0",
       "license": "MIT",
       "dependencies": {
         "@mxenabled/cssinjs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-react-components",
-  "version": "8.6.3",
+  "version": "8.7.0",
   "description": "A collection of generic React UI components",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -47,6 +47,7 @@ export const getNewDateStateChange = ({
 
 class Calendar extends React.Component {
   static propTypes = {
+    getTranslation: PropTypes.func,
     locale: PropTypes.string,
     minimumDate: PropTypes.number,
     onDateSelect: PropTypes.func,
@@ -66,6 +67,10 @@ class Calendar extends React.Component {
     focusedDay:
       this.props.selectedDate || this.props.minimumDate || moment().unix()
   };
+
+  componentDidMount() {
+    moment.locale(this.props.locale)
+  }
 
   UNSAFE_componentWillReceiveProps (newProps) {
     if (
@@ -189,7 +194,7 @@ class Calendar extends React.Component {
 
             return (
               <a
-                aria-label={`${day.format('dddd, MMMM Do, YYYY')}${isSelectedDay ? ', Currently Selected' : ''}`}
+                aria-label={isSelectedDay ? this.props.getTranslation('%1, Currently Selected', day.format('dddd, MMMM Do, YYYY')) : day.format('dddd, MMMM Do, YYYY')}
                 className='calendar-day'
                 id={
                   day.isSame(moment.unix(this.state.focusedDay), 'day')
@@ -229,15 +234,6 @@ class Calendar extends React.Component {
   render () {
     const theme = StyleUtils.mergeTheme(this.props.theme);
     const styles = this.styles(theme);
-    const daysOfWeek = [
-      { label: 'Sunday', value: 'S' },
-      { label: 'Monday', value: 'M' },
-      { label: 'Tuesday', value: 'T' },
-      { label: 'Wednesday', value: 'W' },
-      { label: 'Thursday', value: 'T' },
-      { label: 'Friday', value: 'F' },
-      { label: 'Saturday', value: 'S' }
-    ];
     const currentMonthText = moment.unix(this.state.currentDate).format('MMMM YYYY');
     const nextMonthText = moment.unix(this.state.currentDate).add(1, 'month').format('MMMM YYYY');
     const previousMonthText = moment.unix(this.state.currentDate).subtract(1, 'month').format('MMMM YYYY');
@@ -246,7 +242,7 @@ class Calendar extends React.Component {
       <div className='mx-calendar' style={styles.component}>
         <div className='mx-calendar-header' style={styles.calendarHeader}>
           <a
-            aria-label={`Go back a month to ${previousMonthText}`}
+            aria-label={this.props.getTranslation('Go back a month to %1', previousMonthText)}
             className='mx-calendar-previous'
             onClick={this._handlePreviousClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handlePreviousClick()}
@@ -259,9 +255,9 @@ class Calendar extends React.Component {
               type='caret-left'
             />
           </a>
-          <div aria-label={`Currently in ${currentMonthText}`} className='mx-calendar-current-month' role='heading'>{currentMonthText}</div>
+          <div aria-label={this.props.getTranslation('Currently in %1',currentMonthText)} className='mx-calendar-current-month' role='heading'>{currentMonthText}</div>
           <a
-            aria-label={`Go forward a month to ${nextMonthText}`}
+            aria-label={this.props.getTranslation('Go forward a month to %1', nextMonthText)}
             className='mx-calendar-next'
             onClick={this._handleNextClick}
             onKeyUp={e => keycode(e) === 'enter' && this._handleNextClick()}
@@ -276,15 +272,15 @@ class Calendar extends React.Component {
           </a>
         </div>
         <div className='mx-calendar-week-header' style={styles.calendarWeekHeader}>
-          {daysOfWeek.map((day) => {
+          {moment.weekdaysMin().map((day, index) => {
             return (
               <div
                 aria-hidden={true}
                 className='mx-calendar-week-day'
-                key={day.label}
+                key={index}
                 style={styles.calendarWeekDay}
               >
-                {day.value}
+                {day}
               </div>
             );
           })}


### PR DESCRIPTION
Issue: https://mxcom.atlassian.net/browse/MEW-562

#### Description
* Translates all calendar-related strings
* Localizes dates based on language

| language | before | after |
| ------ | ------ | ------ |
|    Spanish    | <img width="264" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/3b6c0f13-803f-44a8-bb7e-79f05e5def22"> |  <img width="224" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/fa24c7b1-ddc7-484a-9b9f-3979e91981d8">  |
|    French    | <img width="248" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/e0aa5148-904c-40b4-83f5-392764f86a87">    |  <img width="222" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/23005f4e-e03e-4c7b-acda-c8709d57d7a0"> |
| English |  <img width="252" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/9837a17f-bf63-4e8f-87f1-ef849dba9841"> |  <img width="220" alt="image" src="https://github.com/mxenabled/mx-react-components/assets/12092523/20aec249-74c2-4da5-b419-fdc9235441b3"> |

#### Testing (must be completed in Serenity)
1. Load Serenity > Transactions with the client profile language set to `en-US`, `es` and `fr-CA`
2. Click a transaction to open the drawer
3. Click the Date row to open the calendar
4. Ensure the calendar's days of the week and all related text is correctly localized for different languages
5. Check that Voice Over announces everything in the correct language